### PR TITLE
feat(openbao): add install openbao command

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -25,4 +25,5 @@ func AddInstallCmd(rootCmd *cobra.Command, opts *GlobalOptions) {
 
 	AddInstallCodesphereCmd(install.cmd, opts)
 	AddInstallK0sCmd(install.cmd, opts)
+	AddInstallOpenBaoCmd(install.cmd, opts)
 }

--- a/cli/cmd/install_openbao.go
+++ b/cli/cmd/install_openbao.go
@@ -117,10 +117,10 @@ func AddInstallOpenBaoCmd(install *cobra.Command, opts *GlobalOptions) {
 // validateOpenBaoPrereqs checks that required external tools are available.
 func validateOpenBaoPrereqs() error {
 	if _, err := exec.LookPath("sops"); err != nil {
-		return fmt.Errorf("sops not found in PATH — install it with: brew install sops")
+		return fmt.Errorf("sops not found in PATH — install from https://github.com/getsops/sops")
 	}
 	if _, err := exec.LookPath("age-keygen"); err != nil {
-		return fmt.Errorf("age-keygen not found in PATH — install it with: brew install age")
+		return fmt.Errorf("age-keygen not found in PATH — install from https://github.com/FiloSottile/age")
 	}
 	return nil
 }

--- a/cli/cmd/install_openbao.go
+++ b/cli/cmd/install_openbao.go
@@ -101,7 +101,7 @@ func AddInstallOpenBaoCmd(install *cobra.Command, opts *GlobalOptions) {
 		Opts: &InstallOpenBaoOpts{GlobalOptions: opts},
 	}
 	openbao.cmd.Flags().StringVar(&openbao.Opts.SecretsEngineName, "secrets-engine", "cs-secrets-engine", "Name of the KV-v2 secrets engine to provision")
-	openbao.cmd.Flags().StringVar(&openbao.Opts.BaoUsername, "bao-user", "admin", "Username for the userpass auth method")
+	openbao.cmd.Flags().StringVar(&openbao.Opts.BaoUsername, "bao-user", "admin", "Username for the userpass auth method (ignored on restore, uses DR backup value)")
 	openbao.cmd.Flags().StringVar(&openbao.Opts.DRBackupPath, "dr-backup-path", "", "Path for SOPS-encrypted DR backup file (required)")
 	openbao.cmd.Flags().IntVar(&openbao.Opts.Replicas, "replicas", 1, "Number of OpenBao replicas (1 for single-node, odd number >= 3 for HA)")
 	openbao.cmd.Flags().StringVar(&openbao.Opts.StorageSize, "storage-size", "10Gi", "PVC storage size for each OpenBao replica")

--- a/cli/cmd/install_openbao.go
+++ b/cli/cmd/install_openbao.go
@@ -104,7 +104,7 @@ func AddInstallOpenBaoCmd(install *cobra.Command, opts *GlobalOptions) {
 	openbao.cmd.Flags().StringVar(&openbao.Opts.BaoUsername, "bao-user", "admin", "Username for the userpass auth method")
 	openbao.cmd.Flags().StringVar(&openbao.Opts.DRBackupPath, "dr-backup-path", "", "Path for SOPS-encrypted DR backup file (required)")
 	openbao.cmd.Flags().IntVar(&openbao.Opts.Replicas, "replicas", 1, "Number of OpenBao replicas (1 for single-node, odd number >= 3 for HA)")
-	openbao.cmd.Flags().StringVar(&openbao.Opts.StorageSize, "storage-size", "10Gi", "PVC storage size for each OpenBao replica (only used with replicas > 1)")
+	openbao.cmd.Flags().StringVar(&openbao.Opts.StorageSize, "storage-size", "10Gi", "PVC storage size for each OpenBao replica")
 	openbao.cmd.Flags().DurationVar(&openbao.Opts.Timeout, "timeout", 5*time.Minute, "Timeout for waiting on initialization")
 
 	util.MarkFlagRequired(openbao.cmd, "dr-backup-path")

--- a/cli/cmd/install_openbao.go
+++ b/cli/cmd/install_openbao.go
@@ -33,6 +33,7 @@ type InstallOpenBaoOpts struct {
 	BaoUsername       string
 	DRBackupPath      string
 	Replicas          int
+	StorageSize       string
 	Timeout           time.Duration
 }
 
@@ -57,6 +58,7 @@ func (c *InstallOpenBaoCmd) RunE(_ *cobra.Command, _ []string) error {
 		Username:          c.Opts.BaoUsername,
 		DRBackupPath:      c.Opts.DRBackupPath,
 		Replicas:          c.Opts.Replicas,
+		StorageSize:       c.Opts.StorageSize,
 		Timeout:           c.Opts.Timeout,
 		AgeRecipient:      recipient,
 		AgeKeyPath:        keyPath,
@@ -88,7 +90,6 @@ func AddInstallOpenBaoCmd(install *cobra.Command, opts *GlobalOptions) {
 				4. Apply the Vault CR with desired-state configuration
 				5. Wait for initialization to complete
 				6. Extract and encrypt unseal keys + password as SOPS DR backup
-				7. Remove root token from cluster for security
 
 				The command is idempotent and safe to re-run.`),
 			Example: formatExamples("install openbao", []packageio.Example{
@@ -103,6 +104,7 @@ func AddInstallOpenBaoCmd(install *cobra.Command, opts *GlobalOptions) {
 	openbao.cmd.Flags().StringVar(&openbao.Opts.BaoUsername, "bao-user", "admin", "Username for the userpass auth method")
 	openbao.cmd.Flags().StringVar(&openbao.Opts.DRBackupPath, "dr-backup-path", "", "Path for SOPS-encrypted DR backup file (required)")
 	openbao.cmd.Flags().IntVar(&openbao.Opts.Replicas, "replicas", 1, "Number of OpenBao replicas (1 for single-node, odd number >= 3 for HA)")
+	openbao.cmd.Flags().StringVar(&openbao.Opts.StorageSize, "storage-size", "10Gi", "PVC storage size for each OpenBao replica (only used with replicas > 1)")
 	openbao.cmd.Flags().DurationVar(&openbao.Opts.Timeout, "timeout", 5*time.Minute, "Timeout for waiting on initialization")
 
 	util.MarkFlagRequired(openbao.cmd, "dr-backup-path")

--- a/cli/cmd/install_openbao.go
+++ b/cli/cmd/install_openbao.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	packageio "github.com/codesphere-cloud/cs-go/pkg/io"
@@ -65,7 +67,10 @@ func (c *InstallOpenBaoCmd) RunE(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("initializing openbao installer: %w", err)
 	}
 
-	return inst.Install(context.Background())
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	return inst.Install(ctx)
 }
 
 // AddInstallOpenBaoCmd registers the openbao subcommand under install.

--- a/cli/cmd/install_openbao.go
+++ b/cli/cmd/install_openbao.go
@@ -1,0 +1,108 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	packageio "github.com/codesphere-cloud/cs-go/pkg/io"
+	"github.com/spf13/cobra"
+
+	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/util"
+)
+
+// InstallOpenBaoCmd represents the openbao command
+type InstallOpenBaoCmd struct {
+	cmd  *cobra.Command
+	Opts *InstallOpenBaoOpts
+}
+
+// InstallOpenBaoOpts holds the CLI flags for the OpenBao installer.
+type InstallOpenBaoOpts struct {
+	*GlobalOptions
+	SecretsEngineName string
+	BaoUsername       string
+	DRBackupPath      string
+	Replicas          int
+	Timeout           time.Duration
+}
+
+func (c *InstallOpenBaoCmd) RunE(_ *cobra.Command, _ []string) error {
+	if err := validateOpenBaoPrereqs(); err != nil {
+		return err
+	}
+
+	recipient, keyPath, err := installer.ResolveAgeKey("")
+	if err != nil {
+		return fmt.Errorf("resolving age key: %w", err)
+	}
+
+	cfg := installer.OpenBaoInstallerConfig{
+		SecretsEngineName: c.Opts.SecretsEngineName,
+		Username:          c.Opts.BaoUsername,
+		DRBackupPath:      c.Opts.DRBackupPath,
+		Replicas:          c.Opts.Replicas,
+		Timeout:           c.Opts.Timeout,
+		AgeRecipient:      recipient,
+		AgeKeyPath:        keyPath,
+	}
+
+	inst, err := installer.NewOpenBaoInstaller(cfg)
+	if err != nil {
+		return fmt.Errorf("initializing openbao installer: %w", err)
+	}
+
+	return inst.Install(context.Background())
+}
+
+// AddInstallOpenBaoCmd registers the openbao subcommand under install.
+func AddInstallOpenBaoCmd(install *cobra.Command, opts *GlobalOptions) {
+	openbao := InstallOpenBaoCmd{
+		cmd: &cobra.Command{
+			Use:   "openbao",
+			Short: "Bootstrap OpenBao with Bank-Vaults Operator and DR backup",
+			Long: packageio.Long(`Bootstrap OpenBao using the Bank-Vaults Operator with a KMS-less Day-0 workflow.
+
+				This command performs the full lifecycle:
+				1. Pre-flight DR check (restore from SOPS backup if exists)
+				2. Generate a secure password for userpass auth
+				3. Deploy the Bank-Vaults Operator via Helm
+				4. Apply the Vault CR with desired-state configuration
+				5. Wait for initialization to complete
+				6. Extract and encrypt unseal keys + password as SOPS DR backup
+				7. Remove root token from cluster for security
+
+				The command is idempotent and safe to re-run.`),
+			Example: formatExamples("install openbao", []packageio.Example{
+				{Cmd: "--dr-backup-path ./backups/cluster-1.enc.json", Desc: "Fresh bootstrap with DR backup saved locally"},
+				{Cmd: "--dr-backup-path ./backups/cluster-1.enc.json --secrets-engine my-engine --bao-user myuser", Desc: "Custom engine and user"},
+				{Cmd: "--dr-backup-path ./backups/cluster-1.enc.json --timeout 10m", Desc: "Extended timeout for slower clusters"},
+			}),
+		},
+		Opts: &InstallOpenBaoOpts{GlobalOptions: opts},
+	}
+	openbao.cmd.Flags().StringVar(&openbao.Opts.SecretsEngineName, "secrets-engine", "cs-secrets-engine", "Name of the KV-v2 secrets engine to provision")
+	openbao.cmd.Flags().StringVar(&openbao.Opts.BaoUsername, "bao-user", "admin", "Username for the userpass auth method")
+	openbao.cmd.Flags().StringVar(&openbao.Opts.DRBackupPath, "dr-backup-path", "", "Path for SOPS-encrypted DR backup file (required)")
+	openbao.cmd.Flags().IntVar(&openbao.Opts.Replicas, "replicas", 1, "Number of OpenBao replicas (1 for single-node, odd number >= 3 for HA)")
+	openbao.cmd.Flags().DurationVar(&openbao.Opts.Timeout, "timeout", 5*time.Minute, "Timeout for waiting on initialization")
+
+	util.MarkFlagRequired(openbao.cmd, "dr-backup-path")
+
+	AddCmd(install, openbao.cmd)
+
+	openbao.cmd.RunE = openbao.RunE
+}
+
+// validateOpenBaoPrereqs checks that required external tools are available.
+func validateOpenBaoPrereqs() error {
+	if _, err := exec.LookPath("sops"); err != nil {
+		return fmt.Errorf("sops not found in PATH — install it with: brew install sops")
+	}
+	return nil
+}

--- a/cli/cmd/install_openbao.go
+++ b/cli/cmd/install_openbao.go
@@ -20,7 +20,7 @@ import (
 	"github.com/codesphere-cloud/oms/internal/util"
 )
 
-// InstallOpenBaoCmd represents the openbao command
+// InstallOpenBaoCmd wraps the cobra command and options for 'oms install openbao'.
 type InstallOpenBaoCmd struct {
 	cmd  *cobra.Command
 	Opts *InstallOpenBaoOpts

--- a/cli/cmd/install_openbao.go
+++ b/cli/cmd/install_openbao.go
@@ -6,7 +6,9 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	packageio "github.com/codesphere-cloud/cs-go/pkg/io"
@@ -37,7 +39,13 @@ func (c *InstallOpenBaoCmd) RunE(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	recipient, keyPath, err := installer.ResolveAgeKey("")
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return fmt.Errorf("determining user config directory: %w", err)
+	}
+	fallbackDir := filepath.Join(configDir, "sops", "age")
+
+	recipient, keyPath, err := installer.ResolveAgeKey(fallbackDir)
 	if err != nil {
 		return fmt.Errorf("resolving age key: %w", err)
 	}
@@ -103,6 +111,9 @@ func AddInstallOpenBaoCmd(install *cobra.Command, opts *GlobalOptions) {
 func validateOpenBaoPrereqs() error {
 	if _, err := exec.LookPath("sops"); err != nil {
 		return fmt.Errorf("sops not found in PATH — install it with: brew install sops")
+	}
+	if _, err := exec.LookPath("age-keygen"); err != nil {
+		return fmt.Errorf("age-keygen not found in PATH — install it with: brew install age")
 	}
 	return nil
 }

--- a/docs/oms_install.md
+++ b/docs/oms_install.md
@@ -17,4 +17,5 @@ Install Codesphere and other components like Ceph and PostgreSQL.
 * [oms](oms.md)	 - Codesphere Operations Management System (OMS)
 * [oms install codesphere](oms_install_codesphere.md)	 - Install a Codesphere instance
 * [oms install k0s](oms_install_k0s.md)	 - Install k0s Kubernetes distribution
+* [oms install openbao](oms_install_openbao.md)	 - Bootstrap OpenBao with Bank-Vaults Operator and DR backup
 

--- a/docs/oms_install_openbao.md
+++ b/docs/oms_install_openbao.md
@@ -42,7 +42,7 @@ $ oms install openbao --dr-backup-path ./backups/cluster-1.enc.json --timeout 10
   -h, --help                    help for openbao
       --replicas int            Number of OpenBao replicas (1 for single-node, odd number >= 3 for HA) (default 1)
       --secrets-engine string   Name of the KV-v2 secrets engine to provision (default "cs-secrets-engine")
-      --storage-size string     PVC storage size for each OpenBao replica (only used with replicas > 1) (default "10Gi")
+      --storage-size string     PVC storage size for each OpenBao replica (default "10Gi")
       --timeout duration        Timeout for waiting on initialization (default 5m0s)
 ```
 

--- a/docs/oms_install_openbao.md
+++ b/docs/oms_install_openbao.md
@@ -13,7 +13,6 @@ This command performs the full lifecycle:
 4. Apply the Vault CR with desired-state configuration
 5. Wait for initialization to complete
 6. Extract and encrypt unseal keys + password as SOPS DR backup
-7. Remove root token from cluster for security
 
 The command is idempotent and safe to re-run.
 
@@ -43,6 +42,7 @@ $ oms install openbao --dr-backup-path ./backups/cluster-1.enc.json --timeout 10
   -h, --help                    help for openbao
       --replicas int            Number of OpenBao replicas (1 for single-node, odd number >= 3 for HA) (default 1)
       --secrets-engine string   Name of the KV-v2 secrets engine to provision (default "cs-secrets-engine")
+      --storage-size string     PVC storage size for each OpenBao replica (only used with replicas > 1) (default "10Gi")
       --timeout duration        Timeout for waiting on initialization (default 5m0s)
 ```
 

--- a/docs/oms_install_openbao.md
+++ b/docs/oms_install_openbao.md
@@ -1,0 +1,52 @@
+## oms install openbao
+
+Bootstrap OpenBao with Bank-Vaults Operator and DR backup
+
+### Synopsis
+
+Bootstrap OpenBao using the Bank-Vaults Operator with a KMS-less Day-0 workflow.
+
+This command performs the full lifecycle:
+1. Pre-flight DR check (restore from SOPS backup if exists)
+2. Generate a secure password for userpass auth
+3. Deploy the Bank-Vaults Operator via Helm
+4. Apply the Vault CR with desired-state configuration
+5. Wait for initialization to complete
+6. Extract and encrypt unseal keys + password as SOPS DR backup
+7. Remove root token from cluster for security
+
+The command is idempotent and safe to re-run.
+
+```
+oms install openbao [flags]
+```
+
+### Examples
+
+```
+# Fresh bootstrap with DR backup saved locally
+$ oms install openbao --dr-backup-path ./backups/cluster-1.enc.json
+
+# Custom engine and user
+$ oms install openbao --dr-backup-path ./backups/cluster-1.enc.json --secrets-engine my-engine --bao-user myuser
+
+# Extended timeout for slower clusters
+$ oms install openbao --dr-backup-path ./backups/cluster-1.enc.json --timeout 10m
+
+```
+
+### Options
+
+```
+      --bao-user string         Username for the userpass auth method (default "admin")
+      --dr-backup-path string   Path for SOPS-encrypted DR backup file (required)
+  -h, --help                    help for openbao
+      --replicas int            Number of OpenBao replicas (1 for single-node, odd number >= 3 for HA) (default 1)
+      --secrets-engine string   Name of the KV-v2 secrets engine to provision (default "cs-secrets-engine")
+      --timeout duration        Timeout for waiting on initialization (default 5m0s)
+```
+
+### SEE ALSO
+
+* [oms install](oms_install.md)	 - Install Codesphere and other components
+

--- a/docs/oms_install_openbao.md
+++ b/docs/oms_install_openbao.md
@@ -37,7 +37,7 @@ $ oms install openbao --dr-backup-path ./backups/cluster-1.enc.json --timeout 10
 ### Options
 
 ```
-      --bao-user string         Username for the userpass auth method (default "admin")
+      --bao-user string         Username for the userpass auth method (ignored on restore, uses DR backup value) (default "admin")
       --dr-backup-path string   Path for SOPS-encrypted DR backup file (required)
   -h, --help                    help for openbao
       --replicas int            Number of OpenBao replicas (1 for single-node, odd number >= 3 for HA) (default 1)

--- a/internal/installer/helm_client.go
+++ b/internal/installer/helm_client.go
@@ -38,7 +38,7 @@ type ChartConfig struct {
 }
 
 type UpgradeChartOptions struct {
-	InstallIfNotExist bool // if true, perform an install if the release does not already exist
+	InstallIfNotExist bool
 }
 
 // HelmClient is the seam that makes the Helm SDK mockable.
@@ -191,7 +191,6 @@ func (h *helmClient) InstallChart(ctx context.Context, cfg ChartConfig) error {
 
 func (h *helmClient) UpgradeChart(ctx context.Context, cfg ChartConfig, opts UpgradeChartOptions) error {
 	if opts.InstallIfNotExist {
-		// If a release does not exist, install it.
 		rel, err := h.FindRelease(cfg.Namespace, cfg.ReleaseName)
 		if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
 			return err

--- a/internal/installer/helm_client.go
+++ b/internal/installer/helm_client.go
@@ -14,6 +14,7 @@ import (
 	"helm.sh/helm/v4/pkg/chart"
 	"helm.sh/helm/v4/pkg/chart/loader"
 	"helm.sh/helm/v4/pkg/cli"
+	"helm.sh/helm/v4/pkg/registry"
 	"helm.sh/helm/v4/pkg/release"
 	"helm.sh/helm/v4/pkg/storage/driver"
 )
@@ -61,20 +62,26 @@ type HelmClient interface {
 // ---------------------------------------------------------------------------
 
 type helmClient struct {
-	settings         *cli.EnvSettings
 	defaultNamespace string
 	driver           string
 }
 
 func NewHelmClient(namespace string) (HelmClient, error) {
 	return &helmClient{
-		settings:         cli.New(),
 		defaultNamespace: namespace,
 		driver:           os.Getenv("HELM_DRIVER"),
 	}, nil
 }
 
-func (h *helmClient) newActionConfig(namespace string) (*action.Configuration, error) {
+// helmEnv holds the per-call Helm action configuration and CLI settings.
+// Both are scoped to the same namespace so that the RESTClientGetter, Helm
+// storage driver, and LocateChart all operate in the intended namespace.
+type helmEnv struct {
+	actionConfig *action.Configuration
+	settings     *cli.EnvSettings
+}
+
+func (h *helmClient) newHelmEnv(namespace string) (*helmEnv, error) {
 	if namespace == "" {
 		namespace = h.defaultNamespace
 	}
@@ -82,25 +89,38 @@ func (h *helmClient) newActionConfig(namespace string) (*action.Configuration, e
 		return nil, fmt.Errorf("helm namespace is required")
 	}
 
+	// Create per-call settings so the RESTClientGetter uses the correct
+	// namespace for Kubernetes operations (resource deployment), not just
+	// Helm storage. Without this, resources land in the kubeconfig context's
+	// default namespace instead of the requested one.
+	settings := cli.New()
+	settings.SetNamespace(namespace)
+
 	actionConfig := new(action.Configuration)
 	if err := actionConfig.Init(
-		h.settings.RESTClientGetter(),
+		settings.RESTClientGetter(),
 		namespace,
 		h.driver,
 	); err != nil {
 		return nil, fmt.Errorf("helm action config init failed: %w", err)
 	}
 
-	return actionConfig, nil
+	registryClient, err := registry.NewClient()
+	if err != nil {
+		return nil, fmt.Errorf("helm registry client init failed: %w", err)
+	}
+	actionConfig.RegistryClient = registryClient
+
+	return &helmEnv{actionConfig: actionConfig, settings: settings}, nil
 }
 
 func (h *helmClient) FindRelease(namespace, releaseName string) (*ReleaseInfo, error) {
-	actionConfig, err := h.newActionConfig(namespace)
+	env, err := h.newHelmEnv(namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	listClient := action.NewList(actionConfig)
+	listClient := action.NewList(env.actionConfig)
 	listClient.Filter = "^" + releaseName + "$"
 	listClient.Deployed = true
 	listClient.SetStateMask()
@@ -136,12 +156,12 @@ func (h *helmClient) FindRelease(namespace, releaseName string) (*ReleaseInfo, e
 }
 
 func (h *helmClient) InstallChart(ctx context.Context, cfg ChartConfig) error {
-	actionConfig, err := h.newActionConfig(cfg.Namespace)
+	env, err := h.newHelmEnv(cfg.Namespace)
 	if err != nil {
 		return err
 	}
 
-	installClient := action.NewInstall(actionConfig)
+	installClient := action.NewInstall(env.actionConfig)
 	installClient.ReleaseName = cfg.ReleaseName
 	installClient.Namespace = cfg.Namespace
 	installClient.CreateNamespace = cfg.CreateNamespace
@@ -151,7 +171,7 @@ func (h *helmClient) InstallChart(ctx context.Context, cfg ChartConfig) error {
 	installClient.RepoURL = cfg.RepoURL
 	installClient.Timeout = 5 * time.Minute
 
-	chartPath, err := installClient.LocateChart(cfg.ChartName, h.settings)
+	chartPath, err := installClient.LocateChart(cfg.ChartName, env.settings)
 	if err != nil {
 		return fmt.Errorf("LocateChart failed: %w", err)
 	}
@@ -170,11 +190,6 @@ func (h *helmClient) InstallChart(ctx context.Context, cfg ChartConfig) error {
 }
 
 func (h *helmClient) UpgradeChart(ctx context.Context, cfg ChartConfig, opts UpgradeChartOptions) error {
-	actionConfig, err := h.newActionConfig(cfg.Namespace)
-	if err != nil {
-		return err
-	}
-
 	if opts.InstallIfNotExist {
 		// If a release does not exist, install it.
 		rel, err := h.FindRelease(cfg.Namespace, cfg.ReleaseName)
@@ -186,14 +201,19 @@ func (h *helmClient) UpgradeChart(ctx context.Context, cfg ChartConfig, opts Upg
 		}
 	}
 
-	upgradeClient := action.NewUpgrade(actionConfig)
+	env, err := h.newHelmEnv(cfg.Namespace)
+	if err != nil {
+		return err
+	}
+
+	upgradeClient := action.NewUpgrade(env.actionConfig)
 	upgradeClient.Namespace = cfg.Namespace
 	upgradeClient.WaitStrategy = "watcher"
 	upgradeClient.Version = cfg.Version
 	upgradeClient.RepoURL = cfg.RepoURL
 	upgradeClient.Timeout = 5 * time.Minute
 
-	chartPath, err := upgradeClient.LocateChart(cfg.ChartName, h.settings)
+	chartPath, err := upgradeClient.LocateChart(cfg.ChartName, env.settings)
 	if err != nil {
 		return fmt.Errorf("LocateChart failed: %w", err)
 	}

--- a/internal/installer/manifests/openbao/vault-cr.yaml
+++ b/internal/installer/manifests/openbao/vault-cr.yaml
@@ -80,7 +80,9 @@ spec:
           fieldRef:
             fieldPath: metadata.name
       - name: BAO_CLUSTER_ADDR
-        value: "https://$(POD_NAME).openbao.{{ .Namespace }}.svc.cluster.local:8201"
+        value: "https://$(POD_NAME).{{ .Namespace }}.svc.cluster.local:8201"
+      - name: BAO_API_ADDR
+        value: "http://$(POD_NAME).{{ .Namespace }}.svc.cluster.local:8200"
     {{- end }}
   unsealConfig:
     options:

--- a/internal/installer/manifests/openbao/vault-cr.yaml
+++ b/internal/installer/manifests/openbao/vault-cr.yaml
@@ -77,7 +77,7 @@ spec:
           fieldRef:
             fieldPath: metadata.name
       - name: BAO_CLUSTER_ADDR
-        value: "https://$(POD_NAME).{{ .Namespace }}.svc.cluster.local:8201"
+        value: "http://$(POD_NAME).{{ .Namespace }}.svc.cluster.local:8201"
       - name: BAO_API_ADDR
         value: "http://$(POD_NAME).{{ .Namespace }}.svc.cluster.local:8200"
   unsealConfig:

--- a/internal/installer/manifests/openbao/vault-cr.yaml
+++ b/internal/installer/manifests/openbao/vault-cr.yaml
@@ -105,12 +105,12 @@ spec:
     api_addr: http://openbao.{{ .Namespace }}:8200
   externalConfig:
     secrets:
-      - path: {{ .SecretsEngineName }}
+      - path: "{{ .SecretsEngineName }}"
         type: kv
         options:
           version: "2"
     policies:
-      - name: {{ .SecretsEngineName }}-rw
+      - name: "{{ .SecretsEngineName }}-rw"
         rules: |
           path "{{ .SecretsEngineName }}/data/*" {
             capabilities = ["create", "read", "update", "delete", "list"]
@@ -121,6 +121,6 @@ spec:
     auth:
       - type: userpass
         users:
-          - username: {{ .BaoUsername }}
-            password: {{ .BaoPassword }}
-            policies: {{ .SecretsEngineName }}-rw
+          - username: "{{ .BaoUsername }}"
+            password: "{{ .BaoPassword }}"
+            policies: "{{ .SecretsEngineName }}-rw"

--- a/internal/installer/manifests/openbao/vault-cr.yaml
+++ b/internal/installer/manifests/openbao/vault-cr.yaml
@@ -50,7 +50,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 10Gi
+            storage: {{ .StorageSize }}
   volumeMounts:
     - name: openbao-data
       mountPath: /openbao/data
@@ -87,7 +87,7 @@ spec:
   unsealConfig:
     options:
       preFlightChecks: false
-      storeRootToken: true
+      storeRootToken: false
     kubernetes:
       secretNamespace: {{ .Namespace }}
       secretName: openbao-unseal-keys

--- a/internal/installer/manifests/openbao/vault-cr.yaml
+++ b/internal/installer/manifests/openbao/vault-cr.yaml
@@ -41,7 +41,6 @@ spec:
   image: {{ .OpenBaoImage }}
   bankVaultsImage: {{ .BankVaultsImage }}
   serviceAccount: openbao
-  {{- if gt .Replicas 1 }}
   volumeClaimTemplates:
     - metadata:
         name: openbao-data
@@ -54,7 +53,6 @@ spec:
   volumeMounts:
     - name: openbao-data
       mountPath: /openbao/data
-  {{- end }}
   vaultContainerSpec:
     name: vault
     command:
@@ -73,7 +71,6 @@ spec:
       initialDelaySeconds: 5
       periodSeconds: 10
       failureThreshold: 30
-    {{- if gt .Replicas 1 }}
     env:
       - name: POD_NAME
         valueFrom:
@@ -83,7 +80,6 @@ spec:
         value: "https://$(POD_NAME).{{ .Namespace }}.svc.cluster.local:8201"
       - name: BAO_API_ADDR
         value: "http://$(POD_NAME).{{ .Namespace }}.svc.cluster.local:8200"
-    {{- end }}
   unsealConfig:
     options:
       preFlightChecks: false
@@ -94,7 +90,6 @@ spec:
   config:
     ui: true
     storage:
-      {{- if gt .Replicas 1 }}
       raft:
         path: /openbao/data
         {{- if .RetryJoinAddrs }}
@@ -103,10 +98,6 @@ spec:
           - leader_api_addr: "{{ . }}"
           {{- end }}
         {{- end }}
-      {{- else }}
-      file:
-        path: /openbao/file
-      {{- end }}
     listener:
       tcp:
         address: "0.0.0.0:8200"

--- a/internal/installer/manifests/openbao/vault-cr.yaml
+++ b/internal/installer/manifests/openbao/vault-cr.yaml
@@ -1,0 +1,133 @@
+# Copyright (c) Codesphere Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openbao
+  namespace: {{ .Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openbao-secrets
+  namespace: {{ .Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openbao-secrets
+  namespace: {{ .Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openbao-secrets
+subjects:
+  - kind: ServiceAccount
+    name: openbao
+    namespace: {{ .Namespace }}
+---
+apiVersion: vault.banzaicloud.com/v1alpha1
+kind: Vault
+metadata:
+  name: openbao
+  namespace: {{ .Namespace }}
+spec:
+  size: {{ .Replicas }}
+  image: {{ .OpenBaoImage }}
+  bankVaultsImage: {{ .BankVaultsImage }}
+  serviceAccount: openbao
+  {{- if gt .Replicas 1 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: openbao-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+  volumeMounts:
+    - name: openbao-data
+      mountPath: /openbao/data
+  {{- end }}
+  vaultContainerSpec:
+    name: vault
+    command:
+      - bao
+      - server
+      - -config=/vault/config
+    # Override the operator's default liveness probe to accept 501 (uninitialized)
+    # and 503 (sealed) responses as healthy. Without this, Kubernetes kills vault
+    # after 3 failures (~30s) before bank-vaults can complete initialization,
+    # causing a crash loop where stale keys accumulate in the secret.
+    livenessProbe:
+      httpGet:
+        path: /v1/sys/health?standbyok=true&uninitcode=204&sealedcode=204
+        port: 8200
+        scheme: HTTP
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      failureThreshold: 30
+    {{- if gt .Replicas 1 }}
+    env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: BAO_CLUSTER_ADDR
+        value: "https://$(POD_NAME).openbao.{{ .Namespace }}.svc.cluster.local:8201"
+    {{- end }}
+  unsealConfig:
+    options:
+      preFlightChecks: false
+      storeRootToken: true
+    kubernetes:
+      secretNamespace: {{ .Namespace }}
+      secretName: openbao-unseal-keys
+  config:
+    ui: true
+    storage:
+      {{- if gt .Replicas 1 }}
+      raft:
+        path: /openbao/data
+        {{- if .RetryJoinAddrs }}
+        retry_join:
+          {{- range .RetryJoinAddrs }}
+          - leader_api_addr: "{{ . }}"
+          {{- end }}
+        {{- end }}
+      {{- else }}
+      file:
+        path: /openbao/file
+      {{- end }}
+    listener:
+      tcp:
+        address: "0.0.0.0:8200"
+        tls_disable: true
+    api_addr: http://openbao.{{ .Namespace }}:8200
+  externalConfig:
+    secrets:
+      - path: {{ .SecretsEngineName }}
+        type: kv
+        options:
+          version: "2"
+    policies:
+      - name: {{ .SecretsEngineName }}-rw
+        rules: |
+          path "{{ .SecretsEngineName }}/data/*" {
+            capabilities = ["create", "read", "update", "delete", "list"]
+          }
+          path "{{ .SecretsEngineName }}/metadata/*" {
+            capabilities = ["list", "read", "delete"]
+          }
+    auth:
+      - type: userpass
+        users:
+          - username: {{ .BaoUsername }}
+            password: {{ .BaoPassword }}
+            policies: {{ .SecretsEngineName }}-rw

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -135,10 +135,11 @@ func (o *OpenBaoInstaller) Install(ctx context.Context) error {
 		return fmt.Errorf("failed to deploy Bank-Vaults Operator: %w", err)
 	}
 
-	// Clean up stale unseal keys after the namespace exists but before the
-	// Vault CR triggers pods. We must wait for any existing vault pods to
-	// terminate first; otherwise the old bank-vaults sidecar's retry loop
-	// will re-create the secret after we delete it (race condition).
+	// If a previous install left behind an unseal-keys Secret (e.g. Raft storage
+	// was wiped or the cluster was rebuilt), those keys belong to the old master
+	// key and will cause bank-vaults to permanently fail unsealing the new instance.
+	// We delete the Vault CR first and wait for pods to exit, otherwise the old
+	// sidecar's retry loop re-creates the secret after we remove it.
 	if !o.drBackupExists {
 		err = o.Logger.Step("Removing stale unseal keys", o.DeleteStaleUnsealKeys)
 		if err != nil {
@@ -185,19 +186,16 @@ func (o *OpenBaoInstaller) PreFlightDRCheck() error {
 
 	o.Logger.Logf("Found existing DR backup at %s — restoring unseal keys", o.Config.DRBackupPath)
 
-	// Decrypt using sops
 	decrypted, err := DecryptFileWithSOPS(o.Config.DRBackupPath, o.Config.AgeKeyPath)
 	if err != nil {
 		return err
 	}
 
-	// Parse the decrypted JSON to extract unseal keys
 	var backup drBackup
 	if err := json.Unmarshal(decrypted, &backup); err != nil {
 		return fmt.Errorf("parsing DR backup: %w", err)
 	}
 
-	// Reconstruct the K8s Secret from the backup
 	secretData := make(map[string][]byte)
 	for k, v := range backup.UnsealKeys {
 		secretData[k] = []byte(v)
@@ -211,12 +209,10 @@ func (o *OpenBaoInstaller) PreFlightDRCheck() error {
 		Data: secretData,
 	}
 
-	// Ensure namespace exists
 	if err := o.ensureNamespace(o.ctx); err != nil {
 		return err
 	}
 
-	// Create or update the Secret
 	secretsClient := o.Clientset.CoreV1().Secrets(openBaoNamespace)
 	existing, err := secretsClient.Get(o.ctx, openBaoUnsealSecretName, metav1.GetOptions{})
 	if err != nil {
@@ -364,7 +360,6 @@ func (o *OpenBaoInstaller) WaitForInitialization() error {
 // ExtractAndEncrypt reads the unseal keys Secret, combines it with the generated
 // password, and creates a SOPS-encrypted backup file.
 func (o *OpenBaoInstaller) ExtractAndEncrypt() error {
-	// Build the DR backup payload
 	backup := drBackup{
 		UnsealKeys: make(map[string]string),
 		Password:   o.password,
@@ -376,13 +371,11 @@ func (o *OpenBaoInstaller) ExtractAndEncrypt() error {
 		backup.UnsealKeys[key] = string(val)
 	}
 
-	// Marshal to JSON
 	plaintext, err := json.MarshalIndent(backup, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling DR backup: %w", err)
 	}
 
-	// Ensure the output directory exists
 	dir := filepath.Dir(o.Config.DRBackupPath)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating DR backup directory: %w", err)
@@ -409,7 +402,6 @@ func (o *OpenBaoInstaller) ExtractAndEncrypt() error {
 		return fmt.Errorf("closing temp backup file: %w", err)
 	}
 
-	// Encrypt using sops + age
 	if err := EncryptFileWithSOPS(tmpPath, o.Config.DRBackupPath, o.Config.AgeRecipient); err != nil {
 		return fmt.Errorf("encrypting DR backup: %w", err)
 	}
@@ -418,16 +410,18 @@ func (o *OpenBaoInstaller) ExtractAndEncrypt() error {
 	return nil
 }
 
-// DeleteStaleUnsealKeys safely removes the openbao-unseal-keys Secret so that
-// bank-vaults can perform a clean initialization on the next pod start.
+// DeleteStaleUnsealKeys removes unseal keys left by a prior installation whose
+// Raft storage no longer exists (e.g. cluster rebuild, PVC deletion). Without
+// removal, bank-vaults would attempt to unseal with the old master key's shares
+// and fail permanently — the new instance needs to run a fresh init.
 //
-// The method first deletes the Vault CR (which terminates all vault pods) and
-// waits for every pod to exit, preventing the race where the old bank-vaults
-// sidecar recreates the secret after the installer deletes it.
+// To prevent the old bank-vaults sidecar from re-creating the secret via its
+// retry loop, the Vault CR is deleted first and we wait for all pods to exit
+// before removing the secret.
 func (o *OpenBaoInstaller) DeleteStaleUnsealKeys() error {
 	vaultGVR := k8s.VaultGVR()
 
-	// Attempt to delete the Vault CR. Not an error if it doesn't exist yet.
+	// Tolerates NotFound — this may be a first-time install with no prior Vault CR.
 	delErr := o.DynClient.Resource(vaultGVR).Namespace(openBaoNamespace).Delete(
 		o.ctx, "openbao", metav1.DeleteOptions{},
 	)
@@ -435,7 +429,6 @@ func (o *OpenBaoInstaller) DeleteStaleUnsealKeys() error {
 		return fmt.Errorf("deleting Vault CR: %w", delErr)
 	}
 
-	// Wait for all vault pods (labelled vault_cr=openbao) to terminate.
 	if err := o.waitForVaultPodsGone(); err != nil {
 		return err
 	}
@@ -540,17 +533,17 @@ func GenerateSecurePassword(length int) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
-// SetCtx sets the context for testing purposes.
+// SetCtx is a test helper.
 func (o *OpenBaoInstaller) SetCtx(ctx context.Context) {
 	o.ctx = ctx
 }
 
-// SetUnsealSecret sets the unseal secret for testing purposes.
+// SetUnsealSecret is a test helper.
 func (o *OpenBaoInstaller) SetUnsealSecret(secret *corev1.Secret) {
 	o.unsealSecret = secret
 }
 
-// SetPassword sets the password for testing purposes.
+// SetPassword is a test helper.
 func (o *OpenBaoInstaller) SetPassword(password string) {
 	o.password = password
 }

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -233,6 +233,9 @@ func (o *OpenBaoInstaller) PreFlightDRCheck() error {
 
 	// Reuse the password and username from the DR backup so the Vault CR is
 	// rendered with the same credentials that OpenBao already has configured.
+	if o.Config.Username != backup.Username {
+		log.Printf("Warning: --bao-user=%q differs from DR backup username %q — using backup value", o.Config.Username, backup.Username)
+	}
 	o.password = backup.Password
 	o.Config.Username = backup.Username
 

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -1,0 +1,580 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package installer
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	_ "embed"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"text/template"
+	"time"
+
+	"github.com/codesphere-cloud/oms/internal/bootstrap"
+	k8s "github.com/codesphere-cloud/oms/internal/util"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+//go:embed manifests/openbao/vault-cr.yaml
+var vaultCRTemplate []byte
+
+const (
+	openBaoUnsealSecretName = "openbao-unseal-keys"
+	openBaoNamespace        = "vault"
+	openBaoImage            = "quay.io/openbao/openbao:2.1.0"
+	bankVaultsImage         = "ghcr.io/bank-vaults/bank-vaults:v1.31.3"
+	bankVaultsChartRepo     = "oci://ghcr.io/bank-vaults/helm-charts"
+	bankVaultsChartName     = "vault-operator"
+	bankVaultsChartVersion  = "1.22.5"
+	defaultPasswordLength   = 32
+	pollInterval            = 5 * time.Second
+	maxPollInterval         = 30 * time.Second
+)
+
+// OpenBaoInstallerConfig holds all configurable parameters for the OpenBao bootstrap.
+type OpenBaoInstallerConfig struct {
+	SecretsEngineName string
+	Username          string
+	DRBackupPath      string
+	Replicas          int
+	Timeout           time.Duration
+	AgeRecipient      string
+	AgeKeyPath        string
+}
+
+// OpenBaoInstaller orchestrates the Day-0 bootstrap, configuration, and DR
+// workflow for OpenBao using the Bank-Vaults Operator.
+type OpenBaoInstaller struct {
+	Helm      HelmClient
+	Clientset kubernetes.Interface
+	DynClient dynamic.Interface
+	Logger    *bootstrap.StepLogger
+	Config    OpenBaoInstallerConfig
+
+	// Intermediate state populated during the install pipeline
+	ctx           context.Context
+	password      string
+	drBackupExists bool
+	unsealSecret  *corev1.Secret
+}
+
+// NewOpenBaoInstaller constructs an OpenBaoInstaller with real Kubernetes and Helm clients.
+func NewOpenBaoInstaller(cfg OpenBaoInstallerConfig) (*OpenBaoInstaller, error) {
+	helm, err := NewHelmClient(openBaoNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("creating helm client: %w", err)
+	}
+
+	clientset, dynClient, err := k8s.NewClients()
+	if err != nil {
+		return nil, fmt.Errorf("creating kubernetes clients: %w", err)
+	}
+
+	return &OpenBaoInstaller{
+		Helm:      helm,
+		Clientset: clientset,
+		DynClient: dynClient,
+		Logger:    bootstrap.NewStepLogger(false),
+		Config:    cfg,
+	}, nil
+}
+
+func (o *OpenBaoInstaller) validateConfig() error {
+	r := o.Config.Replicas
+	if r < 1 {
+		return fmt.Errorf("--replicas must be >= 1, got %d", r)
+	}
+	if r == 2 {
+		return fmt.Errorf("--replicas=2 is invalid: Raft requires 1 (single-node) or an odd number >= 3 for HA")
+	}
+	return nil
+}
+
+// Install is the top-level orchestrator for the full OpenBao bootstrap pipeline.
+// It is idempotent — safe to re-run at any point.
+func (o *OpenBaoInstaller) Install(ctx context.Context) error {
+	if err := o.validateConfig(); err != nil {
+		return err
+	}
+
+	o.ctx = ctx
+
+	err := o.Logger.Step("Pre-flight DR check", o.PreFlightDRCheck)
+	if err != nil {
+		return fmt.Errorf("pre-flight DR check failed: %w", err)
+	}
+
+	err = o.Logger.Step("Generating secure password", o.GeneratePassword)
+	if err != nil {
+		return fmt.Errorf("failed to generate secure password: %w", err)
+	}
+
+	err = o.Logger.Step("Deploying Bank-Vaults Operator", o.DeployBankVaultsOperator)
+	if err != nil {
+		return fmt.Errorf("failed to deploy Bank-Vaults Operator: %w", err)
+	}
+
+	// Clean up stale unseal keys after the namespace exists but before the
+	// Vault CR triggers pods. We must wait for any existing vault pods to
+	// terminate first; otherwise the old bank-vaults sidecar's retry loop
+	// will re-create the secret after we delete it (race condition).
+	if !o.drBackupExists {
+		err = o.Logger.Step("Removing stale unseal keys", o.DeleteStaleUnsealKeys)
+		if err != nil {
+			return fmt.Errorf("failed to remove stale unseal keys: %w", err)
+		}
+	}
+
+	err = o.Logger.Step("Applying Vault CR (OpenBao desired state)", o.ApplyVaultCR)
+	if err != nil {
+		return fmt.Errorf("failed to apply Vault CR: %w", err)
+	}
+
+	err = o.Logger.Step("Waiting for initialization", o.WaitForInitialization)
+	if err != nil {
+		return fmt.Errorf("failed waiting for initialization: %w", err)
+	}
+
+	err = o.Logger.Step("Extracting and encrypting DR backup", o.ExtractAndEncrypt)
+	if err != nil {
+		return fmt.Errorf("failed to extract and encrypt DR backup: %w", err)
+	}
+
+	err = o.Logger.Step("Security cleanup (removing root token from cluster)", o.SecurityCleanup)
+	if err != nil {
+		return fmt.Errorf("failed to clean up root token: %w", err)
+	}
+
+	log.Printf("OpenBao bootstrap complete. DR backup saved to: %s", o.Config.DRBackupPath)
+	return nil
+}
+
+// PreFlightDRCheck checks if a SOPS-encrypted DR backup exists.
+// If it does, the backup is decrypted and the unseal keys Secret is pre-applied
+// so that Bank-Vaults can unseal an existing OpenBao instance.
+// Sets o.drBackupExists to true if a DR backup was found and restored.
+func (o *OpenBaoInstaller) PreFlightDRCheck() error {
+	if o.Config.DRBackupPath == "" {
+		return fmt.Errorf("--dr-backup-path is required")
+	}
+
+	if _, err := os.Stat(o.Config.DRBackupPath); os.IsNotExist(err) {
+		log.Println("No existing DR backup found — proceeding with fresh initialization")
+		o.drBackupExists = false
+		return nil
+	}
+
+	log.Printf("Found existing DR backup at %s — restoring unseal keys", o.Config.DRBackupPath)
+
+	// Decrypt using sops
+	decrypted, err := DecryptFileWithSOPS(o.Config.DRBackupPath, o.Config.AgeKeyPath)
+	if err != nil {
+		return err
+	}
+
+	// Parse the decrypted JSON to extract unseal keys
+	var backup drBackup
+	if err := json.Unmarshal(decrypted, &backup); err != nil {
+		return fmt.Errorf("parsing DR backup: %w", err)
+	}
+
+	// Reconstruct the K8s Secret from the backup
+	secretData := make(map[string][]byte)
+	for k, v := range backup.UnsealKeys {
+		secretData[k] = []byte(v)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      openBaoUnsealSecretName,
+			Namespace: openBaoNamespace,
+		},
+		Data: secretData,
+	}
+
+	// Ensure namespace exists
+	if err := o.ensureNamespace(o.ctx); err != nil {
+		return err
+	}
+
+	// Create or update the Secret
+	secretsClient := o.Clientset.CoreV1().Secrets(openBaoNamespace)
+	existing, err := secretsClient.Get(o.ctx, openBaoUnsealSecretName, metav1.GetOptions{})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("checking for existing secret: %w", err)
+		}
+		_, err = secretsClient.Create(o.ctx, secret, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("creating unseal secret from DR backup: %w", err)
+		}
+	} else {
+		secret.ResourceVersion = existing.ResourceVersion
+		_, err = secretsClient.Update(o.ctx, secret, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("updating unseal secret from DR backup: %w", err)
+		}
+	}
+
+	log.Println("Unseal keys restored from DR backup successfully")
+	o.drBackupExists = true
+	return nil
+}
+
+// GeneratePassword generates a secure password and stores it on the installer.
+func (o *OpenBaoInstaller) GeneratePassword() error {
+	var err error
+	o.password, err = GenerateSecurePassword(defaultPasswordLength)
+	return err
+}
+
+// DeployBankVaultsOperator installs or upgrades the Bank-Vaults Operator Helm chart.
+// This is idempotent via UpgradeChart with InstallIfNotExist.
+func (o *OpenBaoInstaller) DeployBankVaultsOperator() error {
+	cfg := ChartConfig{
+		ReleaseName:     "vault-operator",
+		ChartName:       bankVaultsChartRepo + "/" + bankVaultsChartName,
+		Version:         bankVaultsChartVersion,
+		Namespace:       openBaoNamespace,
+		CreateNamespace: true,
+		Values:          map[string]interface{}{},
+	}
+
+	return o.Helm.UpgradeChart(o.ctx, cfg, UpgradeChartOptions{InstallIfNotExist: true})
+}
+
+// vaultCRTemplateData holds the values injected into the Vault CR template.
+type vaultCRTemplateData struct {
+	Namespace         string
+	OpenBaoImage      string
+	BankVaultsImage   string
+	SecretsEngineName string
+	BaoUsername       string
+	BaoPassword       string
+	Replicas          int
+	RetryJoinAddrs    []string
+}
+
+// ApplyVaultCR renders the Bank-Vaults Vault CR template and applies it to the cluster.
+func (o *OpenBaoInstaller) ApplyVaultCR() error {
+	tmpl, err := template.New("vault-cr").Parse(string(vaultCRTemplate))
+	if err != nil {
+		return fmt.Errorf("parsing vault CR template: %w", err)
+	}
+
+	// Build retry_join addresses for Raft HA so each node can autonomously
+	// find and join the cluster leader, preventing pods from getting stuck
+	// in an uninitialized state due to sidecar timing races.
+	var retryJoinAddrs []string
+	if o.Config.Replicas > 1 {
+		for i := 0; i < o.Config.Replicas; i++ {
+			addr := fmt.Sprintf("http://openbao-%d.openbao.%s.svc.cluster.local:8200", i, openBaoNamespace)
+			retryJoinAddrs = append(retryJoinAddrs, addr)
+		}
+	}
+
+	data := vaultCRTemplateData{
+		Namespace:         openBaoNamespace,
+		OpenBaoImage:      openBaoImage,
+		BankVaultsImage:   bankVaultsImage,
+		SecretsEngineName: o.Config.SecretsEngineName,
+		BaoUsername:       o.Config.Username,
+		BaoPassword:       o.password,
+		Replicas:          o.Config.Replicas,
+		RetryJoinAddrs:    retryJoinAddrs,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("rendering vault CR template: %w", err)
+	}
+
+	objects, err := k8s.DecodeMultiDocYAML(buf.Bytes())
+	if err != nil {
+		return fmt.Errorf("decoding vault CR: %w", err)
+	}
+
+	for _, obj := range objects {
+		gvr, err := k8s.GvrForUnstructured(obj)
+		if err != nil {
+			return fmt.Errorf("resolving GVR for %s: %w", obj.GetKind(), err)
+		}
+		if err := k8s.ApplyUnstructured(o.ctx, o.DynClient, gvr, obj); err != nil {
+			return fmt.Errorf("applying vault CR: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// WaitForInitialization polls the openbao-unseal-keys Secret until it contains
+// unseal key data, indicating that Bank-Vaults has completed initialization.
+func (o *OpenBaoInstaller) WaitForInitialization() error {
+	deadline := time.Now().Add(o.Config.Timeout)
+	interval := pollInterval
+
+	secretsClient := o.Clientset.CoreV1().Secrets(openBaoNamespace)
+
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for openbao-unseal-keys to be populated (timeout: %s)", o.Config.Timeout)
+		}
+
+		secret, err := secretsClient.Get(o.ctx, openBaoUnsealSecretName, metav1.GetOptions{})
+		if err != nil {
+			if !k8serrors.IsNotFound(err) {
+				return fmt.Errorf("fetching unseal secret: %w", err)
+			}
+			// Secret doesn't exist yet — keep polling
+			o.Logger.LogRetry()
+			time.Sleep(interval)
+			interval = minDuration(interval*2, maxPollInterval)
+			continue
+		}
+
+		// Check if the secret has meaningful data (at least one unseal key)
+		if len(secret.Data) > 0 {
+			hasUnsealKey := false
+			for key := range secret.Data {
+				if key == "vault-unseal-0" || key == "vault-unseal-key-0" || key == "unseal-key-0" {
+					hasUnsealKey = true
+					break
+				}
+			}
+			// Also accept if root_token is present (indicates init is done)
+			if _, hasRoot := secret.Data["root_token"]; hasRoot {
+				hasUnsealKey = true
+			}
+			if hasUnsealKey {
+				o.unsealSecret = secret
+				return nil
+			}
+		}
+
+		o.Logger.LogRetry()
+		time.Sleep(interval)
+		interval = minDuration(interval*2, maxPollInterval)
+	}
+}
+
+// ExtractAndEncrypt reads the unseal keys Secret, combines it with the generated
+// password, and creates a SOPS-encrypted backup file.
+func (o *OpenBaoInstaller) ExtractAndEncrypt() error {
+	// Build the DR backup payload
+	backup := drBackup{
+		UnsealKeys: make(map[string]string),
+		Password:   o.password,
+		Username:   o.Config.Username,
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+	}
+
+	for key, val := range o.unsealSecret.Data {
+		backup.UnsealKeys[key] = string(val)
+	}
+
+	// Marshal to JSON
+	plaintext, err := json.MarshalIndent(backup, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling DR backup: %w", err)
+	}
+
+	// Ensure the output directory exists
+	dir := filepath.Dir(o.Config.DRBackupPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating DR backup directory: %w", err)
+	}
+
+	// Write plaintext to a temp file (sops encrypts in-place)
+	tmpFile := o.Config.DRBackupPath + ".tmp.json"
+	if err := os.WriteFile(tmpFile, plaintext, 0o600); err != nil {
+		return fmt.Errorf("writing temp backup file: %w", err)
+	}
+	defer func() { _ = os.Remove(tmpFile) }() // clean up temp file on failure
+
+	// Encrypt using sops + age
+	if err := EncryptFileWithSOPS(tmpFile, o.Config.DRBackupPath, o.Config.AgeRecipient); err != nil {
+		return fmt.Errorf("encrypting DR backup: %w", err)
+	}
+
+	// Remove temp file on success
+	_ = os.Remove(tmpFile)
+
+	log.Printf("DR backup encrypted and saved to: %s", o.Config.DRBackupPath)
+	return nil
+}
+
+// SecurityCleanup removes the root_token key from the openbao-unseal-keys Secret.
+// This ensures that even if the cluster is compromised, root access is not available.
+// Only unseal keys remain for Bank-Vaults to handle pod restart unsealing.
+func (o *OpenBaoInstaller) SecurityCleanup() error {
+	secretsClient := o.Clientset.CoreV1().Secrets(openBaoNamespace)
+
+	secret, err := secretsClient.Get(o.ctx, openBaoUnsealSecretName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("fetching unseal secret for cleanup: %w", err)
+	}
+
+	if _, hasRoot := secret.Data["root_token"]; !hasRoot {
+		log.Println("root_token already absent from unseal secret — no cleanup needed")
+		return nil
+	}
+
+	delete(secret.Data, "root_token")
+
+	_, err = secretsClient.Update(o.ctx, secret, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("patching unseal secret to remove root_token: %w", err)
+	}
+
+	log.Println("root_token removed from cluster secret")
+	return nil
+}
+
+// DeleteStaleUnsealKeys safely removes the openbao-unseal-keys Secret so that
+// bank-vaults can perform a clean initialization on the next pod start.
+//
+// The method first deletes the Vault CR (which terminates all vault pods) and
+// waits for every pod to exit, preventing the race where the old bank-vaults
+// sidecar recreates the secret after the installer deletes it.
+func (o *OpenBaoInstaller) DeleteStaleUnsealKeys() error {
+	vaultGVR := k8s.VaultGVR()
+
+	// Attempt to delete the Vault CR. Not an error if it doesn't exist yet.
+	delErr := o.DynClient.Resource(vaultGVR).Namespace(openBaoNamespace).Delete(
+		o.ctx, "openbao", metav1.DeleteOptions{},
+	)
+	if delErr != nil && !k8serrors.IsNotFound(delErr) {
+		return fmt.Errorf("deleting Vault CR: %w", delErr)
+	}
+
+	// Wait for all vault pods (labelled vault_cr=openbao) to terminate.
+	if err := o.waitForVaultPodsGone(); err != nil {
+		return err
+	}
+
+	// Now it is safe to delete the stale secret.
+	delErr = o.Clientset.CoreV1().Secrets(openBaoNamespace).Delete(
+		o.ctx, openBaoUnsealSecretName, metav1.DeleteOptions{},
+	)
+	if delErr != nil && !k8serrors.IsNotFound(delErr) {
+		return fmt.Errorf("deleting stale unseal secret: %w", delErr)
+	}
+
+	log.Println("Stale unseal keys removed (vault CR deleted, pods terminated)")
+	return nil
+}
+
+// waitForVaultPodsGone polls until no pods with label vault_cr=openbao remain
+// in the vault namespace, or until the context deadline is exceeded.
+func (o *OpenBaoInstaller) waitForVaultPodsGone() error {
+	selector := labels.SelectorFromSet(labels.Set{"vault_cr": "openbao"}).String()
+	deadline := time.Now().Add(o.Config.Timeout)
+	interval := pollInterval
+
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for vault pods to terminate (timeout: %s)", o.Config.Timeout)
+		}
+
+		list, err := o.Clientset.CoreV1().Pods(openBaoNamespace).List(o.ctx, metav1.ListOptions{
+			LabelSelector: selector,
+		})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("listing vault pods: %w", err)
+		}
+		if len(list.Items) == 0 {
+			return nil
+		}
+
+		o.Logger.LogRetry()
+		time.Sleep(interval)
+		interval = minDuration(interval*2, maxPollInterval)
+	}
+}
+
+// ensureNamespace creates the target namespace if it doesn't exist.
+func (o *OpenBaoInstaller) ensureNamespace(ctx context.Context) error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: openBaoNamespace,
+		},
+	}
+
+	_, err := o.Clientset.CoreV1().Namespaces().Get(ctx, openBaoNamespace, metav1.GetOptions{})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("checking namespace %s: %w", openBaoNamespace, err)
+		}
+		_, err = o.Clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+		if err != nil && !k8serrors.IsAlreadyExists(err) {
+			return fmt.Errorf("creating namespace %s: %w", openBaoNamespace, err)
+		}
+	}
+	return nil
+}
+
+// drBackup represents the structure of the SOPS-encrypted DR backup file.
+type drBackup struct {
+	UnsealKeys map[string]string `json:"unseal_keys"`
+	Password   string            `json:"password"`
+	Username   string            `json:"username"`
+	Timestamp  string            `json:"timestamp"`
+}
+
+// GenerateSecurePassword generates a cryptographically secure random password
+// of the specified byte length, returned as base64url-encoded string.
+func GenerateSecurePassword(length int) (string, error) {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating random bytes: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// SetCtx sets the context for testing purposes.
+func (o *OpenBaoInstaller) SetCtx(ctx context.Context) {
+	o.ctx = ctx
+}
+
+// SetUnsealSecret sets the unseal secret for testing purposes.
+func (o *OpenBaoInstaller) SetUnsealSecret(secret *corev1.Secret) {
+	o.unsealSecret = secret
+}
+
+// SetPassword sets the password for testing purposes.
+func (o *OpenBaoInstaller) SetPassword(password string) {
+	o.password = password
+}
+
+// GetDRBackupExists returns whether a DR backup was found during pre-flight check.
+func (o *OpenBaoInstaller) GetDRBackupExists() bool {
+	return o.drBackupExists
+}
+
+// GetUnsealSecret returns the unseal secret populated during initialization.
+func (o *OpenBaoInstaller) GetUnsealSecret() *corev1.Secret {
+	return o.unsealSecret
+}
+
+// minDuration returns the smaller of two durations.
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -91,6 +91,8 @@ func NewOpenBaoInstaller(cfg OpenBaoInstallerConfig) (*OpenBaoInstaller, error) 
 	}, nil
 }
 
+const defaultTimeout = 5 * time.Minute
+
 func (o *OpenBaoInstaller) validateConfig() error {
 	r := o.Config.Replicas
 	if r < 1 {
@@ -98,6 +100,9 @@ func (o *OpenBaoInstaller) validateConfig() error {
 	}
 	if r > 1 && r%2 == 0 {
 		return fmt.Errorf("--replicas=%d is invalid: Raft requires 1 (single-node) or an odd number >= 3 for HA", r)
+	}
+	if o.Config.Timeout <= 0 {
+		o.Config.Timeout = defaultTimeout
 	}
 	return nil
 }

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -167,7 +167,7 @@ func (o *OpenBaoInstaller) Install(ctx context.Context) error {
 // Sets o.drBackupExists to true if a DR backup was found and restored.
 func (o *OpenBaoInstaller) PreFlightDRCheck() error {
 	if o.Config.DRBackupPath == "" {
-		return fmt.Errorf("--dr-backup-path is required")
+		return fmt.Errorf("DRBackupPath must be set")
 	}
 
 	if _, err := os.Stat(o.Config.DRBackupPath); err != nil {
@@ -231,9 +231,10 @@ func (o *OpenBaoInstaller) PreFlightDRCheck() error {
 		}
 	}
 
-	// Reuse the password from the DR backup so the Vault CR is rendered with
-	// the same credential that OpenBao already has configured.
+	// Reuse the password and username from the DR backup so the Vault CR is
+	// rendered with the same credentials that OpenBao already has configured.
 	o.password = backup.Password
+	o.Config.Username = backup.Username
 
 	log.Println("Unseal keys restored from DR backup successfully")
 	o.drBackupExists = true
@@ -282,15 +283,14 @@ func (o *OpenBaoInstaller) ApplyVaultCR() error {
 		return fmt.Errorf("parsing vault CR template: %w", err)
 	}
 
-	// Build retry_join addresses for Raft HA so each node can autonomously
-	// find and join the cluster leader, preventing pods from getting stuck
-	// in an uninitialized state due to sidecar timing races.
+	// Build retry_join addresses for Raft so each node can autonomously
+	// find and join the cluster leader. For a single replica this produces
+	// one self-referencing address, which is harmless and means scaling up
+	// later only requires changing the replica count.
 	var retryJoinAddrs []string
-	if o.Config.Replicas > 1 {
-		for i := 0; i < o.Config.Replicas; i++ {
-			addr := fmt.Sprintf("http://openbao-%d.%s.svc.cluster.local:8200", i, openBaoNamespace)
-			retryJoinAddrs = append(retryJoinAddrs, addr)
-		}
+	for i := 0; i < o.Config.Replicas; i++ {
+		addr := fmt.Sprintf("http://openbao-%d.%s.svc.cluster.local:8200", i, openBaoNamespace)
+		retryJoinAddrs = append(retryJoinAddrs, addr)
 	}
 
 	data := vaultCRTemplateData{

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -11,7 +11,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -157,7 +156,7 @@ func (o *OpenBaoInstaller) Install(ctx context.Context) error {
 		return fmt.Errorf("failed to extract and encrypt DR backup: %w", err)
 	}
 
-	log.Printf("OpenBao bootstrap complete. DR backup saved to: %s", o.Config.DRBackupPath)
+	o.Logger.Logf("OpenBao bootstrap complete. DR backup saved to: %s", o.Config.DRBackupPath)
 	return nil
 }
 
@@ -172,14 +171,14 @@ func (o *OpenBaoInstaller) PreFlightDRCheck() error {
 
 	if _, err := os.Stat(o.Config.DRBackupPath); err != nil {
 		if os.IsNotExist(err) {
-			log.Println("No existing DR backup found — proceeding with fresh initialization")
+			o.Logger.Logf("No existing DR backup found — proceeding with fresh initialization")
 			o.drBackupExists = false
 			return nil
 		}
 		return fmt.Errorf("checking DR backup file %s: %w", o.Config.DRBackupPath, err)
 	}
 
-	log.Printf("Found existing DR backup at %s — restoring unseal keys", o.Config.DRBackupPath)
+	o.Logger.Logf("Found existing DR backup at %s — restoring unseal keys", o.Config.DRBackupPath)
 
 	// Decrypt using sops
 	decrypted, err := DecryptFileWithSOPS(o.Config.DRBackupPath, o.Config.AgeKeyPath)
@@ -234,12 +233,12 @@ func (o *OpenBaoInstaller) PreFlightDRCheck() error {
 	// Reuse the password and username from the DR backup so the Vault CR is
 	// rendered with the same credentials that OpenBao already has configured.
 	if o.Config.Username != backup.Username {
-		log.Printf("Warning: --bao-user=%q differs from DR backup username %q — using backup value", o.Config.Username, backup.Username)
+		o.Logger.Logf("Warning: --bao-user=%q differs from DR backup username %q — using backup value", o.Config.Username, backup.Username)
 	}
 	o.password = backup.Password
 	o.Config.Username = backup.Username
 
-	log.Println("Unseal keys restored from DR backup successfully")
+	o.Logger.Logf("Unseal keys restored from DR backup successfully")
 	o.drBackupExists = true
 	return nil
 }
@@ -334,30 +333,15 @@ func (o *OpenBaoInstaller) ApplyVaultCR() error {
 // WaitForInitialization polls the openbao-unseal-keys Secret until it contains
 // unseal key data, indicating that Bank-Vaults has completed initialization.
 func (o *OpenBaoInstaller) WaitForInitialization() error {
-	deadline := time.Now().Add(o.Config.Timeout)
-	interval := pollInterval
-
 	secretsClient := o.Clientset.CoreV1().Secrets(openBaoNamespace)
 
-	for {
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timed out waiting for openbao-unseal-keys to be populated (timeout: %s)", o.Config.Timeout)
-		}
-
+	return o.pollUntil("waiting for openbao-unseal-keys to be populated", func() (bool, error) {
 		secret, err := secretsClient.Get(o.ctx, openBaoUnsealSecretName, metav1.GetOptions{})
 		if err != nil {
-			if !k8serrors.IsNotFound(err) {
-				return fmt.Errorf("fetching unseal secret: %w", err)
+			if k8serrors.IsNotFound(err) {
+				return false, nil // Secret doesn't exist yet — keep polling
 			}
-			// Secret doesn't exist yet — keep polling
-			o.Logger.LogRetry()
-			select {
-			case <-o.ctx.Done():
-				return o.ctx.Err()
-			case <-time.After(interval):
-			}
-			interval = minDuration(interval*2, maxPollInterval)
-			continue
+			return false, fmt.Errorf("fetching unseal secret: %w", err)
 		}
 
 		// Check if the secret has meaningful data: at least one key must be
@@ -366,17 +350,10 @@ func (o *OpenBaoInstaller) WaitForInitialization() error {
 		// during Init(), so any data means init is done.
 		if len(secret.Data) > 0 {
 			o.unsealSecret = secret
-			return nil
+			return true, nil
 		}
-
-		o.Logger.LogRetry()
-		select {
-		case <-o.ctx.Done():
-			return o.ctx.Err()
-		case <-time.After(interval):
-		}
-		interval = minDuration(interval*2, maxPollInterval)
-	}
+		return false, nil
+	})
 }
 
 // ExtractAndEncrypt reads the unseal keys Secret, combines it with the generated
@@ -432,10 +409,7 @@ func (o *OpenBaoInstaller) ExtractAndEncrypt() error {
 		return fmt.Errorf("encrypting DR backup: %w", err)
 	}
 
-	// Remove temp file on success (deferred remove handles failure/panic)
-	_ = os.Remove(tmpPath)
-
-	log.Printf("DR backup encrypted and saved to: %s", o.Config.DRBackupPath)
+	o.Logger.Logf("DR backup encrypted and saved to: %s", o.Config.DRBackupPath)
 	return nil
 }
 
@@ -469,7 +443,7 @@ func (o *OpenBaoInstaller) DeleteStaleUnsealKeys() error {
 		return fmt.Errorf("deleting stale unseal secret: %w", delErr)
 	}
 
-	log.Println("Stale unseal keys removed (vault CR deleted, pods terminated)")
+	o.Logger.Logf("Stale unseal keys removed (vault CR deleted, pods terminated)")
 	return nil
 }
 
@@ -477,24 +451,38 @@ func (o *OpenBaoInstaller) DeleteStaleUnsealKeys() error {
 // in the vault namespace, or until the context deadline is exceeded.
 func (o *OpenBaoInstaller) waitForVaultPodsGone() error {
 	selector := labels.SelectorFromSet(labels.Set{"vault_cr": "openbao"}).String()
-	deadline := time.Now().Add(o.Config.Timeout)
-	interval := pollInterval
 
-	for {
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timed out waiting for vault pods to terminate (timeout: %s)", o.Config.Timeout)
-		}
-
+	return o.pollUntil("waiting for vault pods to terminate", func() (bool, error) {
 		list, err := o.Clientset.CoreV1().Pods(openBaoNamespace).List(o.ctx, metav1.ListOptions{
 			LabelSelector: selector,
 		})
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
-				return nil
+				return true, nil
 			}
-			return fmt.Errorf("listing vault pods: %w", err)
+			return false, fmt.Errorf("listing vault pods: %w", err)
 		}
-		if len(list.Items) == 0 {
+		return len(list.Items) == 0, nil
+	})
+}
+
+// pollUntil runs check in a loop with exponential backoff until it returns
+// true or the configured timeout expires. timeoutMsg describes the operation
+// for the timeout error message.
+func (o *OpenBaoInstaller) pollUntil(timeoutMsg string, check func() (bool, error)) error {
+	deadline := time.Now().Add(o.Config.Timeout)
+	interval := pollInterval
+
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out %s (timeout: %s)", timeoutMsg, o.Config.Timeout)
+		}
+
+		done, err := check()
+		if err != nil {
+			return err
+		}
+		if done {
 			return nil
 		}
 
@@ -504,7 +492,7 @@ func (o *OpenBaoInstaller) waitForVaultPodsGone() error {
 			return o.ctx.Err()
 		case <-time.After(interval):
 		}
-		interval = minDuration(interval*2, maxPollInterval)
+		interval = min(interval*2, maxPollInterval)
 	}
 }
 
@@ -572,10 +560,3 @@ func (o *OpenBaoInstaller) GetUnsealSecret() *corev1.Secret {
 	return o.unsealSecret
 }
 
-// minDuration returns the smaller of two durations.
-func minDuration(a, b time.Duration) time.Duration {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -359,22 +359,17 @@ func (o *OpenBaoInstaller) WaitForInitialization() error {
 			continue
 		}
 
-		// Check if the secret has meaningful data (at least one unseal key)
+		// Check if the secret has meaningful data: at least one unseal key
+		// must be present. We do NOT accept root_token alone because
+		// bank-vaults could theoretically write root_token before the
+		// unseal keys in a partial update, and a DR backup without unseal
+		// keys would be useless.
 		if len(secret.Data) > 0 {
-			hasUnsealKey := false
 			for key := range secret.Data {
 				if key == "vault-unseal-0" || key == "vault-unseal-key-0" || key == "unseal-key-0" {
-					hasUnsealKey = true
-					break
+					o.unsealSecret = secret
+					return nil
 				}
-			}
-			// Also accept if root_token is present (indicates init is done)
-			if _, hasRoot := secret.Data["root_token"]; hasRoot {
-				hasUnsealKey = true
-			}
-			if hasUnsealKey {
-				o.unsealSecret = secret
-				return nil
 			}
 		}
 

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -116,9 +116,13 @@ func (o *OpenBaoInstaller) Install(ctx context.Context) error {
 		return fmt.Errorf("pre-flight DR check failed: %w", err)
 	}
 
-	err = o.Logger.Step("Generating secure password", o.GeneratePassword)
-	if err != nil {
-		return fmt.Errorf("failed to generate secure password: %w", err)
+	// Only generate a new password for fresh installs; on DR restore the
+	// password was already extracted from the backup in PreFlightDRCheck.
+	if !o.drBackupExists {
+		err = o.Logger.Step("Generating secure password", o.GeneratePassword)
+		if err != nil {
+			return fmt.Errorf("failed to generate secure password: %w", err)
+		}
 	}
 
 	err = o.Logger.Step("Deploying Bank-Vaults Operator", o.DeployBankVaultsOperator)
@@ -170,10 +174,13 @@ func (o *OpenBaoInstaller) PreFlightDRCheck() error {
 		return fmt.Errorf("--dr-backup-path is required")
 	}
 
-	if _, err := os.Stat(o.Config.DRBackupPath); os.IsNotExist(err) {
-		log.Println("No existing DR backup found — proceeding with fresh initialization")
-		o.drBackupExists = false
-		return nil
+	if _, err := os.Stat(o.Config.DRBackupPath); err != nil {
+		if os.IsNotExist(err) {
+			log.Println("No existing DR backup found — proceeding with fresh initialization")
+			o.drBackupExists = false
+			return nil
+		}
+		return fmt.Errorf("checking DR backup file %s: %w", o.Config.DRBackupPath, err)
 	}
 
 	log.Printf("Found existing DR backup at %s — restoring unseal keys", o.Config.DRBackupPath)
@@ -227,6 +234,10 @@ func (o *OpenBaoInstaller) PreFlightDRCheck() error {
 			return fmt.Errorf("updating unseal secret from DR backup: %w", err)
 		}
 	}
+
+	// Reuse the password from the DR backup so the Vault CR is rendered with
+	// the same credential that OpenBao already has configured.
+	o.password = backup.Password
 
 	log.Println("Unseal keys restored from DR backup successfully")
 	o.drBackupExists = true

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -280,7 +280,7 @@ func (o *OpenBaoInstaller) ApplyVaultCR() error {
 	var retryJoinAddrs []string
 	if o.Config.Replicas > 1 {
 		for i := 0; i < o.Config.Replicas; i++ {
-			addr := fmt.Sprintf("http://openbao-%d.openbao.%s.svc.cluster.local:8200", i, openBaoNamespace)
+			addr := fmt.Sprintf("http://openbao-%d.%s.svc.cluster.local:8200", i, openBaoNamespace)
 			retryJoinAddrs = append(retryJoinAddrs, addr)
 		}
 	}

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -64,10 +64,10 @@ type OpenBaoInstaller struct {
 	Config    OpenBaoInstallerConfig
 
 	// Intermediate state populated during the install pipeline
-	ctx           context.Context
-	password      string
+	ctx            context.Context
+	password       string
 	drBackupExists bool
-	unsealSecret  *corev1.Secret
+	unsealSecret   *corev1.Secret
 }
 
 // NewOpenBaoInstaller constructs an OpenBaoInstaller with real Kubernetes and Helm clients.
@@ -96,8 +96,8 @@ func (o *OpenBaoInstaller) validateConfig() error {
 	if r < 1 {
 		return fmt.Errorf("--replicas must be >= 1, got %d", r)
 	}
-	if r == 2 {
-		return fmt.Errorf("--replicas=2 is invalid: Raft requires 1 (single-node) or an odd number >= 3 for HA")
+	if r > 1 && r%2 == 0 {
+		return fmt.Errorf("--replicas=%d is invalid: Raft requires 1 (single-node) or an odd number >= 3 for HA", r)
 	}
 	return nil
 }
@@ -339,7 +339,11 @@ func (o *OpenBaoInstaller) WaitForInitialization() error {
 			}
 			// Secret doesn't exist yet — keep polling
 			o.Logger.LogRetry()
-			time.Sleep(interval)
+			select {
+			case <-o.ctx.Done():
+				return o.ctx.Err()
+			case <-time.After(interval):
+			}
 			interval = minDuration(interval*2, maxPollInterval)
 			continue
 		}
@@ -364,7 +368,11 @@ func (o *OpenBaoInstaller) WaitForInitialization() error {
 		}
 
 		o.Logger.LogRetry()
-		time.Sleep(interval)
+		select {
+		case <-o.ctx.Done():
+			return o.ctx.Err()
+		case <-time.After(interval):
+		}
 		interval = minDuration(interval*2, maxPollInterval)
 	}
 }
@@ -396,20 +404,34 @@ func (o *OpenBaoInstaller) ExtractAndEncrypt() error {
 		return fmt.Errorf("creating DR backup directory: %w", err)
 	}
 
-	// Write plaintext to a temp file (sops encrypts in-place)
-	tmpFile := o.Config.DRBackupPath + ".tmp.json"
-	if err := os.WriteFile(tmpFile, plaintext, 0o600); err != nil {
+	// Write plaintext to a temp file (sops encrypts in-place).
+	// Use os.CreateTemp to avoid predictable filenames (symlink attacks).
+	tmpFile, err := os.CreateTemp(dir, "openbao-dr-*.json")
+	if err != nil {
+		return fmt.Errorf("creating temp backup file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpPath) }() // clean up temp file on failure or panic
+
+	if err := tmpFile.Chmod(0o600); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("setting temp file permissions: %w", err)
+	}
+	if _, err := tmpFile.Write(plaintext); err != nil {
+		_ = tmpFile.Close()
 		return fmt.Errorf("writing temp backup file: %w", err)
 	}
-	defer func() { _ = os.Remove(tmpFile) }() // clean up temp file on failure
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("closing temp backup file: %w", err)
+	}
 
 	// Encrypt using sops + age
-	if err := EncryptFileWithSOPS(tmpFile, o.Config.DRBackupPath, o.Config.AgeRecipient); err != nil {
+	if err := EncryptFileWithSOPS(tmpPath, o.Config.DRBackupPath, o.Config.AgeRecipient); err != nil {
 		return fmt.Errorf("encrypting DR backup: %w", err)
 	}
 
-	// Remove temp file on success
-	_ = os.Remove(tmpFile)
+	// Remove temp file on success (deferred remove handles failure/panic)
+	_ = os.Remove(tmpPath)
 
 	log.Printf("DR backup encrypted and saved to: %s", o.Config.DRBackupPath)
 	return nil
@@ -502,7 +524,11 @@ func (o *OpenBaoInstaller) waitForVaultPodsGone() error {
 		}
 
 		o.Logger.LogRetry()
-		time.Sleep(interval)
+		select {
+		case <-o.ctx.Done():
+			return o.ctx.Err()
+		case <-time.After(interval):
+		}
 		interval = minDuration(interval*2, maxPollInterval)
 	}
 }

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -49,6 +49,7 @@ type OpenBaoInstallerConfig struct {
 	Username          string
 	DRBackupPath      string
 	Replicas          int
+	StorageSize       string
 	Timeout           time.Duration
 	AgeRecipient      string
 	AgeKeyPath        string
@@ -154,11 +155,6 @@ func (o *OpenBaoInstaller) Install(ctx context.Context) error {
 	err = o.Logger.Step("Extracting and encrypting DR backup", o.ExtractAndEncrypt)
 	if err != nil {
 		return fmt.Errorf("failed to extract and encrypt DR backup: %w", err)
-	}
-
-	err = o.Logger.Step("Security cleanup (removing root token from cluster)", o.SecurityCleanup)
-	if err != nil {
-		return fmt.Errorf("failed to clean up root token: %w", err)
 	}
 
 	log.Printf("OpenBao bootstrap complete. DR backup saved to: %s", o.Config.DRBackupPath)
@@ -275,6 +271,7 @@ type vaultCRTemplateData struct {
 	BaoUsername       string
 	BaoPassword       string
 	Replicas          int
+	StorageSize       string
 	RetryJoinAddrs    []string
 }
 
@@ -304,6 +301,7 @@ func (o *OpenBaoInstaller) ApplyVaultCR() error {
 		BaoUsername:       o.Config.Username,
 		BaoPassword:       o.password,
 		Replicas:          o.Config.Replicas,
+		StorageSize:       o.Config.StorageSize,
 		RetryJoinAddrs:    retryJoinAddrs,
 	}
 
@@ -359,18 +357,13 @@ func (o *OpenBaoInstaller) WaitForInitialization() error {
 			continue
 		}
 
-		// Check if the secret has meaningful data: at least one unseal key
-		// must be present. We do NOT accept root_token alone because
-		// bank-vaults could theoretically write root_token before the
-		// unseal keys in a partial update, and a DR backup without unseal
-		// keys would be useless.
+		// Check if the secret has meaningful data: at least one key must be
+		// present, indicating bank-vaults has completed initialization and
+		// written the unseal keys. Bank-vaults writes all keys atomically
+		// during Init(), so any data means init is done.
 		if len(secret.Data) > 0 {
-			for key := range secret.Data {
-				if key == "vault-unseal-0" || key == "vault-unseal-key-0" || key == "unseal-key-0" {
-					o.unsealSecret = secret
-					return nil
-				}
-			}
+			o.unsealSecret = secret
+			return nil
 		}
 
 		o.Logger.LogRetry()
@@ -440,33 +433,6 @@ func (o *OpenBaoInstaller) ExtractAndEncrypt() error {
 	_ = os.Remove(tmpPath)
 
 	log.Printf("DR backup encrypted and saved to: %s", o.Config.DRBackupPath)
-	return nil
-}
-
-// SecurityCleanup removes the root_token key from the openbao-unseal-keys Secret.
-// This ensures that even if the cluster is compromised, root access is not available.
-// Only unseal keys remain for Bank-Vaults to handle pod restart unsealing.
-func (o *OpenBaoInstaller) SecurityCleanup() error {
-	secretsClient := o.Clientset.CoreV1().Secrets(openBaoNamespace)
-
-	secret, err := secretsClient.Get(o.ctx, openBaoUnsealSecretName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("fetching unseal secret for cleanup: %w", err)
-	}
-
-	if _, hasRoot := secret.Data["root_token"]; !hasRoot {
-		log.Println("root_token already absent from unseal secret — no cleanup needed")
-		return nil
-	}
-
-	delete(secret.Data, "root_token")
-
-	_, err = secretsClient.Update(o.ctx, secret, metav1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("patching unseal secret to remove root_token: %w", err)
-	}
-
-	log.Println("root_token removed from cluster secret")
 	return nil
 }
 

--- a/internal/installer/openbao_test.go
+++ b/internal/installer/openbao_test.go
@@ -1,0 +1,312 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package installer_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/codesphere-cloud/oms/internal/bootstrap"
+	"github.com/codesphere-cloud/oms/internal/installer"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var _ = Describe("OpenBaoInstaller", func() {
+	var (
+		helmMock  *installer.MockHelmClient
+		clientset *fake.Clientset
+		ctx       context.Context
+		tmpDir    string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		helmMock = installer.NewMockHelmClient(GinkgoT())
+		clientset = fake.NewClientset()
+
+		var err error
+		tmpDir, err = os.MkdirTemp("", "openbao-test-*")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	Describe("Install — deploy Bank-Vaults Operator", func() {
+		It("calls UpgradeChart with InstallIfNotExist for the operator", func() {
+			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				return cfg.ReleaseName == "vault-operator" &&
+					cfg.ChartName == "oci://ghcr.io/bank-vaults/helm-charts/vault-operator" &&
+					cfg.Version == "1.22.5" &&
+					cfg.Namespace == "vault" &&
+					cfg.CreateNamespace == true
+			}), installer.UpgradeChartOptions{InstallIfNotExist: true}).Return(nil)
+
+			inst := &installer.OpenBaoInstaller{
+				Helm:      helmMock,
+				Clientset: clientset,
+				Logger:    bootstrap.NewStepLogger(true),
+				Config:    installer.OpenBaoInstallerConfig{},
+			}
+			inst.SetCtx(ctx)
+
+			err := inst.DeployBankVaultsOperator()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error when Helm fails", func() {
+			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.Anything, mock.Anything).
+				Return(fmt.Errorf("chart not found"))
+
+			inst := &installer.OpenBaoInstaller{
+				Helm:      helmMock,
+				Clientset: clientset,
+				Logger:    bootstrap.NewStepLogger(true),
+				Config:    installer.OpenBaoInstallerConfig{},
+			}
+			inst.SetCtx(ctx)
+
+			err := inst.DeployBankVaultsOperator()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("chart not found"))
+		})
+	})
+
+	Describe("SecurityCleanup", func() {
+		It("removes root_token from the unseal secret", func() {
+			// Pre-create the secret with root_token and unseal keys
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openbao-unseal-keys",
+					Namespace: "vault",
+				},
+				Data: map[string][]byte{
+					"vault-unseal-0": []byte("unseal-key-data"),
+					"root_token":     []byte("root-token-value"),
+				},
+			}
+			_, err := clientset.CoreV1().Secrets("vault").Create(ctx, secret, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			inst := &installer.OpenBaoInstaller{
+				Clientset: clientset,
+				Logger:    bootstrap.NewStepLogger(true),
+				Config:    installer.OpenBaoInstallerConfig{},
+			}
+			inst.SetCtx(ctx)
+
+			err = inst.SecurityCleanup()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify root_token was removed
+			updated, err := clientset.CoreV1().Secrets("vault").Get(ctx, "openbao-unseal-keys", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Data).ToNot(HaveKey("root_token"))
+			Expect(updated.Data).To(HaveKey("vault-unseal-0"))
+		})
+
+		It("is a no-op when root_token is already absent", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openbao-unseal-keys",
+					Namespace: "vault",
+				},
+				Data: map[string][]byte{
+					"vault-unseal-0": []byte("unseal-key-data"),
+				},
+			}
+			_, err := clientset.CoreV1().Secrets("vault").Create(ctx, secret, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			inst := &installer.OpenBaoInstaller{
+				Clientset: clientset,
+				Logger:    bootstrap.NewStepLogger(true),
+				Config:    installer.OpenBaoInstallerConfig{},
+			}
+			inst.SetCtx(ctx)
+
+			err = inst.SecurityCleanup()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("PreFlightDRCheck", func() {
+		Context("when no DR backup file exists", func() {
+			It("proceeds without error", func() {
+				inst := &installer.OpenBaoInstaller{
+					Clientset: clientset,
+					Logger:    bootstrap.NewStepLogger(true),
+					Config: installer.OpenBaoInstallerConfig{
+						DRBackupPath: filepath.Join(tmpDir, "nonexistent.enc.json"),
+					},
+				}
+				inst.SetCtx(ctx)
+
+				err := inst.PreFlightDRCheck()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(inst.GetDRBackupExists()).To(BeFalse())
+			})
+		})
+
+		Context("when DR backup path is empty", func() {
+			It("returns an error", func() {
+				inst := &installer.OpenBaoInstaller{
+					Clientset: clientset,
+					Logger:    bootstrap.NewStepLogger(true),
+					Config: installer.OpenBaoInstallerConfig{
+						DRBackupPath: "",
+					},
+				}
+				inst.SetCtx(ctx)
+
+				err := inst.PreFlightDRCheck()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("--dr-backup-path is required"))
+			})
+		})
+	})
+
+	Describe("WaitForInitialization", func() {
+		It("returns the secret once it contains unseal keys", func() {
+			// Pre-create the namespace
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "vault"}}
+			_, err := clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Pre-create the secret with data
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openbao-unseal-keys",
+					Namespace: "vault",
+				},
+				Data: map[string][]byte{
+					"vault-unseal-0": []byte("key-data"),
+					"root_token":     []byte("root-token"),
+				},
+			}
+			_, err = clientset.CoreV1().Secrets("vault").Create(ctx, secret, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			inst := &installer.OpenBaoInstaller{
+				Clientset: clientset,
+				Logger:    bootstrap.NewStepLogger(true),
+				Config: installer.OpenBaoInstallerConfig{
+					Timeout: 5 * time.Second,
+				},
+			}
+			inst.SetCtx(ctx)
+
+			err = inst.WaitForInitialization()
+			Expect(err).ToNot(HaveOccurred())
+			result := inst.GetUnsealSecret()
+			Expect(result.Data).To(HaveKey("vault-unseal-0"))
+			Expect(result.Data).To(HaveKey("root_token"))
+		})
+
+		It("times out when secret does not appear", func() {
+			inst := &installer.OpenBaoInstaller{
+				Clientset: clientset,
+				Logger:    bootstrap.NewStepLogger(true),
+				Config: installer.OpenBaoInstallerConfig{
+					Timeout: 1 * time.Second,
+				},
+			}
+			inst.SetCtx(ctx)
+
+			err := inst.WaitForInitialization()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("timed out"))
+		})
+	})
+
+	Describe("ExtractAndEncrypt", func() {
+		It("creates an encrypted DR backup file with password and unseal keys", func() {
+			if !sopsAndAgeAvailable() {
+				Skip("sops/age not available")
+			}
+
+			// Generate a real age key for testing
+			keyFile := filepath.Join(tmpDir, "age_key.txt")
+			out, err := exec.Command("age-keygen", "-o", keyFile).CombinedOutput()
+			Expect(err).ToNot(HaveOccurred(), string(out))
+
+			recipient, _, err := installer.ResolveAgeKey(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+
+			backupPath := filepath.Join(tmpDir, "backup.enc.json")
+
+			secret := &corev1.Secret{
+				Data: map[string][]byte{
+					"vault-unseal-0": []byte("test-unseal-key-0"),
+					"root_token":     []byte("test-root-token"),
+				},
+			}
+
+			inst := &installer.OpenBaoInstaller{
+				Logger: bootstrap.NewStepLogger(true),
+				Config: installer.OpenBaoInstallerConfig{
+					DRBackupPath: backupPath,
+					AgeRecipient: recipient,
+					AgeKeyPath:   keyFile,
+					Username:     "admin",
+				},
+			}
+			inst.SetUnsealSecret(secret)
+			inst.SetPassword("generated-password-123")
+
+			err = inst.ExtractAndEncrypt()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the encrypted file exists
+			Expect(backupPath).To(BeAnExistingFile())
+
+			// Decrypt it back and verify contents
+			cmd := exec.Command("sops", "--decrypt", backupPath)
+			cmd.Env = append(os.Environ(), "SOPS_AGE_KEY_FILE="+keyFile)
+			decrypted, err := cmd.Output()
+			Expect(err).ToNot(HaveOccurred())
+
+			var backup map[string]interface{}
+			Expect(json.Unmarshal(decrypted, &backup)).To(Succeed())
+			Expect(backup).To(HaveKey("password"))
+			Expect(backup["password"]).To(Equal("generated-password-123"))
+			Expect(backup).To(HaveKey("username"))
+			Expect(backup["username"]).To(Equal("admin"))
+			Expect(backup).To(HaveKey("unseal_keys"))
+			unsealKeys, ok := backup["unseal_keys"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(unsealKeys).To(HaveKey("vault-unseal-0"))
+			Expect(unsealKeys["vault-unseal-0"]).To(Equal("test-unseal-key-0"))
+		})
+	})
+
+	Describe("GenerateSecurePassword", func() {
+		It("generates a non-empty password of expected length", func() {
+			password, err := installer.GenerateSecurePassword(32)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(password).ToNot(BeEmpty())
+			// 32 bytes base64url-encoded without padding = 43 chars
+			Expect(len(password)).To(Equal(43))
+		})
+
+		It("generates unique passwords on each call", func() {
+			p1, err := installer.GenerateSecurePassword(32)
+			Expect(err).ToNot(HaveOccurred())
+			p2, err := installer.GenerateSecurePassword(32)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(p1).ToNot(Equal(p2))
+		})
+	})
+})

--- a/internal/installer/openbao_test.go
+++ b/internal/installer/openbao_test.go
@@ -4,6 +4,7 @@
 package installer_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/codesphere-cloud/oms/internal/bootstrap"
@@ -20,6 +22,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -85,64 +88,6 @@ var _ = Describe("OpenBaoInstaller", func() {
 		})
 	})
 
-	Describe("SecurityCleanup", func() {
-		It("removes root_token from the unseal secret", func() {
-			// Pre-create the secret with root_token and unseal keys
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "openbao-unseal-keys",
-					Namespace: "vault",
-				},
-				Data: map[string][]byte{
-					"vault-unseal-0": []byte("unseal-key-data"),
-					"root_token":     []byte("root-token-value"),
-				},
-			}
-			_, err := clientset.CoreV1().Secrets("vault").Create(ctx, secret, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			inst := &installer.OpenBaoInstaller{
-				Clientset: clientset,
-				Logger:    bootstrap.NewStepLogger(true),
-				Config:    installer.OpenBaoInstallerConfig{},
-			}
-			inst.SetCtx(ctx)
-
-			err = inst.SecurityCleanup()
-			Expect(err).ToNot(HaveOccurred())
-
-			// Verify root_token was removed
-			updated, err := clientset.CoreV1().Secrets("vault").Get(ctx, "openbao-unseal-keys", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(updated.Data).ToNot(HaveKey("root_token"))
-			Expect(updated.Data).To(HaveKey("vault-unseal-0"))
-		})
-
-		It("is a no-op when root_token is already absent", func() {
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "openbao-unseal-keys",
-					Namespace: "vault",
-				},
-				Data: map[string][]byte{
-					"vault-unseal-0": []byte("unseal-key-data"),
-				},
-			}
-			_, err := clientset.CoreV1().Secrets("vault").Create(ctx, secret, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			inst := &installer.OpenBaoInstaller{
-				Clientset: clientset,
-				Logger:    bootstrap.NewStepLogger(true),
-				Config:    installer.OpenBaoInstallerConfig{},
-			}
-			inst.SetCtx(ctx)
-
-			err = inst.SecurityCleanup()
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
 	Describe("PreFlightDRCheck", func() {
 		Context("when no DR backup file exists", func() {
 			It("proceeds without error", func() {
@@ -186,7 +131,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 			_, err := clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			// Pre-create the secret with data
+			// Pre-create the secret with data (no root_token — storeRootToken is false)
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "openbao-unseal-keys",
@@ -194,7 +139,6 @@ var _ = Describe("OpenBaoInstaller", func() {
 				},
 				Data: map[string][]byte{
 					"vault-unseal-0": []byte("key-data"),
-					"root_token":     []byte("root-token"),
 				},
 			}
 			_, err = clientset.CoreV1().Secrets("vault").Create(ctx, secret, metav1.CreateOptions{})
@@ -213,7 +157,6 @@ var _ = Describe("OpenBaoInstaller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			result := inst.GetUnsealSecret()
 			Expect(result.Data).To(HaveKey("vault-unseal-0"))
-			Expect(result.Data).To(HaveKey("root_token"))
 		})
 
 		It("times out when secret does not appear", func() {
@@ -254,7 +197,6 @@ var _ = Describe("OpenBaoInstaller", func() {
 			secret := &corev1.Secret{
 				Data: map[string][]byte{
 					"vault-unseal-0": []byte("test-unseal-key-0"),
-					"root_token":     []byte("test-root-token"),
 				},
 			}
 
@@ -311,6 +253,179 @@ var _ = Describe("OpenBaoInstaller", func() {
 			p2, err := installer.GenerateSecurePassword(32)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(p1).ToNot(Equal(p2))
+		})
+	})
+
+	Describe("Vault CR template rendering", func() {
+		// templateData mirrors the unexported vaultCRTemplateData struct
+		// so the test can render the template independently.
+		type templateData struct {
+			Namespace         string
+			OpenBaoImage      string
+			BankVaultsImage   string
+			SecretsEngineName string
+			BaoUsername       string
+			BaoPassword       string
+			Replicas          int
+			StorageSize       string
+			RetryJoinAddrs    []string
+		}
+
+		renderTemplate := func(data templateData) []map[string]interface{} {
+			raw, err := os.ReadFile("manifests/openbao/vault-cr.yaml")
+			Expect(err).ToNot(HaveOccurred())
+
+			tmpl, err := template.New("vault-cr").Parse(string(raw))
+			Expect(err).ToNot(HaveOccurred())
+
+			var buf bytes.Buffer
+			Expect(tmpl.Execute(&buf, data)).To(Succeed())
+
+			// Decode multi-doc YAML into a slice of generic maps
+			decoder := yaml.NewYAMLOrJSONDecoder(&buf, 4096)
+			var docs []map[string]interface{}
+			for {
+				var doc map[string]interface{}
+				if err := decoder.Decode(&doc); err != nil {
+					break
+				}
+				if doc != nil {
+					docs = append(docs, doc)
+				}
+			}
+			return docs
+		}
+
+		findDoc := func(docs []map[string]interface{}, kind string) map[string]interface{} {
+			for _, doc := range docs {
+				if doc["kind"] == kind {
+					return doc
+				}
+			}
+			return nil
+		}
+
+		It("renders valid YAML with file storage for replicas=1", func() {
+			data := templateData{
+				Namespace:         "vault",
+				OpenBaoImage:      "quay.io/openbao/openbao:2.1.0",
+				BankVaultsImage:   "ghcr.io/bank-vaults/bank-vaults:v1.31.3",
+				SecretsEngineName: "cs-secrets-engine",
+				BaoUsername:       "admin",
+				BaoPassword:       "test-password",
+				Replicas:          1,
+				StorageSize:       "10Gi",
+				RetryJoinAddrs:    nil,
+			}
+
+			docs := renderTemplate(data)
+			// Expect 4 documents: ServiceAccount, Role, RoleBinding, Vault
+			Expect(docs).To(HaveLen(4))
+
+			// Verify Vault CR
+			vault := findDoc(docs, "Vault")
+			Expect(vault).ToNot(BeNil())
+
+			spec := vault["spec"].(map[string]interface{})
+			Expect(spec["size"]).To(BeNumerically("==", 1))
+			Expect(spec["image"]).To(Equal("quay.io/openbao/openbao:2.1.0"))
+
+			// Should NOT have volumeClaimTemplates for single-node
+			Expect(spec).ToNot(HaveKey("volumeClaimTemplates"))
+			Expect(spec).ToNot(HaveKey("volumeMounts"))
+
+			// Config should use file storage, not raft
+			config := spec["config"].(map[string]interface{})
+			storage := config["storage"].(map[string]interface{})
+			Expect(storage).To(HaveKey("file"))
+			Expect(storage).ToNot(HaveKey("raft"))
+
+			// Unseal config should have storeRootToken: false
+			unsealConfig := spec["unsealConfig"].(map[string]interface{})
+			options := unsealConfig["options"].(map[string]interface{})
+			Expect(options["storeRootToken"]).To(BeFalse())
+
+			// Verify externalConfig has the secrets engine
+			externalConfig := spec["externalConfig"].(map[string]interface{})
+			secrets := externalConfig["secrets"].([]interface{})
+			Expect(secrets).To(HaveLen(1))
+			secretEntry := secrets[0].(map[string]interface{})
+			Expect(secretEntry["path"]).To(Equal("cs-secrets-engine"))
+
+			// Verify auth config
+			auth := externalConfig["auth"].([]interface{})
+			Expect(auth).To(HaveLen(1))
+			authEntry := auth[0].(map[string]interface{})
+			Expect(authEntry["type"]).To(Equal("userpass"))
+			users := authEntry["users"].([]interface{})
+			user := users[0].(map[string]interface{})
+			Expect(user["username"]).To(Equal("admin"))
+			Expect(user["password"]).To(Equal("test-password"))
+
+			// Verify vaultContainerSpec has NO HA env vars
+			containerSpec := spec["vaultContainerSpec"].(map[string]interface{})
+			Expect(containerSpec).ToNot(HaveKey("env"))
+		})
+
+		It("renders valid YAML with raft storage, PVCs, and retry_join for replicas=3", func() {
+			retryJoinAddrs := []string{
+				"http://openbao-0.vault.svc.cluster.local:8200",
+				"http://openbao-1.vault.svc.cluster.local:8200",
+				"http://openbao-2.vault.svc.cluster.local:8200",
+			}
+
+			data := templateData{
+				Namespace:         "vault",
+				OpenBaoImage:      "quay.io/openbao/openbao:2.1.0",
+				BankVaultsImage:   "ghcr.io/bank-vaults/bank-vaults:v1.31.3",
+				SecretsEngineName: "cs-secrets-engine",
+				BaoUsername:       "admin",
+				BaoPassword:       "test-password",
+				Replicas:          3,
+				StorageSize:       "20Gi",
+				RetryJoinAddrs:    retryJoinAddrs,
+			}
+
+			docs := renderTemplate(data)
+			Expect(docs).To(HaveLen(4))
+
+			vault := findDoc(docs, "Vault")
+			Expect(vault).ToNot(BeNil())
+
+			spec := vault["spec"].(map[string]interface{})
+			Expect(spec["size"]).To(BeNumerically("==", 3))
+
+			// Should have volumeClaimTemplates for HA
+			Expect(spec).To(HaveKey("volumeClaimTemplates"))
+			vcts := spec["volumeClaimTemplates"].([]interface{})
+			Expect(vcts).To(HaveLen(1))
+			vct := vcts[0].(map[string]interface{})
+			vctSpec := vct["spec"].(map[string]interface{})
+			resources := vctSpec["resources"].(map[string]interface{})
+			requests := resources["requests"].(map[string]interface{})
+			Expect(requests["storage"]).To(Equal("20Gi"))
+
+			// Should have volumeMounts
+			Expect(spec).To(HaveKey("volumeMounts"))
+
+			// Config should use raft storage with retry_join
+			config := spec["config"].(map[string]interface{})
+			storage := config["storage"].(map[string]interface{})
+			Expect(storage).To(HaveKey("raft"))
+			Expect(storage).ToNot(HaveKey("file"))
+			raft := storage["raft"].(map[string]interface{})
+			retryJoin := raft["retry_join"].([]interface{})
+			Expect(retryJoin).To(HaveLen(3))
+
+			// Verify vaultContainerSpec has HA env vars
+			containerSpec := spec["vaultContainerSpec"].(map[string]interface{})
+			Expect(containerSpec).To(HaveKey("env"))
+			envVars := containerSpec["env"].([]interface{})
+			envNames := make([]string, 0, len(envVars))
+			for _, e := range envVars {
+				envNames = append(envNames, e.(map[string]interface{})["name"].(string))
+			}
+			Expect(envNames).To(ContainElements("POD_NAME", "BAO_CLUSTER_ADDR", "BAO_API_ADDR"))
 		})
 	})
 })

--- a/internal/installer/openbao_test.go
+++ b/internal/installer/openbao_test.go
@@ -119,7 +119,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 
 				err := inst.PreFlightDRCheck()
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("--dr-backup-path is required"))
+				Expect(err.Error()).To(ContainSubstring("DRBackupPath must be set"))
 			})
 		})
 	})
@@ -305,7 +305,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 			return nil
 		}
 
-		It("renders valid YAML with file storage for replicas=1", func() {
+		It("renders valid YAML with raft storage and PVC for replicas=1", func() {
 			data := templateData{
 				Namespace:         "vault",
 				OpenBaoImage:      "quay.io/openbao/openbao:2.1.0",
@@ -315,7 +315,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 				BaoPassword:       "test-password",
 				Replicas:          1,
 				StorageSize:       "10Gi",
-				RetryJoinAddrs:    nil,
+				RetryJoinAddrs:    []string{"http://openbao-0.vault.svc.cluster.local:8200"},
 			}
 
 			docs := renderTemplate(data)
@@ -330,15 +330,27 @@ var _ = Describe("OpenBaoInstaller", func() {
 			Expect(spec["size"]).To(BeNumerically("==", 1))
 			Expect(spec["image"]).To(Equal("quay.io/openbao/openbao:2.1.0"))
 
-			// Should NOT have volumeClaimTemplates for single-node
-			Expect(spec).ToNot(HaveKey("volumeClaimTemplates"))
-			Expect(spec).ToNot(HaveKey("volumeMounts"))
+			// Should have volumeClaimTemplates (raft always needs persistent storage)
+			Expect(spec).To(HaveKey("volumeClaimTemplates"))
+			vcts := spec["volumeClaimTemplates"].([]interface{})
+			Expect(vcts).To(HaveLen(1))
+			vct := vcts[0].(map[string]interface{})
+			vctSpec := vct["spec"].(map[string]interface{})
+			resources := vctSpec["resources"].(map[string]interface{})
+			requests := resources["requests"].(map[string]interface{})
+			Expect(requests["storage"]).To(Equal("10Gi"))
 
-			// Config should use file storage, not raft
+			// Should have volumeMounts
+			Expect(spec).To(HaveKey("volumeMounts"))
+
+			// Config should use raft storage (always, even for single node)
 			config := spec["config"].(map[string]interface{})
 			storage := config["storage"].(map[string]interface{})
-			Expect(storage).To(HaveKey("file"))
-			Expect(storage).ToNot(HaveKey("raft"))
+			Expect(storage).To(HaveKey("raft"))
+			Expect(storage).ToNot(HaveKey("file"))
+			raft := storage["raft"].(map[string]interface{})
+			retryJoin := raft["retry_join"].([]interface{})
+			Expect(retryJoin).To(HaveLen(1))
 
 			// Unseal config should have storeRootToken: false
 			unsealConfig := spec["unsealConfig"].(map[string]interface{})
@@ -362,9 +374,9 @@ var _ = Describe("OpenBaoInstaller", func() {
 			Expect(user["username"]).To(Equal("admin"))
 			Expect(user["password"]).To(Equal("test-password"))
 
-			// Verify vaultContainerSpec has NO HA env vars
+			// Verify vaultContainerSpec has env vars (always present now)
 			containerSpec := spec["vaultContainerSpec"].(map[string]interface{})
-			Expect(containerSpec).ToNot(HaveKey("env"))
+			Expect(containerSpec).To(HaveKey("env"))
 		})
 
 		It("renders valid YAML with raft storage, PVCs, and retry_join for replicas=3", func() {

--- a/internal/installer/openbao_test.go
+++ b/internal/installer/openbao_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/codesphere-cloud/oms/internal/bootstrap"
@@ -237,13 +238,16 @@ var _ = Describe("OpenBaoInstaller", func() {
 				Skip("sops/age not available")
 			}
 
-			// Generate a real age key for testing
+			// Generate a real age key for testing and extract the public key
+			// directly from age-keygen output (format: "Public key: age1...").
+			// This avoids calling ResolveAgeKey which probes env vars and
+			// default config paths, making the test sensitive to the host.
 			keyFile := filepath.Join(tmpDir, "age_key.txt")
 			out, err := exec.Command("age-keygen", "-o", keyFile).CombinedOutput()
 			Expect(err).ToNot(HaveOccurred(), string(out))
 
-			recipient, _, err := installer.ResolveAgeKey(tmpDir)
-			Expect(err).ToNot(HaveOccurred())
+			recipient := extractAgeRecipient(string(out))
+			Expect(recipient).To(HavePrefix("age1"), "could not extract public key from age-keygen output")
 
 			backupPath := filepath.Join(tmpDir, "backup.enc.json")
 
@@ -310,3 +314,14 @@ var _ = Describe("OpenBaoInstaller", func() {
 		})
 	})
 })
+
+// extractAgeRecipient extracts the public key from age-keygen's output.
+// age-keygen -o <file> prints "Public key: age1..." to stderr.
+func extractAgeRecipient(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "Public key: ") {
+			return strings.TrimPrefix(line, "Public key: ")
+		}
+	}
+	return ""
+}

--- a/internal/installer/vault_encryption.go
+++ b/internal/installer/vault_encryption.go
@@ -68,7 +68,6 @@ func ResolveAgeKey(fallbackDir string) (recipient string, keyPath string, err er
 		if !os.IsNotExist(err) {
 			return "", "", fmt.Errorf("failed to read age key from fallback location %s: %w", keyPath, err)
 		}
-		// File does not exist, will generate a new key.
 		recipient, err = generateAgeKey(keyPath)
 		if err != nil {
 			return "", "", fmt.Errorf("failed to generate age key: %w", err)
@@ -135,7 +134,6 @@ func generateAgeKey(keyPath string) (string, error) {
 		return "", fmt.Errorf("age-keygen failed: %w: %s", err, out)
 	}
 
-	// Read back the generated file to extract the public key.
 	recipient, err := readRecipientFromFile(keyPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read generated age key: %w", err)
@@ -143,7 +141,7 @@ func generateAgeKey(keyPath string) (string, error) {
 	return recipient, nil
 }
 
-// EncryptFileWithSOPS encrypts a file in-place using SOPS with the given age recipient.
+// EncryptFileWithSOPS encrypts src with SOPS+age and writes ciphertext to target.
 func EncryptFileWithSOPS(src, target, recipient string) error {
 	cmd := exec.Command("sops", "--encrypt", "--age", recipient, "--output", target, src)
 	out, err := cmd.CombinedOutput()

--- a/internal/installer/vault_encryption.go
+++ b/internal/installer/vault_encryption.go
@@ -152,3 +152,20 @@ func EncryptFileWithSOPS(src, target, recipient string) error {
 	}
 	return nil
 }
+
+// DecryptFileWithSOPS decrypts a SOPS-encrypted file and returns the plaintext bytes.
+// If keyPath is non-empty, SOPS_AGE_KEY_FILE is set for the sops process.
+func DecryptFileWithSOPS(src, keyPath string) ([]byte, error) {
+	cmd := exec.Command("sops", "--decrypt", src)
+	if keyPath != "" {
+		cmd.Env = append(os.Environ(), "SOPS_AGE_KEY_FILE="+keyPath)
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("sops decrypt failed: %s", string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("sops decrypt failed: %w", err)
+	}
+	return out, nil
+}

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -103,14 +103,7 @@ func GvrForUnstructured(obj *unstructured.Unstructured) (schema.GroupVersionReso
 			Resource: "rolebindings",
 		}, nil
 	default:
-		// Generic fallback: lowercase kind + "s". This covers most built-in
-		// resources (e.g., ConfigMap -> configmaps, Secret -> secrets) but will
-		// produce incorrect plurals for irregular kinds (e.g., Ingress).
-		return schema.GroupVersionResource{
-			Group:    gvk.Group,
-			Version:  gvk.Version,
-			Resource: strings.ToLower(gvk.Kind) + "s",
-		}, nil
+		return schema.GroupVersionResource{}, fmt.Errorf("no GVR mapping for %s — add an explicit case to GvrForUnstructured", gvk)
 	}
 }
 

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -62,49 +62,34 @@ func VaultGVR() schema.GroupVersionResource {
 	}
 }
 
+// gvrMappings maps Kubernetes Kind names to their plural resource names.
+// New kinds used in embedded templates need a corresponding entry here.
+var gvrMappings = map[string]string{
+	"AppProject":     "appprojects",
+	"Vault":          "vaults",
+	"ServiceAccount": "serviceaccounts",
+	"Role":           "roles",
+	"RoleBinding":    "rolebindings",
+}
+
 // GvrForUnstructured maps an unstructured object's GVK to the appropriate GVR.
 //
 // This uses a hand-rolled lookup table rather than a discovery-backed RESTMapper
 // to avoid requiring a cluster round-trip during resolution. New kinds used in
-// embedded templates will need a corresponding case here. If this grows unwieldy,
-// consider switching to restmapper.NewDiscoveryRESTMapper.
+// embedded templates will need a corresponding entry in gvrMappings. If this
+// grows unwieldy, consider switching to restmapper.NewDiscoveryRESTMapper.
 func GvrForUnstructured(obj *unstructured.Unstructured) (schema.GroupVersionResource, error) {
 	gvk := obj.GroupVersionKind()
 
-	switch gvk.Kind {
-	case "AppProject":
-		return schema.GroupVersionResource{
-			Group:    gvk.Group,
-			Version:  gvk.Version,
-			Resource: "appprojects",
-		}, nil
-	case "Vault":
-		return schema.GroupVersionResource{
-			Group:    gvk.Group,
-			Version:  gvk.Version,
-			Resource: "vaults",
-		}, nil
-	case "ServiceAccount":
-		return schema.GroupVersionResource{
-			Group:    gvk.Group,
-			Version:  gvk.Version,
-			Resource: "serviceaccounts",
-		}, nil
-	case "Role":
-		return schema.GroupVersionResource{
-			Group:    gvk.Group,
-			Version:  gvk.Version,
-			Resource: "roles",
-		}, nil
-	case "RoleBinding":
-		return schema.GroupVersionResource{
-			Group:    gvk.Group,
-			Version:  gvk.Version,
-			Resource: "rolebindings",
-		}, nil
-	default:
-		return schema.GroupVersionResource{}, fmt.Errorf("no GVR mapping for %s — add an explicit case to GvrForUnstructured", gvk)
+	resource, ok := gvrMappings[gvk.Kind]
+	if !ok {
+		return schema.GroupVersionResource{}, fmt.Errorf("no GVR mapping for %s — add an entry to gvrMappings", gvk)
 	}
+	return schema.GroupVersionResource{
+		Group:    gvk.Group,
+		Version:  gvk.Version,
+		Resource: resource,
+	}, nil
 }
 
 // ApplyUnstructured creates or updates an unstructured resource using the dynamic client.

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -63,6 +63,11 @@ func VaultGVR() schema.GroupVersionResource {
 }
 
 // GvrForUnstructured maps an unstructured object's GVK to the appropriate GVR.
+//
+// This uses a hand-rolled lookup table rather than a discovery-backed RESTMapper
+// to avoid requiring a cluster round-trip during resolution. New kinds used in
+// embedded templates will need a corresponding case here. If this grows unwieldy,
+// consider switching to restmapper.NewDiscoveryRESTMapper.
 func GvrForUnstructured(obj *unstructured.Unstructured) (schema.GroupVersionResource, error) {
 	gvk := obj.GroupVersionKind()
 
@@ -98,7 +103,14 @@ func GvrForUnstructured(obj *unstructured.Unstructured) (schema.GroupVersionReso
 			Resource: "rolebindings",
 		}, nil
 	default:
-		return schema.GroupVersionResource{}, fmt.Errorf("no GVR mapping for %s", gvk)
+		// Generic fallback: lowercase kind + "s". This covers most built-in
+		// resources (e.g., ConfigMap -> configmaps, Secret -> secrets) but will
+		// produce incorrect plurals for irregular kinds (e.g., Ingress).
+		return schema.GroupVersionResource{
+			Group:    gvk.Group,
+			Version:  gvk.Version,
+			Resource: strings.ToLower(gvk.Kind) + "s",
+		}, nil
 	}
 }
 

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -141,7 +141,7 @@ func ApplySecretFromYAML(ctx context.Context, clientset kubernetes.Interface, da
 	return nil
 }
 
-// newClients creates both a typed and dynamic Kubernetes client
+// NewClients creates both a typed and dynamic Kubernetes client
 // using the current kubeconfig context (respects KUBECONFIG env var
 // and defaults to ~/.kube/config).
 func NewClients() (kubernetes.Interface, dynamic.Interface, error) {

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -103,7 +103,14 @@ func GvrForUnstructured(obj *unstructured.Unstructured) (schema.GroupVersionReso
 			Resource: "rolebindings",
 		}, nil
 	default:
-		return schema.GroupVersionResource{}, fmt.Errorf("no GVR mapping for %s — add an explicit case to GvrForUnstructured", gvk)
+		// Generic fallback: lowercase kind + "s". This covers most built-in
+		// resources (e.g., ConfigMap -> configmaps, Secret -> secrets) but will
+		// produce incorrect plurals for irregular kinds (e.g., Ingress).
+		return schema.GroupVersionResource{
+			Group:    gvk.Group,
+			Version:  gvk.Version,
+			Resource: strings.ToLower(gvk.Kind) + "s",
+		}, nil
 	}
 }
 

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -53,6 +53,15 @@ func RenderTemplate(raw []byte, vars map[string]string) ([]byte, error) {
 	return []byte(content), nil
 }
 
+// VaultGVR returns the GroupVersionResource for the bank-vaults Vault CRD.
+func VaultGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "vault.banzaicloud.com",
+		Version:  "v1alpha1",
+		Resource: "vaults",
+	}
+}
+
 // GvrForUnstructured maps an unstructured object's GVK to the appropriate GVR.
 func GvrForUnstructured(obj *unstructured.Unstructured) (schema.GroupVersionResource, error) {
 	gvk := obj.GroupVersionKind()
@@ -63,6 +72,30 @@ func GvrForUnstructured(obj *unstructured.Unstructured) (schema.GroupVersionReso
 			Group:    gvk.Group,
 			Version:  gvk.Version,
 			Resource: "appprojects",
+		}, nil
+	case "Vault":
+		return schema.GroupVersionResource{
+			Group:    gvk.Group,
+			Version:  gvk.Version,
+			Resource: "vaults",
+		}, nil
+	case "ServiceAccount":
+		return schema.GroupVersionResource{
+			Group:    gvk.Group,
+			Version:  gvk.Version,
+			Resource: "serviceaccounts",
+		}, nil
+	case "Role":
+		return schema.GroupVersionResource{
+			Group:    gvk.Group,
+			Version:  gvk.Version,
+			Resource: "roles",
+		}, nil
+	case "RoleBinding":
+		return schema.GroupVersionResource{
+			Group:    gvk.Group,
+			Version:  gvk.Version,
+			Resource: "rolebindings",
 		}, nil
 	default:
 		return schema.GroupVersionResource{}, fmt.Errorf("no GVR mapping for %s", gvk)

--- a/internal/util/k8s_test.go
+++ b/internal/util/k8s_test.go
@@ -145,15 +145,13 @@ var _ = Describe("GvrForUnstructured", func() {
 		Expect(gvr.Resource).To(Equal("appprojects"))
 	})
 
-	It("falls back to lowercase+s pluralization for unmapped kinds", func() {
+	It("returns an error for an unknown kind", func() {
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion("v1")
 		obj.SetKind("ConfigMap")
 
-		gvr, err := util.GvrForUnstructured(obj)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(gvr.Group).To(Equal(""))
-		Expect(gvr.Version).To(Equal("v1"))
-		Expect(gvr.Resource).To(Equal("configmaps"))
+		_, err := util.GvrForUnstructured(obj)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no GVR mapping"))
 	})
 })

--- a/internal/util/k8s_test.go
+++ b/internal/util/k8s_test.go
@@ -145,6 +145,54 @@ var _ = Describe("GvrForUnstructured", func() {
 		Expect(gvr.Resource).To(Equal("appprojects"))
 	})
 
+	It("returns the correct GVR for Vault", func() {
+		obj := &unstructured.Unstructured{}
+		obj.SetAPIVersion("vault.banzaicloud.com/v1alpha1")
+		obj.SetKind("Vault")
+
+		gvr, err := util.GvrForUnstructured(obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gvr.Group).To(Equal("vault.banzaicloud.com"))
+		Expect(gvr.Version).To(Equal("v1alpha1"))
+		Expect(gvr.Resource).To(Equal("vaults"))
+	})
+
+	It("returns the correct GVR for ServiceAccount", func() {
+		obj := &unstructured.Unstructured{}
+		obj.SetAPIVersion("v1")
+		obj.SetKind("ServiceAccount")
+
+		gvr, err := util.GvrForUnstructured(obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gvr.Group).To(Equal(""))
+		Expect(gvr.Version).To(Equal("v1"))
+		Expect(gvr.Resource).To(Equal("serviceaccounts"))
+	})
+
+	It("returns the correct GVR for Role", func() {
+		obj := &unstructured.Unstructured{}
+		obj.SetAPIVersion("rbac.authorization.k8s.io/v1")
+		obj.SetKind("Role")
+
+		gvr, err := util.GvrForUnstructured(obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gvr.Group).To(Equal("rbac.authorization.k8s.io"))
+		Expect(gvr.Version).To(Equal("v1"))
+		Expect(gvr.Resource).To(Equal("roles"))
+	})
+
+	It("returns the correct GVR for RoleBinding", func() {
+		obj := &unstructured.Unstructured{}
+		obj.SetAPIVersion("rbac.authorization.k8s.io/v1")
+		obj.SetKind("RoleBinding")
+
+		gvr, err := util.GvrForUnstructured(obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gvr.Group).To(Equal("rbac.authorization.k8s.io"))
+		Expect(gvr.Version).To(Equal("v1"))
+		Expect(gvr.Resource).To(Equal("rolebindings"))
+	})
+
 	It("returns an error for an unknown kind", func() {
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion("v1")

--- a/internal/util/k8s_test.go
+++ b/internal/util/k8s_test.go
@@ -145,13 +145,15 @@ var _ = Describe("GvrForUnstructured", func() {
 		Expect(gvr.Resource).To(Equal("appprojects"))
 	})
 
-	It("returns an error for an unknown kind", func() {
+	It("falls back to lowercase+s pluralization for unmapped kinds", func() {
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion("v1")
 		obj.SetKind("ConfigMap")
 
-		_, err := util.GvrForUnstructured(obj)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("no GVR mapping"))
+		gvr, err := util.GvrForUnstructured(obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gvr.Group).To(Equal(""))
+		Expect(gvr.Version).To(Equal("v1"))
+		Expect(gvr.Resource).To(Equal("configmaps"))
 	})
 })


### PR DESCRIPTION
## Summary

Adds `oms install openbao` — a Day-0 bootstrap command for OpenBao using the Bank-Vaults Operator with SOPS-encrypted DR backups (no external KMS required).

## What it does

- Deploys Bank-Vaults Operator via Helm, applies a Vault CR with userpass auth and KV-v2
- Uses Raft storage with persistent volumes for all replica counts (including single-node)
- Waits for init, extracts unseal keys + credentials, encrypts to a SOPS/age DR backup
- On re-run, restores from existing DR backup (idempotent), reusing original credentials
- Root token is never persisted to the cluster (`storeRootToken: false`); bank-vaults derives temporary root tokens from unseal keys via the Generate Root Token protocol

## Other changes

- Helm client refactored to per-call settings (fixes namespace scoping, adds OCI support)
- `GvrForUnstructured` extended with explicit cases for Vault CR template kinds (ServiceAccount, Role, RoleBinding, Vault)
- `DecryptFileWithSOPS` helper added
- PVC storage size configurable via `--storage-size` flag