### PR TITLE
feat(bootstrap): configure datacenter for gcp and test users

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -23,9 +23,9 @@ License URL: https://github.com/googleapis/google-cloud-go/blob/auth/oauth2adapt
  
 ----------
 Module: cloud.google.com/go/compute
-Version: v1.62.0
+Version: v1.63.0
 License: Apache-2.0
-License URL: https://github.com/googleapis/google-cloud-go/blob/compute/v1.62.0/compute/LICENSE
+License URL: https://github.com/googleapis/google-cloud-go/blob/compute/v1.63.0/compute/LICENSE
  
 ----------
 Module: cloud.google.com/go/compute/metadata
@@ -41,21 +41,21 @@ License URL: https://github.com/googleapis/google-cloud-go/blob/iam/v1.11.0/iam/
  
 ----------
 Module: cloud.google.com/go/longrunning
-Version: v0.9.0
+Version: v0.11.0
 License: Apache-2.0
-License URL: https://github.com/googleapis/google-cloud-go/blob/longrunning/v0.9.0/longrunning/LICENSE
+License URL: https://github.com/googleapis/google-cloud-go/blob/longrunning/v0.11.0/longrunning/LICENSE
  
 ----------
 Module: cloud.google.com/go/resourcemanager
-Version: v1.14.0
+Version: v1.15.0
 License: Apache-2.0
-License URL: https://github.com/googleapis/google-cloud-go/blob/resourcemanager/v1.14.0/resourcemanager/LICENSE
+License URL: https://github.com/googleapis/google-cloud-go/blob/resourcemanager/v1.15.0/resourcemanager/LICENSE
  
 ----------
 Module: cloud.google.com/go/serviceusage
-Version: v1.13.0
+Version: v1.14.0
 License: Apache-2.0
-License URL: https://github.com/googleapis/google-cloud-go/blob/serviceusage/v1.13.0/serviceusage/LICENSE
+License URL: https://github.com/googleapis/google-cloud-go/blob/serviceusage/v1.14.0/serviceusage/LICENSE
  
 ----------
 Module: code.gitea.io/sdk/gitea
@@ -215,9 +215,9 @@ License URL: https://github.com/cloudnative-pg/machinery/blob/v0.3.3/LICENSE
  
 ----------
 Module: github.com/codesphere-cloud/cs-go
-Version: v1.0.1
+Version: v1.1.0
 License: Apache-2.0
-License URL: https://github.com/codesphere-cloud/cs-go/blob/v1.0.1/LICENSE
+License URL: https://github.com/codesphere-cloud/cs-go/blob/v1.1.0/LICENSE
    
 ----------
 Module: github.com/codesphere-cloud/oms/internal/tmpl
@@ -329,9 +329,9 @@ License URL: https://github.com/getsops/gopgagent/blob/7044f28e491e/LICENSE
  
 ----------
 Module: github.com/getsops/sops/v3
-Version: v3.12.2
+Version: v3.13.0
 License: MPL-2.0
-License URL: https://github.com/getsops/sops/blob/v3.12.2/LICENSE
+License URL: https://github.com/getsops/sops/blob/v3.13.0/LICENSE
  
 ----------
 Module: github.com/go-errors/errors
@@ -737,9 +737,9 @@ License URL: https://github.com/mattn/go-colorable/blob/v0.1.14/LICENSE
  
 ----------
 Module: github.com/mattn/go-isatty
-Version: v0.0.20
+Version: v0.0.22
 License: MIT
-License URL: https://github.com/mattn/go-isatty/blob/v0.0.20/LICENSE
+License URL: https://github.com/mattn/go-isatty/blob/v0.0.22/LICENSE
  
 ----------
 Module: github.com/mattn/go-runewidth
@@ -1025,27 +1025,27 @@ License URL: https://github.com/open-telemetry/opentelemetry-go-instrumentation/
  
 ----------
 Module: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
