### PR TITLE
fix(bootstrap-local): Fix helm upgrade, add k0s flag

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -23,9 +23,9 @@ License URL: https://github.com/googleapis/google-cloud-go/blob/auth/oauth2adapt
  
 ----------
 Module: cloud.google.com/go/compute
-Version: v1.58.0
+Version: v1.59.0
 License: Apache-2.0
-License URL: https://github.com/googleapis/google-cloud-go/blob/compute/v1.58.0/compute/LICENSE
+License URL: https://github.com/googleapis/google-cloud-go/blob/compute/v1.59.0/compute/LICENSE
  
 ----------
 Module: cloud.google.com/go/compute/metadata
@@ -1187,9 +1187,9 @@ License URL: https://github.com/googleapis/go-genproto/blob/d00831a3d3e7/LICENSE
  
 ----------
 Module: google.golang.org/genproto/googleapis/api
-Version: v0.0.0-20260401001100-f93e5f3e9f0f
+Version: v0.0.0-20260401024825-9d38bb4040a9
 License: Apache-2.0
-License URL: https://github.com/googleapis/go-genproto/blob/f93e5f3e9f0f/googleapis/api/LICENSE
+License URL: https://github.com/googleapis/go-genproto/blob/9d38bb4040a9/googleapis/api/LICENSE
  
 ----------
 Module: google.golang.org/genproto/googleapis/rpc
@@ -1235,9 +1235,9 @@ License URL: https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE
  
 ----------
 Module: helm.sh/helm/v4
-Version: v4.1.3
+Version: v4.1.4
 License: Apache-2.0
-License URL: https://github.com/helm/helm/blob/v4.1.3/LICENSE
+License URL: https://github.com/helm/helm/blob/v4.1.4/LICENSE
  
 ----------
 Module: k8s.io/api

