### PR TITLE
feat(bootstrap-gcp): make root disk size configurable

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -821,9 +821,9 @@ License URL: https://github.com/mxk/go-flowrate/blob/cca7078d478f/LICENSE
  
 ----------
 Module: github.com/onsi/gomega
-Version: v1.39.1
+Version: v1.40.0
 License: MIT
-License URL: https://github.com/onsi/gomega/blob/v1.39.1/LICENSE
+License URL: https://github.com/onsi/gomega/blob/v1.40.0/LICENSE
  
 ----------
 Module: github.com/opencontainers/go-digest

--- a/cli/cmd/bootstrap_gcp.go
+++ b/cli/cmd/bootstrap_gcp.go
@@ -95,6 +95,7 @@ func AddBootstrapGcpCmd(parent *cobra.Command, opts *GlobalOptions) {
 	flags.BoolVar(&bootstrapGcpCmd.CodesphereEnv.RecoverConfig, "recover-config", false, "Recover previously generated install config from the jumpbox. This will overwrite the local config! (default: false)")
 	flags.BoolVar(&bootstrapGcpCmd.SSHQuiet, "ssh-quiet", false, "Suppress SSH command output (default: false)")
 	flags.BoolVar(&bootstrapGcpCmd.CodesphereEnv.CreateTestUser, "create-test-user", false, "Create a test user with API token on the bootstrapped instance for smoke testing (default: false)")
+	flags.Int64Var(&bootstrapGcpCmd.CodesphereEnv.RootDiskSize, "root-disk-size", 50, "Instance root disk size in GB (default: 50)")
 
 	flags.StringVar(&bootstrapGcpCmd.CodesphereEnv.OpenBaoURI, "openbao-uri", "", "URI for OpenBao (optional)")
 	flags.StringVar(&bootstrapGcpCmd.CodesphereEnv.OpenBaoEngine, "openbao-engine", "cs-secrets-engine", "OpenBao engine name (default: cs-secrets-engine)")

--- a/docs/oms_beta_bootstrap-gcp.md
+++ b/docs/oms_beta_bootstrap-gcp.md
@@ -50,6 +50,7 @@ oms beta bootstrap-gcp [flags]
       --region string                     GCP Region (default: europe-west4) (default "europe-west4")
       --registry-type string              Container registry type to use (options: local-container, artifact-registry) (default: local-container) (default "local-container")
       --registry-user string              Custom Registry username (only for GitHub registry type) (optional)
+      --root-disk-size int                Instance root disk size in GB (default: 50) (default 50)
       --secrets-dir string                Directory for secrets (default: /etc/codesphere/secrets) (default "/etc/codesphere/secrets")
       --secrets-file string               Path to secrets files (optional) (default "prod.vault.yaml")
       --spot-vms                          Use Spot VMs for Codesphere infrastructure. Falls back to standard VMs if spot capacity unavailable. Mutually exclusive with --preemptible (default: false)

--- a/internal/bootstrap/gcp/gce.go
+++ b/internal/bootstrap/gcp/gce.go
@@ -55,11 +55,6 @@ type vmResult struct {
 
 // EnsureComputeInstances ensures that all required compute instances are present and running.
 func (b *GCPBootstrapper) EnsureComputeInstances() error {
-	rootDiskSize := int64(200)
-	if b.Env.RegistryType == RegistryTypeGitHub {
-		rootDiskSize = 50
-	}
-
 	wg := sync.WaitGroup{}
 	errCh := make(chan error, len(vmDefs))
 	resultCh := make(chan vmResult, len(vmDefs))
@@ -69,7 +64,7 @@ func (b *GCPBootstrapper) EnsureComputeInstances() error {
 		wg.Add(1)
 		go func(vm VMDef) {
 			defer wg.Done()
-			result, err := b.ensureVM(vm, rootDiskSize, logCh)
+			result, err := b.ensureVM(vm, b.Env.RootDiskSize, logCh)
 			if err != nil {
 				errCh <- err
 				return

--- a/internal/bootstrap/gcp/gce_test.go
+++ b/internal/bootstrap/gcp/gce_test.go
@@ -548,17 +548,47 @@ var _ = Describe("GCE", func() {
 				SSHPublicKeyPath: "key.pub",
 				Experiments:      gcp.DefaultExperiments,
 				FeatureFlags:     map[string]bool{},
+				RootDiskSize:     50,
 			}
 			bs = newTestBootstrapperAll(csEnv, gc, fw, mockGitHubClient)
 		})
 
 		Describe("Valid EnsureComputeInstances", func() {
-			It("creates all instances", func() {
-				ipResp := makeRunningInstance("10.0.0.x", "1.2.3.x")
-				mockGetInstanceNotFoundThenRunning(gc, csEnv.ProjectID, csEnv.Zone, ipResp, 8)
+			Context("When custom root disk size is specified", func() {
+				BeforeEach(func() {
+					csEnv.RootDiskSize = 200
+					ipResp := makeRunningInstance("10.0.0.x", "1.2.3.x")
+					mockGetInstanceNotFoundThenRunning(gc, csEnv.ProjectID, csEnv.Zone, ipResp, 8)
+				})
 
+				It("Sets the root disk size", func() {
+					fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAA..."), nil).Times(8)
+					allRootDiskSizesCorrect := true
+					mu := sync.Mutex{}
+					gc.EXPECT().CreateInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).RunAndReturn(
+						// Testing the disk size like this instead of a matcher
+						// to avoid the test to panic in case of a mismatch in the parallel go funcs
+						func(projectID, zone string, instance *computepb.Instance) error {
+							if instance.GetDisks()[0].GetInitializeParams().GetDiskSizeGb() != 200 {
+								mu.Lock()
+								allRootDiskSizesCorrect = false
+								mu.Unlock()
+							}
+							return nil
+						},
+					).Times(8)
+
+					err := bs.EnsureComputeInstances()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(allRootDiskSizesCorrect).To(BeTrue())
+				})
+			})
+
+			It("creates all instances", func() {
 				fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAA..."), nil).Times(8)
 				gc.EXPECT().CreateInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).Return(nil).Times(8)
+				ipResp := makeRunningInstance("10.0.0.x", "1.2.3.x")
+				mockGetInstanceNotFoundThenRunning(gc, csEnv.ProjectID, csEnv.Zone, ipResp, 8)
 
 				err := bs.EnsureComputeInstances()
 				Expect(err).NotTo(HaveOccurred())
@@ -590,9 +620,9 @@ var _ = Describe("GCE", func() {
 					It("fetches GitHub team keys", func() {
 						mockGitHubClient.EXPECT().ListTeamMembersBySlug(mock.Anything, csEnv.GitHubTeamOrg, csEnv.GitHubTeamSlug, mock.Anything).Return([]*gh.User{{Login: gh.Ptr("alice")}}, nil).Maybe()
 						mockGitHubClient.EXPECT().ListUserKeys(mock.Anything, "alice").Return([]*gh.Key{{Key: gh.Ptr("ssh-rsa AAALICE...")}}, nil).Maybe()
-
 						ipResp := makeRunningInstance("10.0.0.x", "1.2.3.x")
 						mockGetInstanceNotFoundThenRunning(gc, csEnv.ProjectID, csEnv.Zone, ipResp, 8)
+
 						fw.EXPECT().ReadFile(csEnv.SSHPublicKeyPath).Return([]byte("ssh-rsa AAA..."), nil).Times(8)
 						gc.EXPECT().CreateInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).RunAndReturn(func(projectID, zone string, instance *computepb.Instance) error {
 							sshMetadata := ""

--- a/internal/bootstrap/gcp/gcp.go
+++ b/internal/bootstrap/gcp/gcp.go
@@ -146,6 +146,7 @@ type CodesphereEnvironment struct {
 	// Test user creation
 	CreateTestUser bool   `json:"-"`
 	OmsWorkdir     string `json:"-"`
+	RootDiskSize   int64  `json:"root_disk_size"`
 }
 
 func NewGCPBootstrapper(

--- a/internal/bootstrap/gcp/gcp_test.go
+++ b/internal/bootstrap/gcp/gcp_test.go
@@ -97,6 +97,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 			ProjectID:             "pid",
 			Experiments:           gcp.DefaultExperiments,
 			FeatureFlags:          map[string]bool{},
+			RootDiskSize:          50,
 			InstallConfig: &files.RootConfig{
 				Registry: &files.RegistryConfig{},
 				Postgres: files.PostgresConfig{

--- a/internal/tmpl/NOTICE
+++ b/internal/tmpl/NOTICE
@@ -821,9 +821,9 @@ License URL: https://github.com/mxk/go-flowrate/blob/cca7078d478f/LICENSE
  
 ----------
 Module: github.com/onsi/gomega
-Version: v1.39.1
+Version: v1.40.0
 License: MIT
-License URL: https://github.com/onsi/gomega/blob/v1.39.1/LICENSE
+License URL: https://github.com/onsi/gomega/blob/v1.40.0/LICENSE
  
 ----------
 Module: github.com/opencontainers/go-digest


### PR DESCRIPTION
* Make root disk size a input parameter, defaulting to 50 instead of implicit decision based on other inputs