### PR TITLE
fix(http): Return error when API key is not set

### DIFF
--- a/internal/portal/http.go
+++ b/internal/portal/http.go
@@ -92,6 +92,10 @@ func (c *PortalClient) Get(path string, body []byte) (resp *http.Response, err e
 
 func (c *PortalClient) GetBody(path string) (body []byte, status int, err error) {
 	resp, err := c.Get(path, []byte{})
+	if err != nil || resp == nil {
+		err = fmt.Errorf("GET failed: %w", err)
+		return
+	}
 	defer func() { _ = resp.Body.Close() }()
 	status = resp.StatusCode
 


### PR DESCRIPTION
* When OMS_PORTAL_API_KEY is unset, the CLI crashed because the error wasn't handled correctly

Card: [869adwyg4](https://app.clickup.com/t/869adwyg4)