### PR TITLE
feat(gcp-bootstrap): add option to deploy on gcp using google's acme service

### DIFF
--- a/cli/cmd/bootstrap_gcp.go
+++ b/cli/cmd/bootstrap_gcp.go
@@ -113,6 +113,8 @@ func AddBootstrapGcpCmd(parent *cobra.Command, opts *GlobalOptions) {
 	flags.BoolVar(&bootstrapGcpCmd.CodesphereEnv.CreateTestUser, "create-test-user", false, "Create a test user with API token on the bootstrapped instance for smoke testing (default: false)")
 	flags.Int64Var(&bootstrapGcpCmd.CodesphereEnv.RootDiskSize, "root-disk-size", 50, "Instance root disk size in GB (default: 50)")
 
+	flags.BoolVar(&bootstrapGcpCmd.CodesphereEnv.GoogleACMEIssuer, "google-acme-issuer", false, "Use Google Public CA as the ACME issuer instead of Let's Encrypt. External Account Binding credentials are obtained automatically via the publicca API (default: false)")
+
 	flags.StringVar(&bootstrapGcpCmd.CodesphereEnv.OpenBaoURI, "openbao-uri", "", "URI for OpenBao (optional)")
 	flags.StringVar(&bootstrapGcpCmd.CodesphereEnv.OpenBaoEngine, "openbao-engine", "cs-secrets-engine", "OpenBao engine name (default: cs-secrets-engine)")
 	flags.StringVar(&bootstrapGcpCmd.CodesphereEnv.OpenBaoUser, "openbao-user", "admin", "OpenBao username (optional)")

--- a/docs/oms_beta_bootstrap-gcp.md
+++ b/docs/oms_beta_bootstrap-gcp.md
@@ -45,6 +45,7 @@ oms beta bootstrap-gcp [flags]
       --github-team-slug string                 GitHub team slug used to fetch team SSH keys (optional, used with --github-team-org). Requires --github-pat with at least the read:org scope.
       --gitlab-app-client-id string             GitLab App Client ID (optional)
       --gitlab-app-client-secret string         GitLab App Client Secret (optional)
+      --google-acme-issuer                      Use Google Public CA as the ACME issuer instead of Let's Encrypt. External Account Binding credentials are obtained automatically via the publicca API (default: false)
   -h, --help                                    help for bootstrap-gcp
       --install-config string                   Path to install config file (optional) (default "config.yaml")
       --install-hash string                     Codesphere package hash to install (default: none)

--- a/internal/bootstrap/gcp/gcp.go
+++ b/internal/bootstrap/gcp/gcp.go
@@ -120,6 +120,9 @@ type CodesphereEnvironment struct {
 	ExternalLokiSecret   string          `json:"-"`
 	ExternalLokiUser     string          `json:"external_loki_user,omitempty"`
 
+	// ACME Issuer
+	GoogleACMEIssuer bool `json:"google_acme_issuer,omitempty"`
+
 	// OpenBao
 	OpenBaoURI      string `json:"-"`
 	OpenBaoEngine   string `json:"-"`

--- a/internal/bootstrap/gcp/gcp_client.go
+++ b/internal/bootstrap/gcp/gcp_client.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/api/dns/v1"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/iterator"
+	publicca "google.golang.org/api/publicca/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -61,6 +62,7 @@ type GCPClientManager interface {
 	EnsureDNSManagedZone(projectID, zoneName, dnsName, description string) error
 	EnsureDNSRecordSets(projectID, zoneName string, records []*dns.ResourceRecordSet) error
 	DeleteDNSRecordSets(projectID, zoneName, baseDomain string) error
+	CreatePublicCAExternalAccountKey(projectID string) (keyID, b64MacKey string, err error)
 }
 
 // Concrete implementation
@@ -853,6 +855,23 @@ func (c *GCPClient) DeleteDNSRecordSets(projectID, zoneName, baseDomain string) 
 		return fmt.Errorf("failed to delete DNS records: %w", err)
 	}
 	return nil
