### PR TITLE
fix(bootstrap): write git provider secrets to vault

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -23,9 +23,9 @@ License URL: https://github.com/googleapis/google-cloud-go/blob/auth/oauth2adapt
  
 ----------
 Module: cloud.google.com/go/compute
-Version: v1.61.0
+Version: v1.62.0
 License: Apache-2.0
-License URL: https://github.com/googleapis/google-cloud-go/blob/compute/v1.61.0/compute/LICENSE
+License URL: https://github.com/googleapis/google-cloud-go/blob/compute/v1.62.0/compute/LICENSE
  
 ----------
 Module: cloud.google.com/go/compute/metadata

--- a/internal/installer/files/config_yaml.go
+++ b/internal/installer/files/config_yaml.go
@@ -714,6 +714,66 @@ func (c *RootConfig) addCodesphereSecrets(vault *InstallVault) {
 			})
 		}
 	}
+
+	// GitLab secrets
+	if c.Codesphere.GitProviders != nil && c.Codesphere.GitProviders.GitLab != nil {
+		if c.Codesphere.GitProviders.GitLab.OAuth.ClientID != "" {
+			vault.Secrets = append(vault.Secrets, SecretEntry{
+				Name: "gitlabAppClientId",
+				Fields: &SecretFields{
+					Password: c.Codesphere.GitProviders.GitLab.OAuth.ClientID,
+				},
+			})
+		}
+		if c.Codesphere.GitProviders.GitLab.OAuth.ClientSecret != "" {
+			vault.Secrets = append(vault.Secrets, SecretEntry{
+				Name: "gitlabAppClientSecret",
+				Fields: &SecretFields{
+					Password: c.Codesphere.GitProviders.GitLab.OAuth.ClientSecret,
+				},
+			})
+		}
+	}
+
+	// Bitbucket secrets
+	if c.Codesphere.GitProviders != nil && c.Codesphere.GitProviders.Bitbucket != nil {
+		if c.Codesphere.GitProviders.Bitbucket.OAuth.ClientID != "" {
+			vault.Secrets = append(vault.Secrets, SecretEntry{
+				Name: "bitbucketAppsClientId",
+				Fields: &SecretFields{
+					Password: c.Codesphere.GitProviders.Bitbucket.OAuth.ClientID,
+				},
+			})
+		}
+		if c.Codesphere.GitProviders.Bitbucket.OAuth.ClientSecret != "" {
+			vault.Secrets = append(vault.Secrets, SecretEntry{
+				Name: "bitbucketAppsClientSecret",
+				Fields: &SecretFields{
+					Password: c.Codesphere.GitProviders.Bitbucket.OAuth.ClientSecret,
+				},
+			})
+		}
+	}
+
+	// Azure DevOps secrets
+	if c.Codesphere.GitProviders != nil && c.Codesphere.GitProviders.AzureDevOps != nil {
+		if c.Codesphere.GitProviders.AzureDevOps.OAuth.ClientID != "" {
+			vault.Secrets = append(vault.Secrets, SecretEntry{
+				Name: "azureDevOpsAppClientId",
+				Fields: &SecretFields{
+					Password: c.Codesphere.GitProviders.AzureDevOps.OAuth.ClientID,
+				},
+			})
+		}
+		if c.Codesphere.GitProviders.AzureDevOps.OAuth.ClientSecret != "" {
+			vault.Secrets = append(vault.Secrets, SecretEntry{
+				Name: "azureDevOpsAppClientSecret",
+				Fields: &SecretFields{
+					Password: c.Codesphere.GitProviders.AzureDevOps.OAuth.ClientSecret,
+				},
+			})
+		}
+	}
 }
 
 func (c *RootConfig) addIngressCASecret(vault *InstallVault) {

--- a/internal/installer/secrets_test.go
+++ b/internal/installer/secrets_test.go
@@ -174,7 +174,107 @@ var _ = Describe("ExtractVault", func() {
 			Expect(foundPass).To(BeTrue(), "Password secret for service %s not found", service)
 		}
 	})