--- a/cli/cmd/bootstrap_local.go
+++ b/cli/cmd/bootstrap_local.go
@@ -77,6 +77,8 @@ func AddBootstrapLocalCmd(parent *cobra.Command) {
 	flags.StringArrayVar(&bootstrapLocalCmd.CodesphereEnv.Experiments, "experiments", []string{}, "Experiments to enable in Codesphere installation (optional)")
 	flags.StringArrayVar(&bootstrapLocalCmd.FeatureFlagList, "feature-flags", []string{}, "Feature flags to enable in Codesphere installation (optional)")
 	flags.StringVar(&bootstrapLocalCmd.CodesphereEnv.Profile, "profile", installer.PROFILE_DEV, "Profile to apply to the install config like resources (supported: dev, minimal, prod)")
+	flags.BoolVar(&bootstrapLocalCmd.CodesphereEnv.K0s, "k0s", false, "Use k0s-specific configuration (required to deploy to k0s clusters)")
+
 	// Config
 	flags.StringVar(&bootstrapLocalCmd.CodesphereEnv.InstallDir, "install-dir", ".installer", "Directory for config, secrets, and bundle files")
 	flags.StringVar(&bootstrapLocalCmd.CodesphereEnv.InstallConfigPath, "install-config", "", "Path to install config file (default: <install-dir>/config.yaml)")
@@ -155,25 +157,27 @@ func (c *BootstrapLocalCmd) resolveRegistryPassword() error {
 }
 
 func (c *BootstrapLocalCmd) ConfirmLocalBootstrapWarning() error {
-	fmt.Println(csio.Long(`############################################################
-# Local Bootstrap Warning                                  #
-############################################################
-#
-# Codesphere local bootstrap is for testing only.
-#
-# Currently supported:
-# - One Kubernetes cluster with Linux x86_64 nodes only
-# - Kubernetes Cluster on Linux with a VM and an extra disk for Rook/Ceph
-#
-# Not supported:
-# - Minikube on macOS
-#
-# Never run Rook directly on your host system; local disks may be consumed.
-#
-# Recommended command:
-#   minikube start --disk-size=40g --extra-disks=1 --driver kvm2
-############################################################
-`))
+	fmt.Println(csio.Long(`
+		############################################################
+		# Local Bootstrap Warning                                  #
+		############################################################
+		#
+		# Codesphere local bootstrap is for testing only.
+		#
+		# Currently supported:
+		# - One Kubernetes cluster with Linux x86_64 nodes only
+		# - Kubernetes Cluster on Linux with a VM and an extra disk for Rook/Ceph
+		#   (use --k0s flag for k0s specific configuration)
+		#
+		# Not supported:
+		# - Minikube on macOS
+		#
+		# Never run Rook directly on your host system; local disks may be consumed.
+		#
+		# Recommended command:
+		#   minikube start --disk-size=40g --extra-disks=1 --driver kvm2
+		############################################################
+	`))
 
 	if c.Yes {
 		return nil

--- a/docs/oms_beta_bootstrap-local.md
+++ b/docs/oms_beta_bootstrap-local.md
@@ -25,6 +25,7 @@ oms beta bootstrap-local [flags]
       --install-hash string         Codesphere package hash (required when install-version is set)
       --install-local string        Path to a local installer package (tar.gz or unpacked directory)
       --install-version string      Codesphere version to install (downloaded from the OMS portal)
+      --k0s                         Use k0s-specific configuration (required to deploy to k0s clusters)
       --profile string              Profile to apply to the install config like resources (supported: dev, minimal, prod) (default "dev")
       --registry-user string        Custom Registry username (optional)
       --secrets-file string         Path to secrets file (default: <install-dir>/prod.vault.yaml)

--- a/internal/bootstrap/local/local.go
+++ b/internal/bootstrap/local/local.go
@@ -85,6 +85,7 @@ type CodesphereEnvironment struct {
 	SecretsFilePath    string              `json:"-"`
 	InstallConfig      *files.RootConfig   `json:"-"`
 	Vault              *files.InstallVault `json:"-"`
+	K0s                bool                `json:"-"`
 }
 
 func NewLocalBootstrapper(ctx context.Context, stlog *bootstrap.StepLogger, kubeClient client.Client, restConfig *rest.Config, fw util.FileIO, icg installer.InstallConfigManager, helm installer.HelmClient, env *CodesphereEnvironment) *LocalBootstrapper {

--- a/internal/bootstrap/local/rook.go
+++ b/internal/bootstrap/local/rook.go
@@ -49,7 +49,7 @@ type csiResourceEntry struct {
 // but preserves the default memory limits for each container.
 //
 // Config is based on https://github.com/rook/rook/blob/master/deploy/charts/rook-ceph/values.yaml#L233
-func buildRookHelmValues() (map[string]interface{}, error) {
+func (b *LocalBootstrapper) buildRookHelmValues() (map[string]interface{}, error) {
 	limitOnly := func(memory string) map[string]interface{} {
 		return map[string]interface{}{
 			"limits":   map[string]string{"memory": memory},
@@ -107,6 +107,11 @@ func buildRookHelmValues() (map[string]interface{}, error) {
 		return nil, fmt.Errorf("failed to marshal csiCephFSPluginResource: %w", err)
 	}
 
+	kubeletDir := "/var/lib/kubelet"
+	if b.Env.K0s {
+		kubeletDir = "/var/lib/k0s/kubelet"
+	}
+
 	values := map[string]interface{}{
 		"priorityClassName": "system-cluster-critical",
 		"resources": map[string]interface{}{
@@ -116,6 +121,7 @@ func buildRookHelmValues() (map[string]interface{}, error) {
 			},
 		},
 		"csi": map[string]interface{}{
+			"kubeletDirPath":               kubeletDir,
 			"csiRBDProvisionerResource":    rbdProvisioner,
 			"csiRBDPluginResource":         rbdPlugin,
 			"csiCephFSProvisionerResource": cephfsProvisioner,
@@ -127,7 +133,7 @@ func buildRookHelmValues() (map[string]interface{}, error) {
 }
 
 func (b *LocalBootstrapper) InstallRookHelmChart() error {
-	helmValues, err := buildRookHelmValues()
+	helmValues, err := b.buildRookHelmValues()
 	if err != nil {
 		return fmt.Errorf("failed to build Helm values: %w", err)
 	}

--- a/internal/installer/argocd.go
+++ b/internal/installer/argocd.go
@@ -76,7 +76,7 @@ func (a *ArgoCD) Install() error {
 		},
 	}
 
-	existing, err := a.Helm.FindRelease(cfg.ReleaseName)
+	existing, err := a.Helm.FindRelease(cfg.Namespace, cfg.ReleaseName)
 	if err != nil {
 		return err
 	}

--- a/internal/installer/argocd_test.go
+++ b/internal/installer/argocd_test.go
@@ -28,11 +28,10 @@ var _ = Describe("ArgoCD.Install", func() {
 
 	Context("when no existing release is found", func() {
 		BeforeEach(func() {
-			helmMock.On("FindRelease", "argocd").Return(nil, nil)
+			helmMock.EXPECT().FindRelease("argocd", "argocd").Return(nil, nil)
 		})
 
 		It("performs a fresh install with a specific version", func() {
-			helmMock.EXPECT().FindRelease("argocd").Return(nil, nil)
 			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
 				return cfg.Version == "7.0.0" &&
 					cfg.ReleaseName == "argocd" &&
@@ -45,7 +44,7 @@ var _ = Describe("ArgoCD.Install", func() {
 		})
 
 		It("performs a fresh install with latest version when Version is empty", func() {
-			helmMock.EXPECT().FindRelease("argocd").Return(nil, nil)
+			helmMock.EXPECT().FindRelease("argocd", "argocd").Return(nil, nil)
 			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
 				return cfg.Version == ""
 			})).Return(nil)
@@ -67,11 +66,8 @@ var _ = Describe("ArgoCD.Install", func() {
 	})
 
 	Context("when an existing release is found", func() {
-		existingRelease := &installer.ReleaseInfo{Name: "argocd", InstalledVersion: "6.0.0"}
-
 		BeforeEach(func() {
-			helmMock.On("FindRelease", "argocd").Return(existingRelease, nil)
-			helmMock.EXPECT().FindRelease("argocd").Return(&installer.ReleaseInfo{
+			helmMock.EXPECT().FindRelease("argocd", "argocd").Return(&installer.ReleaseInfo{
 				Name:             "argocd",
 				InstalledVersion: "6.0.0",
 			}, nil)
@@ -131,7 +127,7 @@ var _ = Describe("ArgoCD.Install", func() {
 
 	Context("when FindRelease returns an error", func() {
 		It("propagates the error without installing or upgrading", func() {
-			helmMock.EXPECT().FindRelease("argocd").
+			helmMock.EXPECT().FindRelease("argocd", "argocd").
 				Return(nil, errors.New("cluster unreachable"))
 
 			a = &installer.ArgoCD{Version: "7.0.0", Helm: helmMock}
@@ -144,7 +140,7 @@ var _ = Describe("ArgoCD.Install", func() {
 
 	Context("chart configuration", func() {
 		It("always uses the correct chart name and repo URL", func() {
-			helmMock.EXPECT().FindRelease("argocd").Return(nil, nil)
+			helmMock.EXPECT().FindRelease("argocd", "argocd").Return(nil, nil)
 			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
 				return cfg.ChartName == "argo-cd" &&
 					cfg.RepoURL == "https://argoproj.github.io/argo-helm"
@@ -157,7 +153,7 @@ var _ = Describe("ArgoCD.Install", func() {
 		})
 
 		It("disables dex in the values", func() {
-			helmMock.EXPECT().FindRelease("argocd").Return(nil, nil)
+			helmMock.EXPECT().FindRelease("argocd", "argocd").Return(nil, nil)
 			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
 				dex, ok := cfg.Values["dex"].(map[string]interface{})
 				return ok && dex["enabled"] == false
@@ -172,7 +168,7 @@ var _ = Describe("ArgoCD.Install", func() {
 
 	Context("full installation", func() {
 		BeforeEach(func() {
-			helmMock.EXPECT().FindRelease("argocd").Return(nil, nil)
+			helmMock.EXPECT().FindRelease("argocd", "argocd").Return(nil, nil)
 			helmMock.EXPECT().InstallChart(mock.Anything, mock.Anything).Return(nil)
 		})
 		It("installs extra ArgoCD resources when FullInstall option in true", func() {

--- a/internal/installer/helm_client.go
+++ b/internal/installer/helm_client.go
@@ -47,7 +47,7 @@ type UpgradeChartOptions struct {
 //mockery:generate: true
 type HelmClient interface {
 	// FindRelease returns info about an existing release, or nil if none exists.
-	FindRelease(releaseName string) (*ReleaseInfo, error)
+	FindRelease(namespace, releaseName string) (*ReleaseInfo, error)
 
 	// InstallChart performs a fresh Helm install and returns an error on failure.
 	InstallChart(ctx context.Context, cfg ChartConfig) error
@@ -94,8 +94,8 @@ func (h *helmClient) newActionConfig(namespace string) (*action.Configuration, e
 	return actionConfig, nil
 }
 
-func (h *helmClient) FindRelease(releaseName string) (*ReleaseInfo, error) {
-	actionConfig, err := h.newActionConfig("")
+func (h *helmClient) FindRelease(namespace, releaseName string) (*ReleaseInfo, error) {
+	actionConfig, err := h.newActionConfig(namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,11 @@ func (h *helmClient) UpgradeChart(ctx context.Context, cfg ChartConfig, opts Upg
 
 	if opts.InstallIfNotExist {
 		// If a release does not exist, install it.
-		if _, err := h.FindRelease(cfg.ReleaseName); errors.Is(err, driver.ErrReleaseNotFound) {
+		rel, err := h.FindRelease(cfg.Namespace, cfg.ReleaseName)
+		if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
+			return err
+		}
+		if rel == nil {
 			return h.InstallChart(ctx, cfg)
 		}
 	}
@@ -188,7 +192,6 @@ func (h *helmClient) UpgradeChart(ctx context.Context, cfg ChartConfig, opts Upg
 	upgradeClient.Version = cfg.Version
 	upgradeClient.RepoURL = cfg.RepoURL
 	upgradeClient.Timeout = 5 * time.Minute
-	upgradeClient.Install = opts.InstallIfNotExist
 
 	chartPath, err := upgradeClient.LocateChart(cfg.ChartName, h.settings)
 	if err != nil {

--- a/internal/installer/mocks.go
+++ b/internal/installer/mocks.go
@@ -814,8 +814,8 @@ func (_m *MockHelmClient) EXPECT() *MockHelmClient_Expecter {
 }
 
 // FindRelease provides a mock function for the type MockHelmClient
-func (_mock *MockHelmClient) FindRelease(releaseName string) (*ReleaseInfo, error) {
-	ret := _mock.Called(releaseName)
+func (_mock *MockHelmClient) FindRelease(namespace string, releaseName string) (*ReleaseInfo, error) {
+	ret := _mock.Called(namespace, releaseName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FindRelease")
@@ -823,18 +823,18 @@ func (_mock *MockHelmClient) FindRelease(releaseName string) (*ReleaseInfo, erro
 
 	var r0 *ReleaseInfo
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*ReleaseInfo, error)); ok {
-		return returnFunc(releaseName)
+	if returnFunc, ok := ret.Get(0).(func(string, string) (*ReleaseInfo, error)); ok {
+		return returnFunc(namespace, releaseName)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *ReleaseInfo); ok {
-		r0 = returnFunc(releaseName)
+	if returnFunc, ok := ret.Get(0).(func(string, string) *ReleaseInfo); ok {
+		r0 = returnFunc(namespace, releaseName)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ReleaseInfo)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(releaseName)
+	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = returnFunc(namespace, releaseName)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -847,19 +847,25 @@ type MockHelmClient_FindRelease_Call struct {
 }
 
 // FindRelease is a helper method to define mock.On call
+//   - namespace string
 //   - releaseName string
-func (_e *MockHelmClient_Expecter) FindRelease(releaseName interface{}) *MockHelmClient_FindRelease_Call {
-	return &MockHelmClient_FindRelease_Call{Call: _e.mock.On("FindRelease", releaseName)}
+func (_e *MockHelmClient_Expecter) FindRelease(namespace interface{}, releaseName interface{}) *MockHelmClient_FindRelease_Call {
+	return &MockHelmClient_FindRelease_Call{Call: _e.mock.On("FindRelease", namespace, releaseName)}
 }
 
-func (_c *MockHelmClient_FindRelease_Call) Run(run func(releaseName string)) *MockHelmClient_FindRelease_Call {
+func (_c *MockHelmClient_FindRelease_Call) Run(run func(namespace string, releaseName string)) *MockHelmClient_FindRelease_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
 			arg0 = args[0].(string)
 		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -870,7 +876,7 @@ func (_c *MockHelmClient_FindRelease_Call) Return(releaseInfo *ReleaseInfo, err 
 	return _c
 }
 
-func (_c *MockHelmClient_FindRelease_Call) RunAndReturn(run func(releaseName string) (*ReleaseInfo, error)) *MockHelmClient_FindRelease_Call {
+func (_c *MockHelmClient_FindRelease_Call) RunAndReturn(run func(namespace string, releaseName string) (*ReleaseInfo, error)) *MockHelmClient_FindRelease_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/tmpl/NOTICE
+++ b/internal/tmpl/NOTICE
@@ -23,9 +23,9 @@ License URL: https://github.com/googleapis/google-cloud-go/blob/auth/oauth2adapt
  
 ----------
 Module: cloud.google.com/go/compute
-Version: v1.58.0
+Version: v1.59.0
 License: Apache-2.0
-License URL: https://github.com/googleapis/google-cloud-go/blob/compute/v1.58.0/compute/LICENSE
+License URL: https://github.com/googleapis/google-cloud-go/blob/compute/v1.59.0/compute/LICENSE
  
 ----------
 Module: cloud.google.com/go/compute/metadata
@@ -1187,9 +1187,9 @@ License URL: https://github.com/googleapis/go-genproto/blob/d00831a3d3e7/LICENSE
  
 ----------
 Module: google.golang.org/genproto/googleapis/api
-Version: v0.0.0-20260401001100-f93e5f3e9f0f
+Version: v0.0.0-20260401024825-9d38bb4040a9
 License: Apache-2.0
-License URL: https://github.com/googleapis/go-genproto/blob/f93e5f3e9f0f/googleapis/api/LICENSE
+License URL: https://github.com/googleapis/go-genproto/blob/9d38bb4040a9/googleapis/api/LICENSE
  
 ----------
 Module: google.golang.org/genproto/googleapis/rpc
@@ -1235,9 +1235,9 @@ License URL: https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE
  
 ----------
 Module: helm.sh/helm/v4
-Version: v4.1.3
+Version: v4.1.4
 License: Apache-2.0
-License URL: https://github.com/helm/helm/blob/v4.1.3/LICENSE
+License URL: https://github.com/helm/helm/blob/v4.1.4/LICENSE
  
 ----------
 Module: k8s.io/api


### PR DESCRIPTION
* Adds --k0s flag to local bootstrapping (set kubelet dir for CSI driver, which is specific in k0s)
* Fixes the helm upgrade function to install if a release doesn't exist
* Fixes the detection of existing release (function was missing the namespace, so release was never found)