-Version: v0.67.0
+Version: v0.68.0
 License: Apache-2.0
-License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/google.golang.org/grpc/otelgrpc/v0.67.0/instrumentation/google.golang.org/grpc/otelgrpc/LICENSE
+License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/google.golang.org/grpc/otelgrpc/v0.68.0/instrumentation/google.golang.org/grpc/otelgrpc/LICENSE
  
 ----------
 Module: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
-Version: v0.67.0
+Version: v0.68.0
 License: BSD-3-Clause
-License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/google.golang.org/grpc/otelgrpc/v0.67.0/instrumentation/google.golang.org/grpc/otelgrpc/LICENSE
+License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/google.golang.org/grpc/otelgrpc/v0.68.0/instrumentation/google.golang.org/grpc/otelgrpc/LICENSE
  
 ----------
 Module: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
-Version: v0.67.0
+Version: v0.68.0
 License: Apache-2.0
-License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/otelhttp/v0.67.0/instrumentation/net/http/otelhttp/LICENSE
+License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/otelhttp/v0.68.0/instrumentation/net/http/otelhttp/LICENSE
  
 ----------
 Module: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
-Version: v0.67.0
+Version: v0.68.0
 License: BSD-3-Clause
-License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/otelhttp/v0.67.0/instrumentation/net/http/otelhttp/LICENSE
+License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/otelhttp/v0.68.0/instrumentation/net/http/otelhttp/LICENSE
  
 ----------
 Module: go.opentelemetry.io/otel
@@ -1187,15 +1187,15 @@ License URL: https://github.com/googleapis/google-api-go-client/blob/v0.277.0/in
  
 ----------
 Module: google.golang.org/genproto/googleapis
-Version: v0.0.0-20260319201613-d00831a3d3e7
+Version: v0.0.0-20260427160629-7cedc36a6bc4
 License: Apache-2.0
-License URL: https://github.com/googleapis/go-genproto/blob/d00831a3d3e7/LICENSE
+License URL: https://github.com/googleapis/go-genproto/blob/7cedc36a6bc4/LICENSE
  
 ----------
 Module: google.golang.org/genproto/googleapis/api
-Version: v0.0.0-20260401024825-9d38bb4040a9
+Version: v0.0.0-20260427160629-7cedc36a6bc4
 License: Apache-2.0
-License URL: https://github.com/googleapis/go-genproto/blob/9d38bb4040a9/googleapis/api/LICENSE
+License URL: https://github.com/googleapis/go-genproto/blob/7cedc36a6bc4/googleapis/api/LICENSE
  
 ----------
 Module: google.golang.org/genproto/googleapis/rpc
@@ -1205,9 +1205,9 @@ License URL: https://github.com/googleapis/go-genproto/blob/7cedc36a6bc4/googlea
  
 ----------
 Module: google.golang.org/grpc
-Version: v1.81.0
+Version: v1.81.1
 License: Apache-2.0
-License URL: https://github.com/grpc/grpc-go/blob/v1.81.0/LICENSE
+License URL: https://github.com/grpc/grpc-go/blob/v1.81.1/LICENSE
  
 ----------
 Module: google.golang.org/protobuf

