### PR TITLE
fix: add eab key and config to the correct expected places

### DIFF
--- a/cli/cmd/init_install_config.go
+++ b/cli/cmd/init_install_config.go
@@ -420,31 +420,32 @@ func (c *InitInstallConfigCmd) updateConfigFromOpts(config *files.RootConfig) *f
 
 	// ACME configuration
 	if c.Opts.ACMEEnabled {
-		if config.Cluster.Certificates.ACME == nil {
-			config.Cluster.Certificates.ACME = &files.ACMEConfig{}
+		if config.Codesphere.CertIssuer.Acme == nil {
+			config.Codesphere.CertIssuer.Acme = &files.ACMEConfig{}
 		}
-		config.Cluster.Certificates.ACME.Enabled = true
+		config.Codesphere.CertIssuer.Type = files.CertIssuerTypeACME
+		config.Codesphere.CertIssuer.Acme.Enabled = true
 
 		if c.Opts.ACMEIssuerName != "" {
-			config.Cluster.Certificates.ACME.Name = c.Opts.ACMEIssuerName
+			config.Codesphere.CertIssuer.Acme.Name = c.Opts.ACMEIssuerName
 		}
 		if c.Opts.ACMEEmail != "" {
-			config.Cluster.Certificates.ACME.Email = c.Opts.ACMEEmail
+			config.Codesphere.CertIssuer.Acme.Email = c.Opts.ACMEEmail
 		}
 		if c.Opts.ACMEServer != "" {
-			config.Cluster.Certificates.ACME.Server = c.Opts.ACMEServer
+			config.Codesphere.CertIssuer.Acme.Server = c.Opts.ACMEServer
 		}
 
 		if c.Opts.ACMEEABKeyID != "" {
-			config.Cluster.Certificates.ACME.EABKeyID = c.Opts.ACMEEABKeyID
+			config.Codesphere.CertIssuer.Acme.EABKeyID = c.Opts.ACMEEABKeyID
 		}
 		if c.Opts.ACMEEABMacKey != "" {
-			config.Cluster.Certificates.ACME.EABMacKey = c.Opts.ACMEEABMacKey
+			config.Codesphere.CertIssuer.Acme.EABMacKey = c.Opts.ACMEEABMacKey
 		}
 
 		// Configure DNS-01 solver
 		if c.Opts.ACMEDNS01Provider != "" {
-			config.Cluster.Certificates.ACME.Solver.DNS01 = &files.ACMEDNS01Solver{
+			config.Codesphere.CertIssuer.Acme.Solver.DNS01 = &files.ACMEDNS01Solver{
 				Provider: c.Opts.ACMEDNS01Provider,
 			}
 		}

--- a/cli/cmd/update_install_config.go
+++ b/cli/cmd/update_install_config.go
@@ -290,55 +290,61 @@ func (c *UpdateInstallConfigCmd) applyACMEUpdates(config *files.RootConfig, trac
 	}
 
 	acmeChanged := false
-	if config.Cluster.Certificates.ACME == nil {
-		config.Cluster.Certificates.ACME = &files.ACMEConfig{}
+	if config.Codesphere.CertIssuer.Acme == nil {
+		config.Codesphere.CertIssuer.Acme = &files.ACMEConfig{}
 	}
 
-	if !config.Cluster.Certificates.ACME.Enabled {
+	if config.Codesphere.CertIssuer.Type != files.CertIssuerTypeACME {
+		log.Printf("Setting cert issuer type to ACME\n")
+		config.Codesphere.CertIssuer.Type = files.CertIssuerTypeACME
+		acmeChanged = true
+	}
+
+	if !config.Codesphere.CertIssuer.Acme.Enabled {
 		log.Printf("Enabling ACME certificate issuer\n")
-		config.Cluster.Certificates.ACME.Enabled = true
+		config.Codesphere.CertIssuer.Acme.Enabled = true
 		acmeChanged = true
 	}
 
-	if c.Opts.ACMEIssuerName != "" && config.Cluster.Certificates.ACME.Name != c.Opts.ACMEIssuerName {
-		log.Printf("Updating ACME issuer name: %s -> %s\n", config.Cluster.Certificates.ACME.Name, c.Opts.ACMEIssuerName)
-		config.Cluster.Certificates.ACME.Name = c.Opts.ACMEIssuerName
+	if c.Opts.ACMEIssuerName != "" && config.Codesphere.CertIssuer.Acme.Name != c.Opts.ACMEIssuerName {
+		log.Printf("Updating ACME issuer name: %s -> %s\n", config.Codesphere.CertIssuer.Acme.Name, c.Opts.ACMEIssuerName)
+		config.Codesphere.CertIssuer.Acme.Name = c.Opts.ACMEIssuerName
 		acmeChanged = true
 	}
 
-	if c.Opts.ACMEEmail != "" && config.Cluster.Certificates.ACME.Email != c.Opts.ACMEEmail {
-		log.Printf("Updating ACME email: %s -> %s\n", config.Cluster.Certificates.ACME.Email, c.Opts.ACMEEmail)
-		config.Cluster.Certificates.ACME.Email = c.Opts.ACMEEmail
+	if c.Opts.ACMEEmail != "" && config.Codesphere.CertIssuer.Acme.Email != c.Opts.ACMEEmail {
+		log.Printf("Updating ACME email: %s -> %s\n", config.Codesphere.CertIssuer.Acme.Email, c.Opts.ACMEEmail)
+		config.Codesphere.CertIssuer.Acme.Email = c.Opts.ACMEEmail
 		acmeChanged = true
 	}
 
-	if c.Opts.ACMEServer != "" && config.Cluster.Certificates.ACME.Server != c.Opts.ACMEServer {
-		log.Printf("Updating ACME server: %s -> %s\n", config.Cluster.Certificates.ACME.Server, c.Opts.ACMEServer)
-		config.Cluster.Certificates.ACME.Server = c.Opts.ACMEServer
+	if c.Opts.ACMEServer != "" && config.Codesphere.CertIssuer.Acme.Server != c.Opts.ACMEServer {
+		log.Printf("Updating ACME server: %s -> %s\n", config.Codesphere.CertIssuer.Acme.Server, c.Opts.ACMEServer)
+		config.Codesphere.CertIssuer.Acme.Server = c.Opts.ACMEServer
 		acmeChanged = true
 	}
 
-	if c.Opts.ACMEEABKeyID != "" && config.Cluster.Certificates.ACME.EABKeyID != c.Opts.ACMEEABKeyID {
-		log.Printf("Updating ACME EAB key ID: %s -> %s\n", config.Cluster.Certificates.ACME.EABKeyID, c.Opts.ACMEEABKeyID)
-		config.Cluster.Certificates.ACME.EABKeyID = c.Opts.ACMEEABKeyID
+	if c.Opts.ACMEEABKeyID != "" && config.Codesphere.CertIssuer.Acme.EABKeyID != c.Opts.ACMEEABKeyID {
+		log.Printf("Updating ACME EAB key ID: %s -> %s\n", config.Codesphere.CertIssuer.Acme.EABKeyID, c.Opts.ACMEEABKeyID)
+		config.Codesphere.CertIssuer.Acme.EABKeyID = c.Opts.ACMEEABKeyID
 		acmeChanged = true
 	}
 
-	if c.Opts.ACMEEABMacKey != "" && config.Cluster.Certificates.ACME.EABMacKey != c.Opts.ACMEEABMacKey {
+	if c.Opts.ACMEEABMacKey != "" && config.Codesphere.CertIssuer.Acme.EABMacKey != c.Opts.ACMEEABMacKey {
 		log.Printf("Updating ACME EAB MAC key\n")
-		config.Cluster.Certificates.ACME.EABMacKey = c.Opts.ACMEEABMacKey
+		config.Codesphere.CertIssuer.Acme.EABMacKey = c.Opts.ACMEEABMacKey
 		acmeChanged = true
 	}
 
 	// Update DNS-01 solver configuration
 	if c.Opts.ACMEDNS01Provider != "" {
-		if config.Cluster.Certificates.ACME.Solver.DNS01 == nil {
-			config.Cluster.Certificates.ACME.Solver.DNS01 = &files.ACMEDNS01Solver{}
+		if config.Codesphere.CertIssuer.Acme.Solver.DNS01 == nil {
+			config.Codesphere.CertIssuer.Acme.Solver.DNS01 = &files.ACMEDNS01Solver{}
 		}
-		if config.Cluster.Certificates.ACME.Solver.DNS01.Provider != c.Opts.ACMEDNS01Provider {
+		if config.Codesphere.CertIssuer.Acme.Solver.DNS01.Provider != c.Opts.ACMEDNS01Provider {
 			log.Printf("Updating ACME DNS-01 provider: %s -> %s\n",
-				config.Cluster.Certificates.ACME.Solver.DNS01.Provider, c.Opts.ACMEDNS01Provider)
-			config.Cluster.Certificates.ACME.Solver.DNS01.Provider = c.Opts.ACMEDNS01Provider
+				config.Codesphere.CertIssuer.Acme.Solver.DNS01.Provider, c.Opts.ACMEDNS01Provider)
+			config.Codesphere.CertIssuer.Acme.Solver.DNS01.Provider = c.Opts.ACMEDNS01Provider
 			acmeChanged = true
 		}
 	}

--- a/internal/installer/config_generator_collector.go
+++ b/internal/installer/config_generator_collector.go
@@ -216,64 +216,66 @@ func (g *InstallConfig) collectACMEConfig(prompter *Prompter) {
 	log.Println("\n=== ACME Certificate Configuration (Optional) ===")
 
 	// Initialize ACME config if it doesn't exist
-	if g.Config.Cluster.Certificates.ACME == nil {
-		g.Config.Cluster.Certificates.ACME = &files.ACMEConfig{}
+	if g.Config.Codesphere.CertIssuer.Acme == nil {
+		g.Config.Codesphere.CertIssuer.Acme = &files.ACMEConfig{}
 	}
 
-	g.Config.Cluster.Certificates.ACME.Enabled = prompter.Bool("Enable ACME certificate issuer (e.g., Let's Encrypt)", g.Config.Cluster.Certificates.ACME.Enabled)
+	g.Config.Codesphere.CertIssuer.Acme.Enabled = prompter.Bool("Enable ACME certificate issuer (e.g., Let's Encrypt)", g.Config.Codesphere.CertIssuer.Acme.Enabled)
 
 	// Early exit if ACME is disabled
-	if !g.Config.Cluster.Certificates.ACME.Enabled {
-		g.Config.Cluster.Certificates.ACME = nil
+	if !g.Config.Codesphere.CertIssuer.Acme.Enabled {
+		g.Config.Codesphere.CertIssuer.Acme = nil
+		g.Config.Codesphere.CertIssuer.Type = files.CertIssuerTypeSelfSigned
 		return
 	}
+	g.Config.Codesphere.CertIssuer.Type = files.CertIssuerTypeACME
 
-	defaultIssuerName := g.Config.Cluster.Certificates.ACME.Name
+	defaultIssuerName := g.Config.Codesphere.CertIssuer.Acme.Name
 	if defaultIssuerName == "" {
 		defaultIssuerName = "acme-issuer"
 	}
-	g.Config.Cluster.Certificates.ACME.Name = g.collectString(prompter, "ACME issuer name", defaultIssuerName)
+	g.Config.Codesphere.CertIssuer.Acme.Name = g.collectString(prompter, "ACME issuer name", defaultIssuerName)
 
-	defaultEmail := g.Config.Cluster.Certificates.ACME.Email
+	defaultEmail := g.Config.Codesphere.CertIssuer.Acme.Email
 	if defaultEmail == "" {
 		defaultEmail = "admin@example.com"
 	}
-	g.Config.Cluster.Certificates.ACME.Email = g.collectString(prompter, "Email address for ACME account registration", defaultEmail)
+	g.Config.Codesphere.CertIssuer.Acme.Email = g.collectString(prompter, "Email address for ACME account registration", defaultEmail)
 
-	defaultServer := g.Config.Cluster.Certificates.ACME.Server
+	defaultServer := g.Config.Codesphere.CertIssuer.Acme.Server
 	if defaultServer == "" {
 		defaultServer = "https://acme-v02.api.letsencrypt.org/directory"
 	}
-	g.Config.Cluster.Certificates.ACME.Server = g.collectString(prompter, "ACME server URL", defaultServer)
+	g.Config.Codesphere.CertIssuer.Acme.Server = g.collectString(prompter, "ACME server URL", defaultServer)
 
 	// External Account Binding (EAB)
 	log.Println("\n--- External Account Binding (Optional) ---")
-	hasEAB := prompter.Bool("Configure External Account Binding (required by some ACME CAs)", g.Config.Cluster.Certificates.ACME.EABKeyID != "")
+	hasEAB := prompter.Bool("Configure External Account Binding (required by some ACME CAs)", g.Config.Codesphere.CertIssuer.Acme.EABKeyID != "")
 
-	g.Config.Cluster.Certificates.ACME.EABKeyID = ""
-	g.Config.Cluster.Certificates.ACME.EABMacKey = ""
+	g.Config.Codesphere.CertIssuer.Acme.EABKeyID = ""
+	g.Config.Codesphere.CertIssuer.Acme.EABMacKey = ""
 	if hasEAB {
-		g.Config.Cluster.Certificates.ACME.EABKeyID = g.collectString(prompter, "EAB Key ID", g.Config.Cluster.Certificates.ACME.EABKeyID)
-		g.Config.Cluster.Certificates.ACME.EABMacKey = g.collectString(prompter, "EAB MAC Key", g.Config.Cluster.Certificates.ACME.EABMacKey)
+		g.Config.Codesphere.CertIssuer.Acme.EABKeyID = g.collectString(prompter, "EAB Key ID", g.Config.Codesphere.CertIssuer.Acme.EABKeyID)
+		g.Config.Codesphere.CertIssuer.Acme.EABMacKey = g.collectString(prompter, "EAB MAC Key", g.Config.Codesphere.CertIssuer.Acme.EABMacKey)
 	}
 
 	// DNS-01 Challenge Configuration
 	log.Println("\n--- DNS-01 Challenge Configuration (Optional) ---")
-	if g.Config.Cluster.Certificates.ACME.Solver.DNS01 == nil {
-		g.Config.Cluster.Certificates.ACME.Solver.DNS01 = &files.ACMEDNS01Solver{}
+	if g.Config.Codesphere.CertIssuer.Acme.Solver.DNS01 == nil {
+		g.Config.Codesphere.CertIssuer.Acme.Solver.DNS01 = &files.ACMEDNS01Solver{}
 	}
 
-	useDNS01 := prompter.Bool("Configure DNS-01 challenge solver", g.Config.Cluster.Certificates.ACME.Solver.DNS01.Provider != "")
+	useDNS01 := prompter.Bool("Configure DNS-01 challenge solver", g.Config.Codesphere.CertIssuer.Acme.Solver.DNS01.Provider != "")
 	if !useDNS01 {
-		g.Config.Cluster.Certificates.ACME.Solver.DNS01 = nil
+		g.Config.Codesphere.CertIssuer.Acme.Solver.DNS01 = nil
 		return
 	}
 	providerOptions := []string{"route53", "cloudflare", "azure", "gcp", "other"}
-	defaultProvider := g.Config.Cluster.Certificates.ACME.Solver.DNS01.Provider
+	defaultProvider := g.Config.Codesphere.CertIssuer.Acme.Solver.DNS01.Provider
 	if defaultProvider == "" {
 		defaultProvider = "cloudflare"
 	}
-	g.Config.Cluster.Certificates.ACME.Solver.DNS01.Provider = g.collectChoice(prompter, "DNS provider", providerOptions, defaultProvider)
+	g.Config.Codesphere.CertIssuer.Acme.Solver.DNS01.Provider = g.collectChoice(prompter, "DNS provider", providerOptions, defaultProvider)
 	log.Println("Note: Additional DNS provider configuration will need to be added to the vault file.")
 	log.Println("Provider config and secrets should be added manually after generation.")
 }

--- a/internal/installer/config_manager.go
+++ b/internal/installer/config_manager.go
@@ -391,12 +391,9 @@ func (g *InstallConfig) MergeVaultIntoConfig() error {
 	}
 
 	// ACME secrets
-	if g.Config.Cluster.Certificates.ACME != nil {
-		if secret, ok := secretsMap["acmeEabKeyId"]; ok && secret.Fields != nil {
-			g.Config.Cluster.Certificates.ACME.EABKeyID = secret.Fields.Password
-		}
+	if g.Config.Codesphere.CertIssuer.Acme != nil {
 		if secret, ok := secretsMap["acmeEabMacKey"]; ok && secret.Fields != nil {
-			g.Config.Cluster.Certificates.ACME.EABMacKey = secret.Fields.Password
+			g.Config.Codesphere.CertIssuer.Acme.EABMacKey = secret.Fields.Password
 		}
 	}
 

--- a/internal/installer/files/config_yaml.go
+++ b/internal/installer/files/config_yaml.go
@@ -195,7 +195,6 @@ type ClusterConfig struct {
 
 type ClusterCertificates struct {
 	CA       CAConfig      `yaml:"ca"`
-	ACME     *ACMEConfig   `yaml:"acme,omitempty"`
 	Override ChartOverride `yaml:"override,omitempty"`
 }
 
@@ -211,9 +210,9 @@ type ACMEConfig struct {
 	Email                string     `yaml:"email,omitempty"`
 	Server               string     `yaml:"server,omitempty"`
 	PrivateKeySecretName string     `yaml:"-"`
-	Solver               ACMESolver `yaml:"solver"`
+	Solver               ACMESolver `yaml:"-"`
 
-	EABKeyID  string `yaml:"-"`
+	EABKeyID  string `yaml:"eabKeyId,omitempty"`
 	EABMacKey string `yaml:"-"`
 }
 
@@ -621,12 +620,17 @@ type S3ManagedServiceConfig struct {
 
 // Marshal serializes the RootConfig to YAML
 func (c *RootConfig) Marshal() ([]byte, error) {
+	c.buildACMEOverride()
 	return yaml.Marshal(c)
 }
 
 // Unmarshal deserializes YAML data into the RootConfig
 func (c *RootConfig) Unmarshal(data []byte) error {
-	return yaml.Unmarshal(data, c)
+	if err := yaml.Unmarshal(data, c); err != nil {
+		return err
+	}
+	c.extractACMESolverFromOverride()
+	return nil
 }
 
 func NewRootConfig() RootConfig {
@@ -837,30 +841,21 @@ func (c *RootConfig) addMonitoringSecrets(vault *InstallVault) {
 }
 
 func (c *RootConfig) addACMESecrets(vault *InstallVault) {
-	if c.Cluster.Certificates.ACME == nil || !c.Cluster.Certificates.ACME.Enabled {
+	if c.Codesphere.CertIssuer.Acme == nil || !c.Codesphere.CertIssuer.Acme.Enabled {
 		return
 	}
 
-	if c.Cluster.Certificates.ACME.EABKeyID != "" {
-		vault.Secrets = append(vault.Secrets, SecretEntry{
-			Name: "acmeEabKeyId",
-			Fields: &SecretFields{
-				Password: c.Cluster.Certificates.ACME.EABKeyID,
-			},
-		})
-	}
-
-	if c.Cluster.Certificates.ACME.EABMacKey != "" {
+	if c.Codesphere.CertIssuer.Acme.EABMacKey != "" {
 		vault.Secrets = append(vault.Secrets, SecretEntry{
 			Name: "acmeEabMacKey",
 			Fields: &SecretFields{
-				Password: c.Cluster.Certificates.ACME.EABMacKey,
+				Password: c.Codesphere.CertIssuer.Acme.EABMacKey,
 			},
 		})
 	}
 
-	if c.Cluster.Certificates.ACME.Solver.DNS01 != nil {
-		for key, value := range c.Cluster.Certificates.ACME.Solver.DNS01.Secrets {
+	if c.Codesphere.CertIssuer.Acme.Solver.DNS01 != nil {
+		for key, value := range c.Codesphere.CertIssuer.Acme.Solver.DNS01.Secrets {
 			vault.Secrets = append(vault.Secrets, SecretEntry{
 				Name: fmt.Sprintf("acmeDNS01%s", Capitalize(key)),
 				Fields: &SecretFields{
@@ -1010,4 +1005,91 @@ func Capitalize(s string) string {
 	}
 	s = strings.ReplaceAll(s, "_", "")
 	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// buildACMEOverride populates cluster.certificates.override with the ACME solver
+// configuration from codesphere.certIssuer.acme.solver, matching the documented
+// config.yaml structure.
+func (c *RootConfig) buildACMEOverride() {
+	if c.Codesphere.CertIssuer.Acme == nil || c.Codesphere.CertIssuer.Acme.Solver.DNS01 == nil {
+		return
+	}
+
+	dns01 := c.Codesphere.CertIssuer.Acme.Solver.DNS01
+
+	acmeOverride := map[string]interface{}{}
+
+	// Build dnsSolver section
+	if dns01.Provider != "" {
+		solverConfig := map[string]interface{}{}
+		if dns01.Config != nil {
+			for k, v := range dns01.Config {
+				solverConfig[k] = v
+			}
+		}
+		acmeOverride["dnsSolver"] = map[string]interface{}{
+			dns01.Provider: solverConfig,
+		}
+	}
+
+	if c.Cluster.Certificates.Override == nil {
+		c.Cluster.Certificates.Override = map[string]interface{}{}
+	}
+
+	issuers, ok := c.Cluster.Certificates.Override["issuers"].(map[string]interface{})
+	if !ok {
+		issuers = map[string]interface{}{}
+	}
+
+	// Merge with existing acme override (don't clobber user-provided fields like solverSecret)
+	existingAcme, ok := issuers["acme"].(map[string]interface{})
+	if !ok {
+		existingAcme = map[string]interface{}{}
+	}
+	for k, v := range acmeOverride {
+		existingAcme[k] = v
+	}
+
+	issuers["acme"] = existingAcme
+	c.Cluster.Certificates.Override["issuers"] = issuers
+}
+
+// extractACMESolverFromOverride populates the ACMEConfig.Solver from
+// cluster.certificates.override.issuers.acme.dnsSolver after unmarshaling.
+func (c *RootConfig) extractACMESolverFromOverride() {
+	if c.Codesphere.CertIssuer.Acme == nil {
+		return
+	}
+
+	override := c.Cluster.Certificates.Override
+	if override == nil {
+		return
+	}
+
+	issuers, ok := override["issuers"].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	acmeIssuer, ok := issuers["acme"].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	dnsSolver, ok := acmeIssuer["dnsSolver"].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	// The dnsSolver map has the provider name as key
+	for provider, cfg := range dnsSolver {
+		solver := &ACMEDNS01Solver{
+			Provider: provider,
+		}
+		if cfgMap, ok := cfg.(map[string]interface{}); ok && len(cfgMap) > 0 {
+			solver.Config = cfgMap
+		}
+		c.Codesphere.CertIssuer.Acme.Solver.DNS01 = solver
+		break // only one provider expected
+	}
 }

--- a/internal/installer/files/config_yaml_test.go
+++ b/internal/installer/files/config_yaml_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/codesphere-cloud/oms/internal/installer/files"
 )
@@ -283,6 +284,168 @@ codesphere:
 					Password: "fake-loki-password",
 				},
 			}))
+		})
+	})
+
+	Describe("ACME config structure", func() {
+		// Verifies the marshaled YAML matches the structure documented at:
+		// https://docs.codesphere.com/private-cloud/cluster-ingress-ca-options
+		It("should marshal config.yaml to the expected ACME structure", func() {
+			rootConfig.Codesphere.CertIssuer = files.CertIssuerConfig{
+				Type: files.CertIssuerTypeACME,
+				Acme: &files.ACMEConfig{
+					Enabled:   true,
+					Server:    "https://acme-v02.api.letsencrypt.org/directory",
+					Email:     "admin@example.com",
+					EABKeyID:  "my-eab-key-id",
+					EABMacKey: "my-eab-mac-key",
+					Solver: files.ACMESolver{
+						DNS01: &files.ACMEDNS01Solver{
+							Provider: "cloudflare",
+							Config: map[string]interface{}{
+								"apiTokenSecretRef": map[string]interface{}{
+									"name": "acme-solver",
+									"key":  "api-token",
+								},
+							},
+							Secrets: map[string]string{
+								"api-token": "fake-api-token",
+							},
+						},
+					},
+				},
+			}
+			// Only set user-provided override fields; buildACMEOverride (called by Marshal)
+			// generates the dnsSolver section from the Solver config.
+
+			data, err := rootConfig.Marshal()
+			Expect(err).NotTo(HaveOccurred())
+
+			var raw map[string]interface{}
+			Expect(yaml.Unmarshal(data, &raw)).NotTo(HaveOccurred())
+
+			// Expected codesphere.certIssuer per upstream docs (no solver field)
+			expectedCertIssuer := map[string]interface{}{
+				"type": "acme",
+				"acme": map[string]interface{}{
+					"enabled":  true,
+					"server":   "https://acme-v02.api.letsencrypt.org/directory",
+					"email":    "admin@example.com",
+					"eabKeyId": "my-eab-key-id",
+				},
+			}
+
+			// Expected cluster.certificates.override per upstream docs
+			expectedOverride := map[string]interface{}{
+				"issuers": map[string]interface{}{
+					"acme": map[string]interface{}{
+						"dnsSolver": map[string]interface{}{
+							"cloudflare": map[string]interface{}{
+								"apiTokenSecretRef": map[string]interface{}{
+									"name": "acme-solver",
+									"key":  "api-token",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			// Deep compare relevant sections
+			codesphere := raw["codesphere"].(map[string]interface{})
+			Expect(codesphere["certIssuer"]).To(Equal(expectedCertIssuer))
+
+			cluster := raw["cluster"].(map[string]interface{})
+			certs := cluster["certificates"].(map[string]interface{})
+			Expect(certs["override"]).To(Equal(expectedOverride))
+		})
+
+		It("should unmarshal ACME config from upstream docs format and populate Solver", func() {
+			acmeYaml := `codesphere:
+  certIssuer:
+    type: acme
+    acme:
+      enabled: true
+      server: https://acme-v02.api.letsencrypt.org/directory
+      email: admin@example.com
+      eabKeyId: my-eab-key-id
+cluster:
+  certificates:
+    override:
+      issuers:
+        acme:
+          dnsSolver:
+            cloudflare:
+              apiTokenSecretRef:
+                key: api-token
+                name: acme-solver
+          solverSecret:
+            data:
+              api-token: fake-api-token
+            name: acme-solver
+`
+			var parsed files.RootConfig
+			err := parsed.Unmarshal([]byte(acmeYaml))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(parsed.Codesphere.CertIssuer.Type).To(Equal(files.CertIssuerTypeACME))
+			Expect(parsed.Codesphere.CertIssuer.Acme).NotTo(BeNil())
+			Expect(parsed.Codesphere.CertIssuer.Acme.Server).To(Equal("https://acme-v02.api.letsencrypt.org/directory"))
+			Expect(parsed.Codesphere.CertIssuer.Acme.Email).To(Equal("admin@example.com"))
+			Expect(parsed.Codesphere.CertIssuer.Acme.EABKeyID).To(Equal("my-eab-key-id"))
+
+			// Solver should be populated from override
+			Expect(parsed.Codesphere.CertIssuer.Acme.Solver.DNS01).NotTo(BeNil())
+			Expect(parsed.Codesphere.CertIssuer.Acme.Solver.DNS01.Provider).To(Equal("cloudflare"))
+		})
+
+		It("should marshal vault secrets to the expected ACME structure", func() {
+			rootConfig.Codesphere.CertIssuer = files.CertIssuerConfig{
+				Type: files.CertIssuerTypeACME,
+				Acme: &files.ACMEConfig{
+					Enabled:   true,
+					Server:    "https://acme-v02.api.letsencrypt.org/directory",
+					Email:     "admin@example.com",
+					EABKeyID:  "my-eab-key-id",
+					EABMacKey: "my-eab-mac-key",
+					Solver: files.ACMESolver{
+						DNS01: &files.ACMEDNS01Solver{
+							Provider: "cloudflare",
+							Secrets: map[string]string{
+								"api-token": "fake-cloudflare-token",
+							},
+						},
+					},
+				},
+			}
+
+			vault := rootConfig.ExtractVault()
+			vaultData, err := vault.Marshal()
+			Expect(err).NotTo(HaveOccurred())
+
+			var raw map[string]interface{}
+			Expect(yaml.Unmarshal(vaultData, &raw)).NotTo(HaveOccurred())
+
+			// Expected vault structure per upstream docs
+			expectedSecrets := []interface{}{
+				map[string]interface{}{
+					"name": "acmeEabMacKey",
+					"fields": map[string]interface{}{
+						"password": "my-eab-mac-key",
+					},
+				},
+				map[string]interface{}{
+					"name": "acmeDNS01Api-token",
+					"fields": map[string]interface{}{
+						"password": "fake-cloudflare-token",
+					},
+				},
+			}
+
+			secrets := raw["secrets"].([]interface{})
+			for _, expected := range expectedSecrets {
+				Expect(secrets).To(ContainElement(expected))
+			}
 		})
 	})
 })


### PR DESCRIPTION
I think the current implementation didn't work with what the private cloud installer expects. See the pc docs: https://docs.codesphere.com/private-cloud/cluster-ingress-ca-options

Basically the acme config is in `codesphere` and not in the `certificates` config. The solver is then in the `certificates`