### PR TITLE
feat(argo-migration): add a command to deploy all secrets of the prod.vault.yaml as secret to the target cluster

### DIFF
--- a/cli/cmd/beta.go
+++ b/cli/cmd/beta.go
@@ -27,4 +27,5 @@ func AddBetaCmd(rootCmd *cobra.Command, opts *GlobalOptions) {
 	AddBootstrapGcpCmd(beta.cmd, opts)
 	AddBootstrapLocalCmd(beta.cmd)
 	AddBetaInstallCmd(beta.cmd, opts)
+	AddBetaVaultSecretCmd(beta.cmd, opts)
 }

--- a/cli/cmd/beta_vault_secret.go
+++ b/cli/cmd/beta_vault_secret.go
@@ -1,0 +1,77 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+
+	packageio "github.com/codesphere-cloud/cs-go/pkg/io"
+	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/util"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+type BetaVaultSecretCmd struct {
+	cmd  *cobra.Command
+	Opts BetaVaultSecretOpts
+}
+
+type BetaVaultSecretOpts struct {
+	*GlobalOptions
+	VaultFile  string
+	AgeKeyPath string
+	Namespace  string
+	SecretName string
+}
+
+func (c *BetaVaultSecretCmd) RunE(_ *cobra.Command, _ []string) error {
+	kubeConfig, err := ctrlconfig.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load kubernetes config: %w", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("failed to add kubernetes scheme: %w", err)
+	}
+
+	kubeClient, err := ctrlclient.New(kubeConfig, ctrlclient.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	creator := installer.NewVaultSecretCreator(kubeClient)
+	return creator.CreateSecretFromVault(c.cmd.Context(), c.Opts.VaultFile, c.Opts.AgeKeyPath, c.Opts.Namespace, c.Opts.SecretName)
+}
+
+func AddBetaVaultSecretCmd(parentCmd *cobra.Command, opts *GlobalOptions) {
+	cmd := BetaVaultSecretCmd{
+		cmd: &cobra.Command{
+			Use:   "vault-secret",
+			Short: "Create a Kubernetes secret from a SOPS-encrypted vault file",
+			Long: packageio.Long(`Create a Kubernetes secret from a SOPS-encrypted prod.vault.yaml file.
+				Reads the encrypted vault file, decrypts it using the age key, and creates a Kubernetes secret
+				with all the vault entries as key-value pairs in the target cluster.`),
+			Example: formatExamples("vault-secret", []packageio.Example{
+				{Cmd: "--vault-file prod.vault.yaml --namespace default --secret-name vault-secrets", Desc: "Create secret using default age key location"},
+				{Cmd: "--vault-file prod.vault.yaml --age-key /path/to/age_key.txt --namespace kube-system --secret-name cluster-secrets", Desc: "Create secret with explicit age key path"},
+			}),
+		},
+		Opts: BetaVaultSecretOpts{GlobalOptions: opts},
+	}
+
+	cmd.cmd.Flags().StringVar(&cmd.Opts.VaultFile, "vault-file", "", "Path to the SOPS-encrypted vault file (required)")
+	cmd.cmd.Flags().StringVar(&cmd.Opts.AgeKeyPath, "age-key", "", "Path to the age key file (optional, will use defaults if not provided)")
+	cmd.cmd.Flags().StringVar(&cmd.Opts.Namespace, "namespace", "codesphere", "Kubernetes namespace where the secret will be created")
+	cmd.cmd.Flags().StringVar(&cmd.Opts.SecretName, "secret-name", "cs-vault", "Name of the Kubernetes secret to create")
+
+	util.MarkFlagRequired(cmd.cmd, "vault-file")
+
+	cmd.cmd.RunE = cmd.RunE
+	AddCmd(parentCmd, cmd.cmd)
+}