--- a/cli/cmd/bootstrap_gcp.go
+++ b/cli/cmd/bootstrap_gcp.go
@@ -85,6 +85,7 @@ func AddBootstrapGcpCmd(parent *cobra.Command, opts *GlobalOptions) {
 	flags.BoolVar(&bootstrapGcpCmd.CodesphereEnv.Preemptible, "preemptible", false, "Use preemptible VMs for Codesphere infrastructure. Mutually exclusive with --spot-vms (default: false)")
 	flags.BoolVar(&bootstrapGcpCmd.CodesphereEnv.SpotVMs, "spot-vms", false, "Use Spot VMs for Codesphere infrastructure. Falls back to standard VMs if spot capacity unavailable. Mutually exclusive with --preemptible (default: false)")
 	flags.IntVar(&bootstrapGcpCmd.CodesphereEnv.DatacenterID, "datacenter-id", 1, "Datacenter ID (default: 1)")
+	flags.StringVar(&bootstrapGcpCmd.CodesphereEnv.DatacenterName, "datacenter-name", "dev", "Datacenter name (default: dev)")
 	flags.StringVar(&bootstrapGcpCmd.CodesphereEnv.CustomPgIP, "custom-pg-ip", "", "Custom PostgreSQL IP (optional)")
 	flags.StringVar(&bootstrapGcpCmd.CodesphereEnv.Region, "region", "europe-west4", "GCP Region (default: europe-west4)")
 	flags.StringVar(&bootstrapGcpCmd.CodesphereEnv.Zone, "zone", "europe-west4-a", "GCP Zone (default: europe-west4-a)")

--- a/cli/cmd/create_test_user.go
+++ b/cli/cmd/create_test_user.go
@@ -65,6 +65,7 @@ func AddCreateTestUserCmd(parent *cobra.Command, opts *GlobalOptions) {
 	flags.StringVar(&c.Opts.Password, "postgres-password", "", "PostgreSQL password (required)")
 	flags.StringVar(&c.Opts.DBName, "postgres-db", testuser.DefaultDBName, "PostgreSQL database name")
 	flags.StringVar(&c.Opts.SSLMode, "ssl-mode", testuser.DefaultSSLMode, "PostgreSQL SSL mode")
+	flags.IntVar(&c.Opts.DatacenterID, "datacenter-id", 1, "Datacenter ID for the created test team")
 
 	util.MarkFlagRequired(c.cmd, "postgres-host")
 	util.MarkFlagRequired(c.cmd, "postgres-password")

--- a/docs/oms_beta_bootstrap-gcp.md
+++ b/docs/oms_beta_bootstrap-gcp.md
@@ -26,6 +26,7 @@ oms beta bootstrap-gcp [flags]
       --create-test-user                        Create a test user with API token on the bootstrapped instance for smoke testing (default: false)
       --custom-pg-ip string                     Custom PostgreSQL IP (optional)
       --datacenter-id int                       Datacenter ID (default: 1) (default 1)
+      --datacenter-name string                  Datacenter name (default: dev) (default "dev")
       --dns-project-id string                   GCP Project ID for Cloud DNS (optional)
       --dns-zone-name string                    Cloud DNS Zone Name (optional) (default "oms-testing")
       --experiments stringArray                 Experiments to enable in Codesphere installation (optional) (default [managed-services,headless-services,vcluster,custom-service-image,ms-in-ls,secret-management,sub-path-mount])

--- a/docs/oms_create_test-user.md
+++ b/docs/oms_create_test-user.md
@@ -23,6 +23,7 @@ oms create test-user [flags]
 ### Options
 
 ```
+      --datacenter-id int          Datacenter ID for the created test team (default 1)
   -h, --help                       help for test-user
       --postgres-db string         PostgreSQL database name (default "codesphere")
       --postgres-host string       PostgreSQL host address (required)

--- a/internal/bootstrap/gcp/gcp.go
+++ b/internal/bootstrap/gcp/gcp.go
@@ -151,6 +151,7 @@ type CodesphereEnvironment struct {
 	SSHPublicKeyPath           string `json:"-"`
 	SSHPrivateKeyPath          string `json:"-"`
 	DatacenterID               int    `json:"-"`
+	DatacenterName             string `json:"-"`
 	CustomPgIP                 string `json:"custom_pg_ip"`
 	Region                     string `json:"region"`
 	Zone                       string `json:"zone"`
@@ -359,12 +360,13 @@ func (b *GCPBootstrapper) createTestUser() error {
 	}
 
 	result, err := testuser.CreateTestUser(testuser.CreateTestUserOpts{
-		Host:     pgHost,
-		Port:     testuser.DefaultPort,
-		User:     testuser.DefaultUser,
-		Password: pgPassword,
-		DBName:   testuser.DefaultDBName,
-		SSLMode:  "require",
+		Host:         pgHost,
+		Port:         testuser.DefaultPort,
+		User:         testuser.DefaultUser,
+		Password:     pgPassword,
+		DBName:       testuser.DefaultDBName,
+		SSLMode:      "require",
+		DatacenterID: b.Env.DatacenterID,
 	})
 	if err != nil {
 		return err

--- a/internal/bootstrap/gcp/install_config.go
+++ b/internal/bootstrap/gcp/install_config.go
@@ -100,6 +100,10 @@ func (b *GCPBootstrapper) recoverVault() error {
 func (b *GCPBootstrapper) UpdateInstallConfig() error {
 	// Update install config with necessary values
 	b.Env.InstallConfig.Datacenter.ID = b.Env.DatacenterID
+	if b.Env.DatacenterName == "" {
+		b.Env.DatacenterName = "dev"
+	}
+	b.Env.InstallConfig.Datacenter.Name = b.Env.DatacenterName
 	b.Env.InstallConfig.Datacenter.City = "Karlsruhe"
 	b.Env.InstallConfig.Datacenter.CountryCode = "DE"
 	b.Env.InstallConfig.Secrets.BaseDir = b.Env.SecretsDir

--- a/internal/bootstrap/gcp/install_config_test.go
+++ b/internal/bootstrap/gcp/install_config_test.go
@@ -85,6 +85,7 @@ var _ = Describe("Installconfig & Secrets", func() {
 			Region:                "us-central1",
 			Zone:                  "us-central1-a",
 			DatacenterID:          1,
+			DatacenterName:        "dev",
 			BaseDomain:            "example.com",
 			DNSProjectID:          "dns-project",
 			DNSZoneName:           "test-zone",
@@ -321,6 +322,7 @@ var _ = Describe("Installconfig & Secrets", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(bs.Env.InstallConfig.Datacenter.ID).To(Equal(1))
+				Expect(bs.Env.InstallConfig.Datacenter.Name).To(Equal("dev"))
 				Expect(bs.Env.InstallConfig.Codesphere.Domain).To(Equal("cs.example.com"))
 				Expect(bs.Env.InstallConfig.Codesphere.Features).To(Equal(map[string]bool{}))
 				Expect(bs.Env.InstallConfig.Codesphere.Experiments).To(Equal(gcp.DefaultExperiments))
@@ -342,6 +344,20 @@ var _ = Describe("Installconfig & Secrets", func() {
 				Expect(cloudDns["project"]).To(Equal(bs.Env.DNSProjectID))
 
 				Expect(bs.Env.InstallConfig.Codesphere.OpenBao).To(BeNil())
+			})
+			It("uses the configured datacenter name", func() {
+				csEnv.DatacenterName = "staging"
+
+				icg.EXPECT().GenerateSecrets().Return(nil)
+				icg.EXPECT().WriteInstallConfig("fake-config-file", true).Return(nil)
+				icg.EXPECT().WriteVault("fake-secret", true).Return(nil)
+
+				nodeClient.EXPECT().CopyFile(mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
+
+				err := bs.UpdateInstallConfig()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(bs.Env.InstallConfig.Datacenter.Name).To(Equal("staging"))
 			})
 			Context("When Experiments are set in CodesphereEnvironment", func() {
 				BeforeEach(func() {

--- a/internal/testuser/testuser.go
+++ b/internal/testuser/testuser.go
@@ -24,20 +24,22 @@ const (
 	tokenPrefix  = "CS_"
 
 	// Default connection parameters.
-	DefaultPort    = 5432
-	DefaultUser    = "postgres"
-	DefaultDBName  = "codesphere"
-	DefaultSSLMode = "disable"
+	DefaultPort         = 5432
+	DefaultUser         = "postgres"
+	DefaultDBName       = "codesphere"
+	DefaultSSLMode      = "disable"
+	DefaultDatacenterID = 1
 )
 
 // CreateTestUserOpts contains the options for creating a test user.
 type CreateTestUserOpts struct {
-	Host     string
-	Port     int
-	User     string
-	Password string
-	DBName   string
-	SSLMode  string
+	Host         string
+	Port         int
+	User         string
+	Password     string
+	DBName       string
+	SSLMode      string
+	DatacenterID int
 }
 
 // TestUserResult contains the result of creating a test user.
@@ -67,6 +69,9 @@ func New(opts CreateTestUserOpts) (*TestUserCreator, error) {
 	}
 	if opts.SSLMode == "" {
 		opts.SSLMode = DefaultSSLMode
+	}
+	if opts.DatacenterID == 0 {
+		opts.DatacenterID = DefaultDatacenterID
 	}
 	if opts.Host == "" {
 		return nil, fmt.Errorf("host is required")
@@ -238,12 +243,16 @@ func (c *TestUserCreator) insertEmailConfirmation(tx *sql.Tx) error {
 
 func (c *TestUserCreator) insertTeam(tx *sql.Tx) (int, error) {
 	var teamID int
+	datacenterID := c.opts.DatacenterID
+	if datacenterID == 0 {
+		datacenterID = DefaultDatacenterID
+	}
 	err := tx.QueryRow(`
 		INSERT INTO "teamService".teams
 			(id, "name", description, first_team, default_data_center_id, deleted, deletion_pending, created_at)
-		VALUES(nextval('"teamService".teams_id_seq'::regclass), $1, '', true, 1, false, false, CURRENT_TIMESTAMP)
+		VALUES(nextval('"teamService".teams_id_seq'::regclass), $1, '', true, $2, false, false, CURRENT_TIMESTAMP)
 		RETURNING id`,
-		TestTeamName,
+		TestTeamName, datacenterID,
 	).Scan(&teamID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to insert team: %w", err)

--- a/internal/testuser/testuser_test.go
+++ b/internal/testuser/testuser_test.go
@@ -133,7 +133,7 @@ var _ = Describe("createInDB", func() {
 
 		// Expect: insert team
 		m.ExpectQuery(`INSERT INTO "teamService".teams`).
-			WithArgs(TestTeamName).
+			WithArgs(TestTeamName, DefaultDatacenterID).
 			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(7))
 
 		// Expect: insert team member
@@ -208,13 +208,46 @@ var _ = Describe("createInDB", func() {
 			WithArgs(TestEmail).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		m.ExpectQuery(`INSERT INTO "teamService".teams`).
-			WithArgs(TestTeamName).
+			WithArgs(TestTeamName, DefaultDatacenterID).
 			WillReturnError(fmt.Errorf("db error"))
 		m.ExpectRollback()
 
 		_, err = (&TestUserCreator{opts: CreateTestUserOpts{Host: "test", Password: "test"}, db: sqlDB, email: TestEmail}).createInDB(hashedPassword, hashedToken)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to insert team"))
+		Expect(m.ExpectationsWereMet()).NotTo(HaveOccurred())
+	})
+
+	It("uses a custom datacenter ID for the created team", func() {
+		sqlDB, m, err := sqlmock.New()
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = sqlDB.Close() }()
+
+		m.ExpectQuery(`SELECT EXISTS`).
+			WithArgs(TestEmail).
+			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+		m.ExpectBegin()
+		m.ExpectQuery(`INSERT INTO authservice.credentials`).
+			WithArgs(TestEmail, hashedPassword).
+			WillReturnRows(sqlmock.NewRows([]string{"user_id"}).AddRow(42))
+		m.ExpectExec(`INSERT INTO authservice.email_confirmations`).
+			WithArgs(TestEmail).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		m.ExpectQuery(`INSERT INTO "teamService".teams`).
+			WithArgs(TestTeamName, 77).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(7))
+		m.ExpectExec(`INSERT INTO "teamService".team_members`).
+			WithArgs(42, 7).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		m.ExpectExec(`INSERT INTO public_api_service.tokens`).
+			WithArgs(hashedToken, 42).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		m.ExpectCommit()
+
+		result, err := (&TestUserCreator{opts: CreateTestUserOpts{Host: "test", Password: "test", DatacenterID: 77}, db: sqlDB, email: TestEmail}).createInDB(hashedPassword, hashedToken)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Email).To(Equal(TestEmail))
 		Expect(m.ExpectationsWereMet()).NotTo(HaveOccurred())
 	})
 })

--- a/internal/tmpl/NOTICE
+++ b/internal/tmpl/NOTICE
@@ -23,9 +23,9 @@ License URL: https://github.com/googleapis/google-cloud-go/blob/auth/oauth2adapt
  
 ----------
 Module: cloud.google.com/go/compute
-Version: v1.62.0
+Version: v1.63.0
 License: Apache-2.0
-License URL: https://github.com/googleapis/google-cloud-go/blob/compute/v1.62.0/compute/LICENSE
+License URL: https://github.com/googleapis/google-cloud-go/blob/compute/v1.63.0/compute/LICENSE
  
 ----------
 Module: cloud.google.com/go/compute/metadata
@@ -41,21 +41,21 @@ License URL: https://github.com/googleapis/google-cloud-go/blob/iam/v1.11.0/iam/
  
 ----------
 Module: cloud.google.com/go/longrunning
-Version: v0.9.0
+Version: v0.11.0
 License: Apache-2.0
-License URL: https://github.com/googleapis/google-cloud-go/blob/longrunning/v0.9.0/longrunning/LICENSE
+License URL: https://github.com/googleapis/google-cloud-go/blob/longrunning/v0.11.0/longrunning/LICENSE
  
 ----------
 Module: cloud.google.com/go/resourcemanager
-Version: v1.14.0
+Version: v1.15.0
 License: Apache-2.0
-License URL: https://github.com/googleapis/google-cloud-go/blob/resourcemanager/v1.14.0/resourcemanager/LICENSE
+License URL: https://github.com/googleapis/google-cloud-go/blob/resourcemanager/v1.15.0/resourcemanager/LICENSE
  
 ----------
 Module: cloud.google.com/go/serviceusage
-Version: v1.13.0
+Version: v1.14.0
 License: Apache-2.0
-License URL: https://github.com/googleapis/google-cloud-go/blob/serviceusage/v1.13.0/serviceusage/LICENSE
+License URL: https://github.com/googleapis/google-cloud-go/blob/serviceusage/v1.14.0/serviceusage/LICENSE
  
 ----------
 Module: code.gitea.io/sdk/gitea
@@ -215,9 +215,9 @@ License URL: https://github.com/cloudnative-pg/machinery/blob/v0.3.3/LICENSE
  
 ----------
 Module: github.com/codesphere-cloud/cs-go
-Version: v1.0.1
+Version: v1.1.0
 License: Apache-2.0
-License URL: https://github.com/codesphere-cloud/cs-go/blob/v1.0.1/LICENSE
+License URL: https://github.com/codesphere-cloud/cs-go/blob/v1.1.0/LICENSE
    
 ----------
 Module: github.com/codesphere-cloud/oms/internal/tmpl
@@ -329,9 +329,9 @@ License URL: https://github.com/getsops/gopgagent/blob/7044f28e491e/LICENSE
  
 ----------
 Module: github.com/getsops/sops/v3
-Version: v3.12.2
+Version: v3.13.0
 License: MPL-2.0
-License URL: https://github.com/getsops/sops/blob/v3.12.2/LICENSE
+License URL: https://github.com/getsops/sops/blob/v3.13.0/LICENSE
  
 ----------
 Module: github.com/go-errors/errors
@@ -737,9 +737,9 @@ License URL: https://github.com/mattn/go-colorable/blob/v0.1.14/LICENSE
  
 ----------
 Module: github.com/mattn/go-isatty
-Version: v0.0.20
+Version: v0.0.22
 License: MIT
-License URL: https://github.com/mattn/go-isatty/blob/v0.0.20/LICENSE
+License URL: https://github.com/mattn/go-isatty/blob/v0.0.22/LICENSE
  
 ----------
 Module: github.com/mattn/go-runewidth
@@ -1025,27 +1025,27 @@ License URL: https://github.com/open-telemetry/opentelemetry-go-instrumentation/
  
 ----------
 Module: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
-Version: v0.67.0
+Version: v0.68.0
 License: Apache-2.0
-License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/google.golang.org/grpc/otelgrpc/v0.67.0/instrumentation/google.golang.org/grpc/otelgrpc/LICENSE
+License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/google.golang.org/grpc/otelgrpc/v0.68.0/instrumentation/google.golang.org/grpc/otelgrpc/LICENSE
  
 ----------
 Module: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
-Version: v0.67.0
+Version: v0.68.0
 License: BSD-3-Clause
-License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/google.golang.org/grpc/otelgrpc/v0.67.0/instrumentation/google.golang.org/grpc/otelgrpc/LICENSE
+License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/google.golang.org/grpc/otelgrpc/v0.68.0/instrumentation/google.golang.org/grpc/otelgrpc/LICENSE
  
 ----------
 Module: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
-Version: v0.67.0
+Version: v0.68.0
 License: Apache-2.0
-License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/otelhttp/v0.67.0/instrumentation/net/http/otelhttp/LICENSE
+License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/otelhttp/v0.68.0/instrumentation/net/http/otelhttp/LICENSE
  
 ----------
 Module: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
-Version: v0.67.0
+Version: v0.68.0
 License: BSD-3-Clause
-License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/otelhttp/v0.67.0/instrumentation/net/http/otelhttp/LICENSE
+License URL: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/otelhttp/v0.68.0/instrumentation/net/http/otelhttp/LICENSE
  
 ----------
 Module: go.opentelemetry.io/otel
@@ -1187,15 +1187,15 @@ License URL: https://github.com/googleapis/google-api-go-client/blob/v0.277.0/in
  
 ----------
 Module: google.golang.org/genproto/googleapis
-Version: v0.0.0-20260319201613-d00831a3d3e7
+Version: v0.0.0-20260427160629-7cedc36a6bc4
 License: Apache-2.0
-License URL: https://github.com/googleapis/go-genproto/blob/d00831a3d3e7/LICENSE
+License URL: https://github.com/googleapis/go-genproto/blob/7cedc36a6bc4/LICENSE
  
 ----------
 Module: google.golang.org/genproto/googleapis/api
-Version: v0.0.0-20260401024825-9d38bb4040a9
+Version: v0.0.0-20260427160629-7cedc36a6bc4
 License: Apache-2.0
-License URL: https://github.com/googleapis/go-genproto/blob/9d38bb4040a9/googleapis/api/LICENSE
+License URL: https://github.com/googleapis/go-genproto/blob/7cedc36a6bc4/googleapis/api/LICENSE
  
 ----------
 Module: google.golang.org/genproto/googleapis/rpc
@@ -1205,9 +1205,9 @@ License URL: https://github.com/googleapis/go-genproto/blob/7cedc36a6bc4/googlea
  
 ----------
 Module: google.golang.org/grpc
-Version: v1.81.0
+Version: v1.81.1
 License: Apache-2.0
-License URL: https://github.com/grpc/grpc-go/blob/v1.81.0/LICENSE
+License URL: https://github.com/grpc/grpc-go/blob/v1.81.1/LICENSE
  
 ----------
 Module: google.golang.org/protobuf


### PR DESCRIPTION
The test-user is always created with the hardcoded datacenterId 1.
But the datacenter is configurable e.g. in the gcp bootstrap. This PR makes the user-creation use the correct datacenter