+
+	It("extracts GitLab secrets into vault", func() {
+		config := files.NewRootConfig()
+		config.Codesphere = files.CodesphereConfig{
+			GitProviders: &files.GitProvidersConfig{
+				GitLab: &files.GitProviderConfig{
+					OAuth: files.OAuthConfig{
+						ClientID:     "gl-client-id",
+						ClientSecret: "gl-client-secret",
+					},
+				},
+			},
+		}
+
+		vault := config.ExtractVault()
+
+		assertSecretPassword(vault, "gitlabAppClientId", "gl-client-id")
+		assertSecretPassword(vault, "gitlabAppClientSecret", "gl-client-secret")
+	})
+
+	It("extracts Bitbucket secrets into vault", func() {
+		config := files.NewRootConfig()
+		config.Codesphere = files.CodesphereConfig{
+			GitProviders: &files.GitProvidersConfig{
+				Bitbucket: &files.GitProviderConfig{
+					OAuth: files.OAuthConfig{
+						ClientID:     "bb-client-id",
+						ClientSecret: "bb-client-secret",
+					},
+				},
+			},
+		}
+
+		vault := config.ExtractVault()
+
+		assertSecretPassword(vault, "bitbucketAppsClientId", "bb-client-id")
+		assertSecretPassword(vault, "bitbucketAppsClientSecret", "bb-client-secret")
+	})
+
+	It("extracts Azure DevOps secrets into vault", func() {
+		config := files.NewRootConfig()
+		config.Codesphere = files.CodesphereConfig{
+			GitProviders: &files.GitProvidersConfig{
+				AzureDevOps: &files.GitProviderConfig{
+					OAuth: files.OAuthConfig{
+						ClientID:     "az-client-id",
+						ClientSecret: "az-client-secret",
+					},
+				},
+			},
+		}
+
+		vault := config.ExtractVault()
+
+		assertSecretPassword(vault, "azureDevOpsAppClientId", "az-client-id")
+		assertSecretPassword(vault, "azureDevOpsAppClientSecret", "az-client-secret")
+	})
+
+	It("does not include git provider secrets when providers are not set", func() {
+		config := files.NewRootConfig()
+		config.Codesphere = files.CodesphereConfig{}
+
+		vault := config.ExtractVault()
+
+		for _, secret := range vault.Secrets {
+			Expect(secret.Name).NotTo(BeElementOf(
+				"gitlabAppClientId", "gitlabAppClientSecret",
+				"bitbucketAppsClientId", "bitbucketAppsClientSecret",
+				"azureDevOpsAppClientId", "azureDevOpsAppClientSecret",
+			))
+		}
+	})
+
+	It("extracts OIDC OAuth secrets into vault", func() {
+		config := files.NewRootConfig()
+		config.Codesphere = files.CodesphereConfig{
+			OAuth: &files.OAuthProvidersConfig{
+				Oidc: &files.OidcOAuthProvider{
+					ClientID:     "oidc-client-id",
+					ClientSecret: "oidc-client-secret",
+				},
+			},
+		}
+
+		vault := config.ExtractVault()
+
+		assertSecretPassword(vault, "oidcClientId", "oidc-client-id")
+		assertSecretPassword(vault, "oidcClientSecret", "oidc-client-secret")
+	})
 })
+
+func assertSecretPassword(vault *files.InstallVault, name string, expectedPassword string) {
+	for _, secret := range vault.Secrets {
+		if secret.Name == name {
+			ExpectWithOffset(1, secret.Fields).NotTo(BeNil(), "Secret %s has no fields", name)
+			ExpectWithOffset(1, secret.Fields.Password).To(Equal(expectedPassword), "Secret %s password mismatch", name)
+			return
+		}
+	}
+	Fail("Secret " + name + " not found in vault")
+}
 
 func capitalize(s string) string {
 	if s == "" {

--- a/internal/tmpl/NOTICE
+++ b/internal/tmpl/NOTICE
@@ -23,9 +23,9 @@ License URL: https://github.com/googleapis/google-cloud-go/blob/auth/oauth2adapt
  
 ----------
 Module: cloud.google.com/go/compute
-Version: v1.61.0
+Version: v1.62.0
 License: Apache-2.0
-License URL: https://github.com/googleapis/google-cloud-go/blob/compute/v1.61.0/compute/LICENSE
+License URL: https://github.com/googleapis/google-cloud-go/blob/compute/v1.62.0/compute/LICENSE
  
 ----------
 Module: cloud.google.com/go/compute/metadata


### PR DESCRIPTION
That was missing in my last PR. Caused secrets to be "dummy" instead of configured secrets.