--- a/docs/oms_beta.md
+++ b/docs/oms_beta.md
@@ -20,4 +20,5 @@ Be aware that that usage and behavior may change as the features are developed.
 * [oms beta bootstrap-local](oms_beta_bootstrap-local.md)	 - Bootstrap a local Codesphere environment
 * [oms beta extend](oms_beta_extend.md)	 - Extend Codesphere ressources such as base images.
 * [oms beta install](oms_beta_install.md)	 - Install beta components
+* [oms beta vault-secret](oms_beta_vault-secret.md)	 - Create a Kubernetes secret from a SOPS-encrypted vault file
 

--- a/docs/oms_beta_vault-secret.md
+++ b/docs/oms_beta_vault-secret.md
@@ -1,0 +1,39 @@
+## oms beta vault-secret
+
+Create a Kubernetes secret from a SOPS-encrypted vault file
+
+### Synopsis
+
+Create a Kubernetes secret from a SOPS-encrypted prod.vault.yaml file.
+Reads the encrypted vault file, decrypts it using the age key, and creates a Kubernetes secret
+with all the vault entries as key-value pairs in the target cluster.
+
+```
+oms beta vault-secret [flags]
+```
+
+### Examples
+
+```
+# Create secret using default age key location
+$ oms vault-secret --vault-file prod.vault.yaml --namespace default --secret-name vault-secrets
+
+# Create secret with explicit age key path
+$ oms vault-secret --vault-file prod.vault.yaml --age-key /path/to/age_key.txt --namespace kube-system --secret-name cluster-secrets
+
+```
+
+### Options
+
+```
+      --age-key string       Path to the age key file (optional, will use defaults if not provided)
+  -h, --help                 help for vault-secret
+      --namespace string     Kubernetes namespace where the secret will be created (default "codesphere")
+      --secret-name string   Name of the Kubernetes secret to create (default "cs-vault")
+      --vault-file string    Path to the SOPS-encrypted vault file (required)
+```
+
+### SEE ALSO
+
+* [oms beta](oms_beta.md)	 - Commands for early testing
+