+}
+
+// CreatePublicCAExternalAccountKey requests a fresh External Account Binding
+// key pair from the Google Public CA, used to register an ACME account against
+// https://dv.acme-v02.api.pki.goog/directory. The publicca.googleapis.com API
+// must be enabled on the project.
+func (c *GCPClient) CreatePublicCAExternalAccountKey(projectID string) (string, string, error) {
+	svc, err := publicca.NewService(c.ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create publicca client: %w", err)
+	}
+	parent := fmt.Sprintf("projects/%s/locations/global", projectID)
+	key, err := svc.Projects.Locations.ExternalAccountKeys.Create(parent, &publicca.ExternalAccountKey{}).Context(c.ctx).Do()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create public CA external account key: %w", err)
+	}
+	return key.KeyId, key.B64MacKey, nil
 }
 
 // Helper functions

--- a/internal/bootstrap/gcp/iam_admin.go
+++ b/internal/bootstrap/gcp/iam_admin.go
@@ -165,6 +165,9 @@ func (b *GCPBootstrapper) EnsureAPIsEnabled() error {
 		"artifactregistry.googleapis.com",
 		"dns.googleapis.com",
 	}
+	if b.Env.GoogleACMEIssuer {
+		apis = append(apis, "publicca.googleapis.com")
+	}
 
 	err := b.GCPClient.EnableAPIs(b.Env.ProjectID, apis)
 	if err != nil {

--- a/internal/bootstrap/gcp/install_config.go
+++ b/internal/bootstrap/gcp/install_config.go
@@ -194,7 +194,7 @@ func (b *GCPBootstrapper) UpdateInstallConfig() error {
 	b.Env.InstallConfig.Cluster.Certificates.Override = map[string]interface{}{
 		"issuers": map[string]interface{}{
 			"letsEncryptHttp": map[string]interface{}{
-				"enabled": true,
+				"enabled": !b.Env.GoogleACMEIssuer,
 			},
 			"acme": map[string]interface{}{
 				"dnsSolver": map[string]interface{}{
@@ -207,12 +207,22 @@ func (b *GCPBootstrapper) UpdateInstallConfig() error {
 			},
 		},
 	}
+	acmeConfig := &files.ACMEConfig{
+		Email:  "oms-testing@" + b.Env.BaseDomain,
+		Server: "https://acme-v02.api.letsencrypt.org/directory",
+	}
+	if b.Env.GoogleACMEIssuer {
+		keyID, b64MacKey, err := b.GCPClient.CreatePublicCAExternalAccountKey(b.Env.ProjectID)
+		if err != nil {
+			return fmt.Errorf("failed to obtain Google Public CA EAB credentials: %w", err)
+		}
+		acmeConfig.Server = "https://dv.acme-v02.api.pki.goog/directory"
+		acmeConfig.EABKeyID = keyID
+		acmeConfig.EABMacKey = b64MacKey
+	}
 	b.Env.InstallConfig.Codesphere.CertIssuer = files.CertIssuerConfig{
 		Type: "acme",
-		Acme: &files.ACMEConfig{
-			Email:  "oms-testing@" + b.Env.BaseDomain,
-			Server: "https://acme-v02.api.letsencrypt.org/directory",
-		},
+		Acme: acmeConfig,
 	}
 
 	b.Env.InstallConfig.Codesphere.Domain = "cs." + b.Env.BaseDomain

--- a/internal/bootstrap/gcp/install_config_test.go
+++ b/internal/bootstrap/gcp/install_config_test.go
@@ -672,6 +672,37 @@ var _ = Describe("Installconfig & Secrets", func() {
 				})
 			})
 
+			Context("When Google ACME issuer is enabled", func() {
+				BeforeEach(func() {
+					csEnv.GoogleACMEIssuer = true
+				})
+				It("requests EAB credentials from Public CA and uses them in the ACME config", func() {
+					gc.EXPECT().CreatePublicCAExternalAccountKey(mock.Anything).Return("fake-eab-key-id", "fake-eab-mac-key", nil)
+					icg.EXPECT().GenerateSecrets().Return(nil)
+					icg.EXPECT().WriteInstallConfig("fake-config-file", true).Return(nil)
+					icg.EXPECT().WriteVault("fake-secret", true).Return(nil)
+					nodeClient.EXPECT().CopyFile(mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
+
+					err := bs.UpdateInstallConfig()
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(bs.Env.InstallConfig.Codesphere.CertIssuer.Acme.Server).To(Equal("https://dv.acme-v02.api.pki.goog/directory"))
+					Expect(bs.Env.InstallConfig.Codesphere.CertIssuer.Acme.EABKeyID).To(Equal("fake-eab-key-id"))
+					Expect(bs.Env.InstallConfig.Codesphere.CertIssuer.Acme.EABMacKey).To(Equal("fake-eab-mac-key"))
+
+					issuers := bs.Env.InstallConfig.Cluster.Certificates.Override["issuers"].(map[string]interface{})
+					httpIssuer := issuers["letsEncryptHttp"].(map[string]interface{})
+					Expect(httpIssuer["enabled"]).To(Equal(false))
+				})
+				It("returns an error when the publicca API call fails", func() {
+					gc.EXPECT().CreatePublicCAExternalAccountKey(mock.Anything).Return("", "", fmt.Errorf("api boom"))
+
+					err := bs.UpdateInstallConfig()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("failed to obtain Google Public CA EAB credentials"))
+				})
+			})
+
 			Context("When OpenBao config is set", func() {
 				BeforeEach(func() {
 					csEnv.OpenBaoURI = "https://openbao.example.com"

--- a/internal/bootstrap/gcp/mocks.go
+++ b/internal/bootstrap/gcp/mocks.go
@@ -504,6 +504,72 @@ func (_c *MockGCPClientManager_CreateProjectID_Call) RunAndReturn(run func(proje
 	return _c
 }
 
+// CreatePublicCAExternalAccountKey provides a mock function for the type MockGCPClientManager
+func (_mock *MockGCPClientManager) CreatePublicCAExternalAccountKey(projectID string) (string, string, error) {
+	ret := _mock.Called(projectID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreatePublicCAExternalAccountKey")
+	}
+
+	var r0 string
+	var r1 string
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(string) (string, string, error)); ok {
+		return returnFunc(projectID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) string); ok {
+		r0 = returnFunc(projectID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) string); ok {
+		r1 = returnFunc(projectID)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+	if returnFunc, ok := ret.Get(2).(func(string) error); ok {
+		r2 = returnFunc(projectID)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockGCPClientManager_CreatePublicCAExternalAccountKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreatePublicCAExternalAccountKey'
+type MockGCPClientManager_CreatePublicCAExternalAccountKey_Call struct {
+	*mock.Call
+}
+
+// CreatePublicCAExternalAccountKey is a helper method to define mock.On call
+//   - projectID string
+func (_e *MockGCPClientManager_Expecter) CreatePublicCAExternalAccountKey(projectID interface{}) *MockGCPClientManager_CreatePublicCAExternalAccountKey_Call {
+	return &MockGCPClientManager_CreatePublicCAExternalAccountKey_Call{Call: _e.mock.On("CreatePublicCAExternalAccountKey", projectID)}
+}
+
+func (_c *MockGCPClientManager_CreatePublicCAExternalAccountKey_Call) Run(run func(projectID string)) *MockGCPClientManager_CreatePublicCAExternalAccountKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGCPClientManager_CreatePublicCAExternalAccountKey_Call) Return(keyID string, b64MacKey string, err error) *MockGCPClientManager_CreatePublicCAExternalAccountKey_Call {
+	_c.Call.Return(keyID, b64MacKey, err)
+	return _c
+}
+
+func (_c *MockGCPClientManager_CreatePublicCAExternalAccountKey_Call) RunAndReturn(run func(projectID string) (string, string, error)) *MockGCPClientManager_CreatePublicCAExternalAccountKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateServiceAccount provides a mock function for the type MockGCPClientManager
 func (_mock *MockGCPClientManager) CreateServiceAccount(projectID string, name string, displayName string) (string, bool, error) {
 	ret := _mock.Called(projectID, name, displayName)


### PR DESCRIPTION
Adds support to enable and use google's offered acme service as described in their guide: https://docs.cloud.google.com/certificate-manager/docs/public-ca-tutorial

Using that service offer higher rate limits.