--- a/internal/installer/vault_secret_creator.go
+++ b/internal/installer/vault_secret_creator.go
@@ -1,0 +1,93 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package installer
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/codesphere-cloud/oms/internal/installer/files"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type VaultSecretCreator struct {
+	client client.Client
+}
+
+func NewVaultSecretCreator(c client.Client) *VaultSecretCreator {
+	return &VaultSecretCreator{client: c}
+}
+
+// CreateSecretFromVault decrypts a SOPS-encrypted vault file and creates or
+// updates a Kubernetes secret with its contents in the target cluster.
+//
+// vaultFile is the path to the SOPS-encrypted prod.vault.yaml.
+// ageKeyPath is the path to the age private key used for decryption; if empty,
+// SOPS falls back to the SOPS_AGE_KEY / SOPS_AGE_KEY_FILE env vars and the
+// default key location (~/.config/sops/age/keys.txt).
+// namespace and secretName identify the target Kubernetes secret.
+//
+// Each vault entry is mapped to one or more secret keys:
+//   - File entries produce a single key equal to the entry name.
+//   - Field entries produce "entryName/password" and, when present, "entryName/username".
+func (v *VaultSecretCreator) CreateSecretFromVault(ctx context.Context, vaultFile, ageKeyPath, namespace, secretName string) error {
+	decrypted, err := DecryptFileWithSOPS(vaultFile, ageKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt vault file: %w", err)
+	}
+
+	vault := &files.InstallVault{}
+	if err := vault.Unmarshal(decrypted); err != nil {
+		return fmt.Errorf("failed to parse vault file: %w", err)
+	}
+
+	secretData, err := vaultToSecretData(vault)
+	if err != nil {
+		return err
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, v.client, secret, func() error {
+		secret.Type = corev1.SecretTypeOpaque
+		secret.Data = secretData
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to apply secret to cluster: %w", err)
+	}
+
+	log.Printf("Successfully created secret '%s' in namespace '%s' with %d entries", secretName, namespace, len(secretData))
+	return nil
+}
+
+// vaultToSecretData converts the entries of an InstallVault into Kubernetes secret data.
+// File entries produce a single key equal to the entry name containing the file content.
+// Field entries produce "entryName/password" and, when a username is present, "entryName/username".
+func vaultToSecretData(vault *files.InstallVault) (map[string][]byte, error) {
+	data := make(map[string][]byte)
+	for _, entry := range vault.Secrets {
+		if entry.File != nil {
+			data[entry.Name] = []byte(entry.File.Content)
+		} else if entry.Fields != nil {
+			data[entry.Name+"/password"] = []byte(entry.Fields.Password)
+			if entry.Fields.Username != "" {
+				data[entry.Name+"/username"] = []byte(entry.Fields.Username)
+			}
+		}
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("no secrets found in vault file")
+	}
+	return data, nil
+}

--- a/internal/installer/vault_secret_creator_test.go
+++ b/internal/installer/vault_secret_creator_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package installer
+
+import (
+	"github.com/codesphere-cloud/oms/internal/installer/files"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("vaultToSecretData", func() {
+	It("stores file entry content under the entry name", func() {
+		vault := &files.InstallVault{
+			Secrets: []files.SecretEntry{
+				{Name: "tlsCert", File: &files.SecretFile{Name: "tls.crt", Content: "cert-content"}},
+			},
+		}
+		data, err := vaultToSecretData(vault)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("tlsCert", []byte("cert-content")))
+	})
+
+	It("stores field entry with password only under entryName/password", func() {
+		vault := &files.InstallVault{
+			Secrets: []files.SecretEntry{
+				{Name: "dbAdmin", Fields: &files.SecretFields{Password: "s3cr3t"}},
+			},
+		}
+		data, err := vaultToSecretData(vault)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("dbAdmin/password", []byte("s3cr3t")))
+		Expect(data).NotTo(HaveKey("dbAdmin/username"))
+	})
+
+	It("stores field entry with username and password under entryName/username and entryName/password", func() {
+		vault := &files.InstallVault{
+			Secrets: []files.SecretEntry{
+				{Name: "registry", Fields: &files.SecretFields{Username: "robot", Password: "token123"}},
+			},
+		}
+		data, err := vaultToSecretData(vault)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(HaveKeyWithValue("registry/username", []byte("robot")))
+		Expect(data).To(HaveKeyWithValue("registry/password", []byte("token123")))
+	})
+
+	It("handles a mix of file and field entries", func() {
+		vault := &files.InstallVault{
+			Secrets: []files.SecretEntry{
+				{Name: "sshKey", File: &files.SecretFile{Name: "id_rsa", Content: "-----BEGIN RSA PRIVATE KEY-----"}},
+				{Name: "git", Fields: &files.SecretFields{Username: "deploy", Password: "gh_token"}},
+			},
+		}
+		data, err := vaultToSecretData(vault)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(HaveKey("sshKey"))
+		Expect(data).To(HaveKey("git/username"))
+		Expect(data).To(HaveKey("git/password"))
+		Expect(data).To(HaveLen(3))
+	})
+
+	It("returns an error for an empty vault", func() {
+		vault := &files.InstallVault{}
+		_, err := vaultToSecretData(vault)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no secrets found"))
+	})
+
+	It("skips entries that have neither file nor fields", func() {
+		vault := &files.InstallVault{
+			Secrets: []files.SecretEntry{
+				{Name: "empty"},
+				{Name: "real", Fields: &files.SecretFields{Password: "pw"}},
+			},
+		}
+		data, err := vaultToSecretData(vault)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).NotTo(HaveKey("empty"))
+		Expect(data).To(HaveKey("real/password"))
+	})
+})


### PR DESCRIPTION
Required for the migration to argocd where secrets are consumed by external secret operator.