### PR TITLE
feat(argocd): add install pc-apps command

### DIFF
--- a/cli/cmd/argocd.go
+++ b/cli/cmd/argocd.go
@@ -1,4 +1,5 @@
-// Copyright (c) Codesphere Inc. SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
 
 package cmd
 

--- a/cli/cmd/beta_install.go
+++ b/cli/cmd/beta_install.go
@@ -21,4 +21,5 @@ func AddBetaInstallCmd(rootCmd *cobra.Command, opts *GlobalOptions) {
 	}
 	AddCmd(rootCmd, install.cmd)
 	AddArgoCDCmd(install.cmd, opts)
+	AddPCAppsCmd(install.cmd, opts)
 }

--- a/cli/cmd/pc_apps.go
+++ b/cli/cmd/pc_apps.go
@@ -9,8 +9,6 @@ import (
 	"github.com/codesphere-cloud/oms/internal/installer"
 	"github.com/codesphere-cloud/oms/internal/util"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
@@ -34,12 +32,7 @@ func (c *InstallPCAppsCmd) RunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load kubernetes config: %w", err)
 	}
 
-	scheme := runtime.NewScheme()
-	if err := clientgoscheme.AddToScheme(scheme); err != nil {
-		return fmt.Errorf("failed to add kubernetes scheme: %w", err)
-	}
-
-	kubeClient, err := ctrlclient.New(kubeConfig, ctrlclient.Options{Scheme: scheme})
+	kubeClient, err := ctrlclient.New(kubeConfig, ctrlclient.Options{})
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/cli/cmd/pc_apps.go
+++ b/cli/cmd/pc_apps.go
@@ -4,12 +4,15 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	packageio "github.com/codesphere-cloud/cs-go/pkg/io"
 	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/util"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 // InstallPCAppsCmd represents the pc-apps command
@@ -20,29 +23,31 @@ type InstallPCAppsCmd struct {
 
 type InstallPCAppsOpts struct {
 	*GlobalOptions
-	Chart       string
 	Version     string
 	Namespace   string
-	Username    string
 	ValuesFiles []string
 }
 
 func (c *InstallPCAppsCmd) RunE(cmd *cobra.Command, args []string) error {
-	var password string
-	if c.Opts.Username != "" {
-		pw, err := c.resolvePassword()
-		if err != nil {
-			return err
-		}
-		password = pw
+	kubeConfig, err := ctrlconfig.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load kubernetes config: %w", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("failed to add kubernetes scheme: %w", err)
+	}
+
+	kubeClient, err := ctrlclient.New(kubeConfig, ctrlclient.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
 	pcApps, err := installer.NewPCApps(
-		c.Opts.Chart,
+		kubeClient,
 		c.Opts.Version,
 		c.Opts.Namespace,
-		c.Opts.Username,
-		password,
 		c.Opts.ValuesFiles,
 	)
 	if err != nil {
@@ -56,25 +61,6 @@ func (c *InstallPCAppsCmd) RunE(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// resolvePassword reads the password from the OMS_REPO_PASSWORD environment variable,
-// or prompts the user interactively if the env var is not set.
-func (c *InstallPCAppsCmd) resolvePassword() (string, error) {
-	if pw := os.Getenv("OMS_REPO_PASSWORD"); len(pw) != 0 {
-		return pw, nil
-	}
-
-	fmt.Print("Registry password/token: ")
-	pw, err := term.ReadPassword(int(os.Stdin.Fd()))
-	fmt.Println()
-	if err != nil {
-		return "", fmt.Errorf("failed to read password: %w", err)
-	}
-	if len(pw) == 0 {
-		return "", fmt.Errorf("password is required; set OMS_REPO_PASSWORD or enter it when prompted")
-	}
-	return string(pw), nil
-}
-
 func AddPCAppsCmd(parentCmd *cobra.Command, opts *GlobalOptions) {
 	pcApps := InstallPCAppsCmd{
 		Opts: InstallPCAppsOpts{
@@ -83,28 +69,26 @@ func AddPCAppsCmd(parentCmd *cobra.Command, opts *GlobalOptions) {
 	}
 	pcApps.cmd = &cobra.Command{
 		Use:   "pc-apps",
-		Short: "Install the pc-apps Helm chart from a private OCI registry",
-		Long: packageio.Long(`Install or upgrade the pc-apps Helm chart from a private OCI registry
-			into the target cluster. This chart deploys ArgoCD Application resources
-			that manage the platform components.
+		Short: "Install the pc-applications Helm chart from a private OCI registry",
+		Long: packageio.Long(`Install or upgrade the pc-applications Helm chart from a private OCI
+			registry into the target cluster. This chart deploys ArgoCD Application
+			resources that manage the platform components.
 
-			If --username is provided, the registry password is read from the
-			OMS_REPO_PASSWORD environment variable or prompted interactively.
-			Otherwise, credentials are read from the Kubernetes secret
-			"argocd-codesphere-oci-read" in the argocd namespace (created by
-			"oms beta install argocd --deploy-dc-config --registry-password <token>").`),
+			Registry credentials and chart URL are read automatically from the
+			Kubernetes secret "argocd-codesphere-oci-read" in the argocd namespace.
+			This secret is created by "oms beta install argocd --deploy-dc-config".`),
 		Example: formatExamples("beta install pc-apps", []packageio.Example{
-			{Cmd: "--version 1.0.0", Desc: "Install a specific version (credentials from K8s secret)"},
-			{Cmd: "--version 1.0.0 --username CodesphereBot", Desc: "Install with explicit registry credentials (prompts for password)"},
-			{Cmd: "--chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --version 1.0.0 -f base.yaml -f dc-overlay.yaml", Desc: "Install with custom chart and values files"},
+			{Cmd: "--version 1.0.0", Desc: "Install a specific version"},
+			{Cmd: "--version 1.0.0 -f base.yaml -f dc-overlay.yaml", Desc: "Install with custom values files"},
+			{Cmd: "--version 1.0.0 --namespace custom-ns", Desc: "Install into a custom namespace"},
 		}),
 	}
-	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Chart, "chart", "oci://ghcr.io/codesphere-cloud/charts/pc-apps", "Full OCI chart URL")
-	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Version, "version", "", "Chart version to install (default: latest)")
+	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Version, "version", "", "Chart version to install (required)")
 	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Namespace, "namespace", "argocd", "Target namespace for the Helm release")
-	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Username, "username", "", "Username for OCI registry authentication (if omitted, reads from K8s secret)")
 	pcApps.cmd.Flags().StringArrayVarP(&pcApps.Opts.ValuesFiles, "values", "f", nil, "Path to values YAML file (can be specified multiple times, merged in order)")
 	pcApps.cmd.RunE = pcApps.RunE
+
+	util.MarkFlagRequired(pcApps.cmd, "version")
 
 	AddCmd(parentCmd, pcApps.cmd)
 }

--- a/cli/cmd/pc_apps.go
+++ b/cli/cmd/pc_apps.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -28,7 +27,7 @@ type InstallPCAppsOpts struct {
 	ValuesFiles []string
 }
 
-func (c *InstallPCAppsCmd) RunE(_ *cobra.Command, args []string) error {
+func (c *InstallPCAppsCmd) RunE(cmd *cobra.Command, args []string) error {
 	var password string
 	if c.Opts.Username != "" {
 		pw, err := c.resolvePassword()
@@ -50,7 +49,7 @@ func (c *InstallPCAppsCmd) RunE(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize pc-apps installer: %w", err)
 	}
 
-	if err := pcApps.Install(context.Background()); err != nil {
+	if err := pcApps.Install(cmd.Context()); err != nil {
 		return fmt.Errorf("failed to install pc-apps: %w", err)
 	}
 
@@ -93,7 +92,7 @@ func AddPCAppsCmd(parentCmd *cobra.Command, opts *GlobalOptions) {
 			OMS_REPO_PASSWORD environment variable or prompted interactively.
 			Otherwise, credentials are read from the Kubernetes secret
 			"argocd-codesphere-oci-read" in the argocd namespace (created by
-			"oms beta install argocd").`),
+			"oms beta install argocd --deploy-dc-config --registry-password <token>").`),
 		Example: formatExamples("beta install pc-apps", []packageio.Example{
 			{Cmd: "--version 1.0.0", Desc: "Install a specific version (credentials from K8s secret)"},
 			{Cmd: "--version 1.0.0 --username CodesphereBot", Desc: "Install with explicit registry credentials (prompts for password)"},

--- a/cli/cmd/pc_apps.go
+++ b/cli/cmd/pc_apps.go
@@ -29,20 +29,13 @@ type InstallPCAppsOpts struct {
 }
 
 func (c *InstallPCAppsCmd) RunE(_ *cobra.Command, args []string) error {
-	requiredFlags := map[string]string{
-		"chart":    c.Opts.Chart,
-		"username": c.Opts.Username,
-	}
-
-	for flagName, value := range requiredFlags {
-		if value == "" {
-			return fmt.Errorf("flag --%s is required", flagName)
+	var password string
+	if c.Opts.Username != "" {
+		pw, err := c.resolvePassword()
+		if err != nil {
+			return err
 		}
-	}
-
-	password, err := c.resolvePassword()
-	if err != nil {
-		return err
+		password = pw
 	}
 
 	pcApps, err := installer.NewPCApps(
@@ -85,26 +78,32 @@ func (c *InstallPCAppsCmd) resolvePassword() (string, error) {
 
 func AddPCAppsCmd(parentCmd *cobra.Command, opts *GlobalOptions) {
 	pcApps := InstallPCAppsCmd{
-		cmd: &cobra.Command{
-			Use:   "pc-apps",
-			Short: "Install the pc-apps Helm chart from a private OCI registry",
-			Long: packageio.Long(`Install or upgrade the pc-apps Helm chart from a private OCI registry
-				into the target cluster. This chart deploys ArgoCD Application resources
-				that manage the platform components.
-
-				The registry password is read from the OMS_REPO_PASSWORD environment variable.
-				If not set, it will be prompted interactively (hidden input).`),
-			Example: formatExamples("install pc-apps", []packageio.Example{
-				{Cmd: "--chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --version 1.0.0 --username CodesphereBot", Desc: "Install a specific version (prompts for password)"},
-				{Cmd: "--chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --username CodesphereBot -f base.yaml -f dc-overlay.yaml", Desc: "Install latest with multiple values files"},
-				{Cmd: "--chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --username CodesphereBot --namespace custom-ns", Desc: "Install into a custom namespace"},
-			}),
+		Opts: InstallPCAppsOpts{
+			GlobalOptions: opts,
 		},
 	}
-	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Chart, "chart", "", "Full OCI chart URL (e.g. oci://ghcr.io/codesphere-cloud/charts/pc-apps)")
+	pcApps.cmd = &cobra.Command{
+		Use:   "pc-apps",
+		Short: "Install the pc-apps Helm chart from a private OCI registry",
+		Long: packageio.Long(`Install or upgrade the pc-apps Helm chart from a private OCI registry
+			into the target cluster. This chart deploys ArgoCD Application resources
+			that manage the platform components.
+
+			If --username is provided, the registry password is read from the
+			OMS_REPO_PASSWORD environment variable or prompted interactively.
+			Otherwise, credentials are read from the Kubernetes secret
+			"argocd-codesphere-oci-read" in the argocd namespace (created by
+			"oms beta install argocd").`),
+		Example: formatExamples("beta install pc-apps", []packageio.Example{
+			{Cmd: "--version 1.0.0", Desc: "Install a specific version (credentials from K8s secret)"},
+			{Cmd: "--version 1.0.0 --username CodesphereBot", Desc: "Install with explicit registry credentials (prompts for password)"},
+			{Cmd: "--chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --version 1.0.0 -f base.yaml -f dc-overlay.yaml", Desc: "Install with custom chart and values files"},
+		}),
+	}
+	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Chart, "chart", "oci://ghcr.io/codesphere-cloud/charts/pc-apps", "Full OCI chart URL")
 	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Version, "version", "", "Chart version to install (default: latest)")
 	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Namespace, "namespace", "argocd", "Target namespace for the Helm release")
-	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Username, "username", "", "Username for OCI registry authentication")
+	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Username, "username", "", "Username for OCI registry authentication (if omitted, reads from K8s secret)")
 	pcApps.cmd.Flags().StringArrayVarP(&pcApps.Opts.ValuesFiles, "values", "f", nil, "Path to values YAML file (can be specified multiple times, merged in order)")
 	pcApps.cmd.RunE = pcApps.RunE
 

--- a/cli/cmd/pc_apps.go
+++ b/cli/cmd/pc_apps.go
@@ -1,0 +1,112 @@
+// Copyright (c) Codesphere Inc. SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	packageio "github.com/codesphere-cloud/cs-go/pkg/io"
+	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// InstallPCAppsCmd represents the pc-apps command
+type InstallPCAppsCmd struct {
+	cmd  *cobra.Command
+	Opts InstallPCAppsOpts
+}
+
+type InstallPCAppsOpts struct {
+	*GlobalOptions
+	Chart       string
+	Version     string
+	Namespace   string
+	Username    string
+	ValuesFiles []string
+}
+
+func (c *InstallPCAppsCmd) RunE(_ *cobra.Command, args []string) error {
+	requiredFlags := map[string]string{
+		"chart":    c.Opts.Chart,
+		"username": c.Opts.Username,
+	}
+
+	for flagName, value := range requiredFlags {
+		if value == "" {
+			return fmt.Errorf("flag --%s is required", flagName)
+		}
+	}
+
+	password, err := c.resolvePassword()
+	if err != nil {
+		return err
+	}
+
+	pcApps, err := installer.NewPCApps(
+		c.Opts.Chart,
+		c.Opts.Version,
+		c.Opts.Namespace,
+		c.Opts.Username,
+		password,
+		c.Opts.ValuesFiles,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to initialize pc-apps installer: %w", err)
+	}
+
+	if err := pcApps.Install(context.Background()); err != nil {
+		return fmt.Errorf("failed to install pc-apps: %w", err)
+	}
+
+	return nil
+}
+
+// resolvePassword reads the password from the OMS_REPO_PASSWORD environment variable,
+// or prompts the user interactively if the env var is not set.
+func (c *InstallPCAppsCmd) resolvePassword() (string, error) {
+	if pw := os.Getenv("OMS_REPO_PASSWORD"); len(pw) != 0 {
+		return pw, nil
+	}
+
+	fmt.Print("Registry password/token: ")
+	pw, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println()
+	if err != nil {
+		return "", fmt.Errorf("failed to read password: %w", err)
+	}
+	if len(pw) == 0 {
+		return "", fmt.Errorf("password is required; set OMS_REPO_PASSWORD or enter it when prompted")
+	}
+	return string(pw), nil
+}
+
+func AddPCAppsCmd(parentCmd *cobra.Command, opts *GlobalOptions) {
+	pcApps := InstallPCAppsCmd{
+		cmd: &cobra.Command{
+			Use:   "pc-apps",
+			Short: "Install the pc-apps Helm chart from a private OCI registry",
+			Long: packageio.Long(`Install or upgrade the pc-apps Helm chart from a private OCI registry
+				into the target cluster. This chart deploys ArgoCD Application resources
+				that manage the platform components.
+
+				The registry password is read from the OMS_REPO_PASSWORD environment variable.
+				If not set, it will be prompted interactively (hidden input).`),
+			Example: formatExamples("install pc-apps", []packageio.Example{
+				{Cmd: "--chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --version 1.0.0 --username CodesphereBot", Desc: "Install a specific version (prompts for password)"},
+				{Cmd: "--chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --username CodesphereBot -f base.yaml -f dc-overlay.yaml", Desc: "Install latest with multiple values files"},
+				{Cmd: "--chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --username CodesphereBot --namespace custom-ns", Desc: "Install into a custom namespace"},
+			}),
+		},
+	}
+	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Chart, "chart", "", "Full OCI chart URL (e.g. oci://ghcr.io/codesphere-cloud/charts/pc-apps)")
+	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Version, "version", "", "Chart version to install (default: latest)")
+	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Namespace, "namespace", "argocd", "Target namespace for the Helm release")
+	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Username, "username", "", "Username for OCI registry authentication")
+	pcApps.cmd.Flags().StringArrayVarP(&pcApps.Opts.ValuesFiles, "values", "f", nil, "Path to values YAML file (can be specified multiple times, merged in order)")
+	pcApps.cmd.RunE = pcApps.RunE
+
+	AddCmd(parentCmd, pcApps.cmd)
+}

--- a/cli/cmd/pc_apps.go
+++ b/cli/cmd/pc_apps.go
@@ -1,4 +1,5 @@
-// Copyright (c) Codesphere Inc. SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
 
 package cmd
 

--- a/docs/oms_beta_install.md
+++ b/docs/oms_beta_install.md
@@ -12,5 +12,5 @@ Install beta components
 
 * [oms beta](oms_beta.md)	 - Commands for early testing
 * [oms beta install argocd](oms_beta_install_argocd.md)	 - Install an ArgoCD helm release
-* [oms beta install pc-apps](oms_beta_install_pc-apps.md)	 - Install the pc-apps Helm chart from a private OCI registry
+* [oms beta install pc-apps](oms_beta_install_pc-apps.md)	 - Install the pc-applications Helm chart from a private OCI registry
 

--- a/docs/oms_beta_install.md
+++ b/docs/oms_beta_install.md
@@ -12,4 +12,5 @@ Install beta components
 
 * [oms beta](oms_beta.md)	 - Commands for early testing
 * [oms beta install argocd](oms_beta_install_argocd.md)	 - Install an ArgoCD helm release
+* [oms beta install pc-apps](oms_beta_install_pc-apps.md)	 - Install the pc-apps Helm chart from a private OCI registry
 

--- a/docs/oms_beta_install_pc-apps.md
+++ b/docs/oms_beta_install_pc-apps.md
@@ -1,18 +1,16 @@
 ## oms beta install pc-apps
 
-Install the pc-apps Helm chart from a private OCI registry
+Install the pc-applications Helm chart from a private OCI registry
 
 ### Synopsis
 
-Install or upgrade the pc-apps Helm chart from a private OCI registry
-into the target cluster. This chart deploys ArgoCD Application resources
-that manage the platform components.
+Install or upgrade the pc-applications Helm chart from a private OCI
+registry into the target cluster. This chart deploys ArgoCD Application
+resources that manage the platform components.
 
-If --username is provided, the registry password is read from the
-OMS_REPO_PASSWORD environment variable or prompted interactively.
-Otherwise, credentials are read from the Kubernetes secret
-"argocd-codesphere-oci-read" in the argocd namespace (created by
-"oms beta install argocd --deploy-dc-config --registry-password <token>").
+Registry credentials and chart URL are read automatically from the
+Kubernetes secret "argocd-codesphere-oci-read" in the argocd namespace.
+This secret is created by "oms beta install argocd --deploy-dc-config".
 
 ```
 oms beta install pc-apps [flags]
@@ -21,26 +19,24 @@ oms beta install pc-apps [flags]
 ### Examples
 
 ```
-# Install a specific version (credentials from K8s secret)
+# Install a specific version
 $ oms beta install pc-apps --version 1.0.0
 
-# Install with explicit registry credentials (prompts for password)
-$ oms beta install pc-apps --version 1.0.0 --username CodesphereBot
+# Install with custom values files
+$ oms beta install pc-apps --version 1.0.0 -f base.yaml -f dc-overlay.yaml
 
-# Install with custom chart and values files
-$ oms beta install pc-apps --chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --version 1.0.0 -f base.yaml -f dc-overlay.yaml
+# Install into a custom namespace
+$ oms beta install pc-apps --version 1.0.0 --namespace custom-ns
 
 ```
 
 ### Options
 
 ```
-      --chart string         Full OCI chart URL (default "oci://ghcr.io/codesphere-cloud/charts/pc-apps")
   -h, --help                 help for pc-apps
       --namespace string     Target namespace for the Helm release (default "argocd")
-      --username string      Username for OCI registry authentication (if omitted, reads from K8s secret)
   -f, --values stringArray   Path to values YAML file (can be specified multiple times, merged in order)
-      --version string       Chart version to install (default: latest)
+      --version string       Chart version to install (required)
 ```
 
 ### SEE ALSO

--- a/docs/oms_beta_install_pc-apps.md
+++ b/docs/oms_beta_install_pc-apps.md
@@ -1,0 +1,46 @@
+## oms beta install pc-apps
+
+Install the pc-apps Helm chart from a private OCI registry
+
+### Synopsis
+
+Install or upgrade the pc-apps Helm chart from a private OCI registry
+into the target cluster. This chart deploys ArgoCD Application resources
+that manage the platform components.
+
+The registry password is read from the OMS_REPO_PASSWORD environment variable.
+If not set, it will be prompted interactively (hidden input).
+
+```
+oms beta install pc-apps [flags]
+```
+
+### Examples
+
+```
+# Install a specific version (prompts for password)
+$ oms install pc-apps --chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --version 1.0.0 --username CodesphereBot
+
+# Install latest with multiple values files
+$ oms install pc-apps --chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --username CodesphereBot -f base.yaml -f dc-overlay.yaml
+
+# Install into a custom namespace
+$ oms install pc-apps --chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --username CodesphereBot --namespace custom-ns
+
+```
+
+### Options
+
+```
+      --chart string         Full OCI chart URL (e.g. oci://ghcr.io/codesphere-cloud/charts/pc-apps)
+  -h, --help                 help for pc-apps
+      --namespace string     Target namespace for the Helm release (default "argocd")
+      --username string      Username for OCI registry authentication
+  -f, --values stringArray   Path to values YAML file (can be specified multiple times, merged in order)
+      --version string       Chart version to install (default: latest)
+```
+
+### SEE ALSO
+
+* [oms beta install](oms_beta_install.md)	 - Install beta components
+

--- a/docs/oms_beta_install_pc-apps.md
+++ b/docs/oms_beta_install_pc-apps.md
@@ -12,7 +12,7 @@ If --username is provided, the registry password is read from the
 OMS_REPO_PASSWORD environment variable or prompted interactively.
 Otherwise, credentials are read from the Kubernetes secret
 "argocd-codesphere-oci-read" in the argocd namespace (created by
-"oms beta install argocd").
+"oms beta install argocd --deploy-dc-config --registry-password <token>").
 
 ```
 oms beta install pc-apps [flags]

--- a/docs/oms_beta_install_pc-apps.md
+++ b/docs/oms_beta_install_pc-apps.md
@@ -8,8 +8,11 @@ Install or upgrade the pc-apps Helm chart from a private OCI registry
 into the target cluster. This chart deploys ArgoCD Application resources
 that manage the platform components.
 
-The registry password is read from the OMS_REPO_PASSWORD environment variable.
-If not set, it will be prompted interactively (hidden input).
+If --username is provided, the registry password is read from the
+OMS_REPO_PASSWORD environment variable or prompted interactively.
+Otherwise, credentials are read from the Kubernetes secret
+"argocd-codesphere-oci-read" in the argocd namespace (created by
+"oms beta install argocd").
 
 ```
 oms beta install pc-apps [flags]
@@ -18,24 +21,24 @@ oms beta install pc-apps [flags]
 ### Examples
 
 ```
-# Install a specific version (prompts for password)
-$ oms install pc-apps --chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --version 1.0.0 --username CodesphereBot
+# Install a specific version (credentials from K8s secret)
+$ oms beta install pc-apps --version 1.0.0
 
-# Install latest with multiple values files
-$ oms install pc-apps --chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --username CodesphereBot -f base.yaml -f dc-overlay.yaml
+# Install with explicit registry credentials (prompts for password)
+$ oms beta install pc-apps --version 1.0.0 --username CodesphereBot
 
-# Install into a custom namespace
-$ oms install pc-apps --chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --username CodesphereBot --namespace custom-ns
+# Install with custom chart and values files
+$ oms beta install pc-apps --chart oci://ghcr.io/codesphere-cloud/charts/pc-apps --version 1.0.0 -f base.yaml -f dc-overlay.yaml
 
 ```
 
 ### Options
 
 ```
-      --chart string         Full OCI chart URL (e.g. oci://ghcr.io/codesphere-cloud/charts/pc-apps)
+      --chart string         Full OCI chart URL (default "oci://ghcr.io/codesphere-cloud/charts/pc-apps")
   -h, --help                 help for pc-apps
       --namespace string     Target namespace for the Helm release (default "argocd")
-      --username string      Username for OCI registry authentication
+      --username string      Username for OCI registry authentication (if omitted, reads from K8s secret)
   -f, --values stringArray   Path to values YAML file (can be specified multiple times, merged in order)
       --version string       Chart version to install (default: latest)
 ```

--- a/internal/installer/helm_client.go
+++ b/internal/installer/helm_client.go
@@ -64,16 +64,9 @@ type HelmClient interface {
 // Concrete implementation backed by the Helm Go SDK v4
 // ---------------------------------------------------------------------------
 
-type registryCredentials struct {
-	host     string
-	username string
-	password string
-}
-
 type helmClient struct {
 	defaultNamespace string
 	driver           string
-	registryCreds    *registryCredentials
 	registryClient   *registry.Client
 }
 
@@ -94,11 +87,6 @@ func (h *helmClient) LoginRegistry(_ context.Context, host, username, password s
 		return fmt.Errorf("registry login to %q failed: %w", host, err)
 	}
 
-	h.registryCreds = &registryCredentials{
-		host:     host,
-		username: username,
-		password: password,
-	}
 	h.registryClient = registryClient
 	return nil
 }

--- a/internal/installer/helm_client.go
+++ b/internal/installer/helm_client.go
@@ -77,6 +77,9 @@ func NewHelmClient(namespace string) (HelmClient, error) {
 	}, nil
 }
 
+// LoginRegistry authenticates against an OCI registry. The context parameter
+// is accepted for interface consistency but is not used by the underlying
+// Helm registry client.
 func (h *helmClient) LoginRegistry(_ context.Context, host, username, password string) error {
 	registryClient, err := registry.NewClient()
 	if err != nil {

--- a/internal/installer/helm_client.go
+++ b/internal/installer/helm_client.go
@@ -55,15 +55,25 @@ type HelmClient interface {
 
 	// UpgradeChart upgrades an existing Helm release and returns an error on failure.
 	UpgradeChart(ctx context.Context, cfg ChartConfig, opts UpgradeChartOptions) error
+
+	// LoginRegistry authenticates against an OCI registry for private chart pulls.
+	LoginRegistry(ctx context.Context, host, username, password string) error
 }
 
 // ---------------------------------------------------------------------------
 // Concrete implementation backed by the Helm Go SDK v4
 // ---------------------------------------------------------------------------
 
+type registryCredentials struct {
+	host     string
+	username string
+	password string
+}
+
 type helmClient struct {
 	defaultNamespace string
 	driver           string
+	registryCreds    *registryCredentials
 }
 
 func NewHelmClient(namespace string) (HelmClient, error) {
@@ -71,6 +81,15 @@ func NewHelmClient(namespace string) (HelmClient, error) {
 		defaultNamespace: namespace,
 		driver:           os.Getenv("HELM_DRIVER"),
 	}, nil
+}
+
+func (h *helmClient) LoginRegistry(_ context.Context, host, username, password string) error {
+	h.registryCreds = &registryCredentials{
+		host:     host,
+		username: username,
+		password: password,
+	}
+	return nil
 }
 
 // helmEnv holds the per-call Helm action configuration and CLI settings.
@@ -109,6 +128,17 @@ func (h *helmClient) newHelmEnv(namespace string) (*helmEnv, error) {
 	if err != nil {
 		return nil, fmt.Errorf("helm registry client init failed: %w", err)
 	}
+
+	if h.registryCreds != nil {
+		err = registryClient.Login(
+			h.registryCreds.host,
+			registry.LoginOptBasicAuth(h.registryCreds.username, h.registryCreds.password),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("helm registry login to %q failed: %w", h.registryCreds.host, err)
+		}
+	}
+
 	actionConfig.RegistryClient = registryClient
 
 	return &helmEnv{actionConfig: actionConfig, settings: settings}, nil

--- a/internal/installer/helm_client.go
+++ b/internal/installer/helm_client.go
@@ -74,6 +74,7 @@ type helmClient struct {
 	defaultNamespace string
 	driver           string
 	registryCreds    *registryCredentials
+	registryClient   *registry.Client
 }
 
 func NewHelmClient(namespace string) (HelmClient, error) {
@@ -84,11 +85,21 @@ func NewHelmClient(namespace string) (HelmClient, error) {
 }
 
 func (h *helmClient) LoginRegistry(_ context.Context, host, username, password string) error {
+	registryClient, err := registry.NewClient()
+	if err != nil {
+		return fmt.Errorf("creating registry client: %w", err)
+	}
+
+	if err := registryClient.Login(host, registry.LoginOptBasicAuth(username, password)); err != nil {
+		return fmt.Errorf("registry login to %q failed: %w", host, err)
+	}
+
 	h.registryCreds = &registryCredentials{
 		host:     host,
 		username: username,
 		password: password,
 	}
+	h.registryClient = registryClient
 	return nil
 }
 
@@ -124,22 +135,16 @@ func (h *helmClient) newHelmEnv(namespace string) (*helmEnv, error) {
 		return nil, fmt.Errorf("helm action config init failed: %w", err)
 	}
 
-	registryClient, err := registry.NewClient()
-	if err != nil {
-		return nil, fmt.Errorf("helm registry client init failed: %w", err)
-	}
-
-	if h.registryCreds != nil {
-		err = registryClient.Login(
-			h.registryCreds.host,
-			registry.LoginOptBasicAuth(h.registryCreds.username, h.registryCreds.password),
-		)
+	if h.registryClient != nil {
+		// Reuse the registry client that was authenticated during LoginRegistry.
+		actionConfig.RegistryClient = h.registryClient
+	} else {
+		registryClient, err := registry.NewClient()
 		if err != nil {
-			return nil, fmt.Errorf("helm registry login to %q failed: %w", h.registryCreds.host, err)
+			return nil, fmt.Errorf("helm registry client init failed: %w", err)
 		}
+		actionConfig.RegistryClient = registryClient
 	}
-
-	actionConfig.RegistryClient = registryClient
 
 	return &helmEnv{actionConfig: actionConfig, settings: settings}, nil
 }

--- a/internal/installer/mocks.go
+++ b/internal/installer/mocks.go
@@ -938,6 +938,75 @@ func (_c *MockHelmClient_InstallChart_Call) RunAndReturn(run func(ctx context.Co
 	return _c
 }
 
+// LoginRegistry provides a mock function for the type MockHelmClient
+func (_mock *MockHelmClient) LoginRegistry(ctx context.Context, host string, username string, password string) error {
+	ret := _mock.Called(ctx, host, username, password)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LoginRegistry")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = returnFunc(ctx, host, username, password)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockHelmClient_LoginRegistry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LoginRegistry'
+type MockHelmClient_LoginRegistry_Call struct {
+	*mock.Call
+}
+
+// LoginRegistry is a helper method to define mock.On call
+//   - ctx context.Context
+//   - host string
+//   - username string
+//   - password string
+func (_e *MockHelmClient_Expecter) LoginRegistry(ctx interface{}, host interface{}, username interface{}, password interface{}) *MockHelmClient_LoginRegistry_Call {
+	return &MockHelmClient_LoginRegistry_Call{Call: _e.mock.On("LoginRegistry", ctx, host, username, password)}
+}
+
+func (_c *MockHelmClient_LoginRegistry_Call) Run(run func(ctx context.Context, host string, username string, password string)) *MockHelmClient_LoginRegistry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockHelmClient_LoginRegistry_Call) Return(err error) *MockHelmClient_LoginRegistry_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockHelmClient_LoginRegistry_Call) RunAndReturn(run func(ctx context.Context, host string, username string, password string) error) *MockHelmClient_LoginRegistry_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpgradeChart provides a mock function for the type MockHelmClient
 func (_mock *MockHelmClient) UpgradeChart(ctx context.Context, cfg ChartConfig, opts UpgradeChartOptions) error {
 	ret := _mock.Called(ctx, cfg, opts)

--- a/internal/installer/pc_apps.go
+++ b/internal/installer/pc_apps.go
@@ -12,9 +12,9 @@ import (
 	"path"
 	"strings"
 
-	k8s "github.com/codesphere-cloud/oms/internal/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 	"gopkg.in/yaml.v3"
 )
 
@@ -51,9 +51,9 @@ func NewPCApps(chartURL, version, namespace, username, password string, valuesFi
 		return nil, fmt.Errorf("creating helm client: %w", err)
 	}
 
-	clientset, _, err := k8s.NewClients()
+	clientset, err := newTypedK8sClient()
 	if err != nil {
-		return nil, fmt.Errorf("creating kubernetes clients: %w", err)
+		return nil, fmt.Errorf("creating kubernetes client: %w", err)
 	}
 
 	return &PCApps{
@@ -66,6 +66,26 @@ func NewPCApps(chartURL, version, namespace, username, password string, valuesFi
 		Helm:        helm,
 		Clientset:   clientset,
 	}, nil
+}
+
+// newTypedK8sClient builds only a typed kubernetes.Interface from the
+// current kubeconfig, avoiding construction of an unused dynamic client.
+func newTypedK8sClient() (kubernetes.Interface, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+
+	cfg, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("loading kubeconfig: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating kubernetes clientset: %w", err)
+	}
+
+	return clientset, nil
 }
 
 // resolveCredentials returns the username and password to use for OCI registry
@@ -90,7 +110,7 @@ func (p *PCApps) resolveCredentials(ctx context.Context) (username, password str
 	if err != nil {
 		return "", "", fmt.Errorf(
 			"no credentials provided and K8s secret %q not found in namespace %q: %w\n"+
-				"Provide --username or run 'oms beta install argocd' first",
+				"Provide --username or run 'oms beta install argocd --deploy-dc-config --registry-password <token>' first",
 			ociCredentialSecretName, ociCredentialNamespace, err,
 		)
 	}
@@ -116,6 +136,12 @@ func (p *PCApps) Install(ctx context.Context) error {
 		return err
 	}
 
+	// Validate values files before any network calls so local errors fail fast.
+	values, err := LoadAndMergeValues(p.ValuesFiles)
+	if err != nil {
+		return fmt.Errorf("loading values files: %w", err)
+	}
+
 	username, password, err := p.resolveCredentials(ctx)
 	if err != nil {
 		return err
@@ -124,11 +150,6 @@ func (p *PCApps) Install(ctx context.Context) error {
 	log.Printf("Authenticating against OCI registry %q...\n", host)
 	if err := p.Helm.LoginRegistry(ctx, host, username, password); err != nil {
 		return fmt.Errorf("registry login failed: %w", err)
-	}
-
-	values, err := LoadAndMergeValues(p.ValuesFiles)
-	if err != nil {
-		return fmt.Errorf("loading values files: %w", err)
 	}
 
 	cfg := ChartConfig{

--- a/internal/installer/pc_apps.go
+++ b/internal/installer/pc_apps.go
@@ -12,7 +12,18 @@ import (
 	"path"
 	"strings"
 
+	k8s "github.com/codesphere-cloud/oms/internal/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"gopkg.in/yaml.v3"
+)
+
+const (
+	// ociCredentialSecretName is the K8s Secret created by "oms beta install argocd"
+	// that stores OCI registry credentials for pulling Codesphere charts.
+	ociCredentialSecretName = "argocd-codesphere-oci-read"
+	// ociCredentialNamespace is the namespace where the credential secret lives.
+	ociCredentialNamespace = "argocd"
 )
 
 // PCApps holds the configuration for installing the pc-apps Helm chart from
@@ -21,13 +32,15 @@ type PCApps struct {
 	ChartURL    string   // full OCI chart reference, e.g. "oci://ghcr.io/codesphere-cloud/charts/pc-apps"
 	Version     string   // chart version ("" means latest)
 	Namespace   string   // target namespace (default: "argocd")
-	Username    string   // OCI registry username
-	Password    string   // OCI registry password/token
+	Username    string   // OCI registry username (optional, falls back to K8s secret)
+	Password    string   // OCI registry password/token (optional, falls back to K8s secret)
 	ValuesFiles []string // paths to values YAML files, merged in order
 	Helm        HelmClient
+	Clientset   kubernetes.Interface
 }
 
-// NewPCApps creates a new PCApps installer with a real Helm client.
+// NewPCApps creates a new PCApps installer with a real Helm client and
+// Kubernetes clientset for credential fallback.
 func NewPCApps(chartURL, version, namespace, username, password string, valuesFiles []string) (*PCApps, error) {
 	if namespace == "" {
 		namespace = "argocd"
@@ -38,6 +51,11 @@ func NewPCApps(chartURL, version, namespace, username, password string, valuesFi
 		return nil, fmt.Errorf("creating helm client: %w", err)
 	}
 
+	clientset, _, err := k8s.NewClients()
+	if err != nil {
+		return nil, fmt.Errorf("creating kubernetes clients: %w", err)
+	}
+
 	return &PCApps{
 		ChartURL:    chartURL,
 		Version:     version,
@@ -46,7 +64,39 @@ func NewPCApps(chartURL, version, namespace, username, password string, valuesFi
 		Password:    password,
 		ValuesFiles: valuesFiles,
 		Helm:        helm,
+		Clientset:   clientset,
 	}, nil
+}
+
+// resolveCredentials returns the username and password to use for OCI registry
+// authentication. If explicit credentials are provided on the struct, those are
+// used. Otherwise it falls back to reading the K8s Secret created by
+// "oms beta install argocd".
+func (p *PCApps) resolveCredentials(ctx context.Context) (username, password string, err error) {
+	if p.Username != "" && p.Password != "" {
+		return p.Username, p.Password, nil
+	}
+
+	secret, err := p.Clientset.CoreV1().Secrets(ociCredentialNamespace).Get(ctx, ociCredentialSecretName, metav1.GetOptions{})
+	if err != nil {
+		return "", "", fmt.Errorf(
+			"no credentials provided and K8s secret %q not found in namespace %q: %w\n"+
+				"Provide --username or run 'oms beta install argocd' first",
+			ociCredentialSecretName, ociCredentialNamespace, err,
+		)
+	}
+
+	username = string(secret.Data["username"])
+	password = string(secret.Data["password"])
+	if username == "" || password == "" {
+		return "", "", fmt.Errorf(
+			"K8s secret %q in namespace %q is missing username or password fields",
+			ociCredentialSecretName, ociCredentialNamespace,
+		)
+	}
+
+	log.Printf("Using credentials from K8s secret %q\n", ociCredentialSecretName)
+	return username, password, nil
 }
 
 // Install authenticates against the OCI registry and installs or upgrades the
@@ -57,8 +107,13 @@ func (p *PCApps) Install(ctx context.Context) error {
 		return err
 	}
 
+	username, password, err := p.resolveCredentials(ctx)
+	if err != nil {
+		return err
+	}
+
 	log.Printf("Authenticating against OCI registry %q...\n", host)
-	if err := p.Helm.LoginRegistry(ctx, host, p.Username, p.Password); err != nil {
+	if err := p.Helm.LoginRegistry(ctx, host, username, password); err != nil {
 		return fmt.Errorf("registry login failed: %w", err)
 	}
 

--- a/internal/installer/pc_apps.go
+++ b/internal/installer/pc_apps.go
@@ -5,6 +5,7 @@ package installer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -25,6 +26,8 @@ const (
 	ociCredentialNamespace = "argocd"
 	// pcAppsReleaseName is the fixed Helm release name for the pc-applications chart.
 	pcAppsReleaseName = "pc-applications"
+	// pcAppsChartName is the chart name used when constructing the OCI chart URL.
+	pcAppsChartName = "pc-applications"
 )
 
 // PCApps holds the configuration for installing the pc-applications Helm chart
@@ -42,10 +45,10 @@ type PCApps struct {
 // declarations only.
 func NewPCApps(c client.Client, version, namespace string, valuesFiles []string) (*PCApps, error) {
 	if version == "" {
-		return nil, fmt.Errorf("version is required")
+		return nil, errors.New("version is required")
 	}
 	if namespace == "" {
-		return nil, fmt.Errorf("namespace is required")
+		return nil, errors.New("namespace is required")
 	}
 
 	helm, err := NewHelmClient(namespace)
@@ -87,7 +90,7 @@ func (p *PCApps) resolveFromSecret(ctx context.Context) (chartURL, username, pas
 		)
 	}
 
-	chartURL = "oci://" + baseURL + "/" + pcAppsReleaseName
+	chartURL = "oci://" + baseURL + "/" + pcAppsChartName
 	log.Printf("Using credentials from K8s secret %q (registry: %s)\n", ociCredentialSecretName, baseURL)
 	return chartURL, username, password, nil
 }

--- a/internal/installer/pc_apps.go
+++ b/internal/installer/pc_apps.go
@@ -33,11 +33,11 @@ const (
 // PCApps holds the configuration for installing the pc-applications Helm chart
 // from a private OCI registry.
 type PCApps struct {
-	Version     string   // chart version (required)
-	Namespace   string   // target namespace for the Helm release
-	ValuesFiles []string // paths to values YAML files, merged in order
-	Helm        HelmClient
-	Client      client.Client
+	version     string   // chart version (required)
+	namespace   string   // target namespace for the Helm release
+	valuesFiles []string // paths to values YAML files, merged in order
+	helm        HelmClient
+	client      client.Client
 }
 
 // NewPCApps creates a new PCApps installer. It validates that required fields
@@ -57,11 +57,11 @@ func NewPCApps(c client.Client, version, namespace string, valuesFiles []string)
 	}
 
 	return &PCApps{
-		Version:     version,
-		Namespace:   namespace,
-		ValuesFiles: valuesFiles,
-		Helm:        helm,
-		Client:      c,
+		version:     version,
+		namespace:   namespace,
+		valuesFiles: valuesFiles,
+		helm:        helm,
+		client:      c,
 	}, nil
 }
 
@@ -71,7 +71,7 @@ func NewPCApps(c client.Client, version, namespace string, valuesFiles []string)
 func (p *PCApps) resolveFromSecret(ctx context.Context) (chartURL, username, password string, err error) {
 	secret := &corev1.Secret{}
 	key := client.ObjectKey{Name: ociCredentialSecretName, Namespace: ociCredentialNamespace}
-	if err := p.Client.Get(ctx, key, secret); err != nil {
+	if err := p.client.Get(ctx, key, secret); err != nil {
 		return "", "", "", fmt.Errorf(
 			"K8s secret %q not found in namespace %q: %w\n"+
 				"Run 'oms beta install argocd --deploy-dc-config' first to create registry credentials",
@@ -99,7 +99,7 @@ func (p *PCApps) resolveFromSecret(ctx context.Context) (chartURL, username, pas
 // pc-applications Helm chart.
 func (p *PCApps) Install(ctx context.Context) error {
 	// Validate values files before any network calls so local errors fail fast.
-	valueOpts := values.Options{ValueFiles: p.ValuesFiles}
+	valueOpts := values.Options{ValueFiles: p.valuesFiles}
 	vals, err := valueOpts.MergeValues(getter.All(cli.New()))
 	if err != nil {
 		return fmt.Errorf("loading values files: %w", err)
@@ -119,24 +119,36 @@ func (p *PCApps) Install(ctx context.Context) error {
 	}
 
 	log.Printf("Authenticating against OCI registry %q...\n", parsed.Host)
-	if err := p.Helm.LoginRegistry(ctx, parsed.Host, username, password); err != nil {
+	if err := p.helm.LoginRegistry(ctx, parsed.Host, username, password); err != nil {
 		return fmt.Errorf("registry login failed: %w", err)
 	}
 
 	cfg := ChartConfig{
 		ReleaseName:     pcAppsReleaseName,
 		ChartName:       chartURL,
-		Namespace:       p.Namespace,
-		Version:         p.Version,
+		Namespace:       p.namespace,
+		Version:         p.version,
 		Values:          vals,
 		CreateNamespace: true,
 	}
 
-	log.Printf("Installing/Upgrading %s (version %s) into namespace %s\n", pcAppsReleaseName, p.Version, p.Namespace)
-	if err := p.Helm.UpgradeChart(ctx, cfg, UpgradeChartOptions{InstallIfNotExist: true}); err != nil {
+	log.Printf("Installing/Upgrading %s (version %s) into namespace %s\n", pcAppsReleaseName, p.version, p.namespace)
+	if err := p.helm.UpgradeChart(ctx, cfg, UpgradeChartOptions{InstallIfNotExist: true}); err != nil {
 		return fmt.Errorf("install/upgrade failed: %w", err)
 	}
 
 	fmt.Printf("Successfully installed/upgraded %s\n", pcAppsReleaseName)
 	return nil
+}
+
+// NewPCAppsForTesting creates a PCApps instance with injected dependencies for
+// use in tests. This avoids exporting struct fields solely for test access.
+func NewPCAppsForTesting(helm HelmClient, c client.Client, version, namespace string, valuesFiles []string) *PCApps {
+	return &PCApps{
+		version:     version,
+		namespace:   namespace,
+		valuesFiles: valuesFiles,
+		helm:        helm,
+		client:      c,
+	}
 }

--- a/internal/installer/pc_apps.go
+++ b/internal/installer/pc_apps.go
@@ -8,14 +8,13 @@ import (
 	"fmt"
 	"log"
 	"net/url"
-	"os"
-	"path"
-	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"helm.sh/helm/v4/pkg/cli"
+	"helm.sh/helm/v4/pkg/cli/values"
+	"helm.sh/helm/v4/pkg/getter"
 )
 
 const (
@@ -24,26 +23,29 @@ const (
 	ociCredentialSecretName = "argocd-codesphere-oci-read"
 	// ociCredentialNamespace is the namespace where the credential secret lives.
 	ociCredentialNamespace = "argocd"
+	// pcAppsReleaseName is the fixed Helm release name for the pc-applications chart.
+	pcAppsReleaseName = "pc-applications"
 )
 
-// PCApps holds the configuration for installing the pc-apps Helm chart from
-// a private OCI registry.
+// PCApps holds the configuration for installing the pc-applications Helm chart
+// from a private OCI registry.
 type PCApps struct {
-	ChartURL    string   // full OCI chart reference, e.g. "oci://ghcr.io/codesphere-cloud/charts/pc-apps"
-	Version     string   // chart version ("" means latest)
-	Namespace   string   // target namespace (default: "argocd")
-	Username    string   // OCI registry username (optional, falls back to K8s secret)
-	Password    string   // OCI registry password/token (optional, falls back to K8s secret)
+	Version     string   // chart version (required)
+	Namespace   string   // target namespace for the Helm release
 	ValuesFiles []string // paths to values YAML files, merged in order
 	Helm        HelmClient
-	Clientset   kubernetes.Interface
+	Client      client.Client
 }
 
-// NewPCApps creates a new PCApps installer with a real Helm client and
-// Kubernetes clientset for credential fallback.
-func NewPCApps(chartURL, version, namespace, username, password string, valuesFiles []string) (*PCApps, error) {
+// NewPCApps creates a new PCApps installer. It validates that required fields
+// are non-empty but does not apply defaults — defaults live on the CLI flag
+// declarations only.
+func NewPCApps(c client.Client, version, namespace string, valuesFiles []string) (*PCApps, error) {
+	if version == "" {
+		return nil, fmt.Errorf("version is required")
+	}
 	if namespace == "" {
-		namespace = "argocd"
+		return nil, fmt.Errorf("namespace is required")
 	}
 
 	helm, err := NewHelmClient(namespace)
@@ -51,209 +53,87 @@ func NewPCApps(chartURL, version, namespace, username, password string, valuesFi
 		return nil, fmt.Errorf("creating helm client: %w", err)
 	}
 
-	clientset, err := newTypedK8sClient()
-	if err != nil {
-		return nil, fmt.Errorf("creating kubernetes client: %w", err)
-	}
-
 	return &PCApps{
-		ChartURL:    chartURL,
 		Version:     version,
 		Namespace:   namespace,
-		Username:    username,
-		Password:    password,
 		ValuesFiles: valuesFiles,
 		Helm:        helm,
-		Clientset:   clientset,
+		Client:      c,
 	}, nil
 }
 
-// newTypedK8sClient builds only a typed kubernetes.Interface from the
-// current kubeconfig, avoiding construction of an unused dynamic client.
-func newTypedK8sClient() (kubernetes.Interface, error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	configOverrides := &clientcmd.ConfigOverrides{}
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-
-	cfg, err := kubeConfig.ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("loading kubeconfig: %w", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("creating kubernetes clientset: %w", err)
-	}
-
-	return clientset, nil
-}
-
-// resolveCredentials returns the username and password to use for OCI registry
-// authentication. If explicit credentials are provided on the struct, those are
-// used. Otherwise it falls back to reading the K8s Secret created by
-// "oms beta install argocd".
-func (p *PCApps) resolveCredentials(ctx context.Context) (username, password string, err error) {
-	if p.Username != "" && p.Password != "" {
-		return p.Username, p.Password, nil
-	}
-
-	// Partial credentials (one set, the other missing) are treated as an error
-	// to avoid silently falling back with potentially mismatched credentials.
-	if p.Username != "" && p.Password == "" {
-		return "", "", fmt.Errorf("--username was provided but password is missing; set OMS_REPO_PASSWORD or enter it when prompted")
-	}
-	if p.Username == "" && p.Password != "" {
-		return "", "", fmt.Errorf("password was provided but --username is missing")
-	}
-
-	secret, err := p.Clientset.CoreV1().Secrets(ociCredentialNamespace).Get(ctx, ociCredentialSecretName, metav1.GetOptions{})
-	if err != nil {
-		return "", "", fmt.Errorf(
-			"no credentials provided and K8s secret %q not found in namespace %q: %w\n"+
-				"Provide --username or run 'oms beta install argocd --deploy-dc-config --registry-password <token>' first",
+// resolveFromSecret reads the OCI registry credentials and chart base URL from
+// the K8s Secret created by "oms beta install argocd --deploy-dc-config".
+// It returns the full OCI chart URL, username, and password.
+func (p *PCApps) resolveFromSecret(ctx context.Context) (chartURL, username, password string, err error) {
+	secret := &corev1.Secret{}
+	key := client.ObjectKey{Name: ociCredentialSecretName, Namespace: ociCredentialNamespace}
+	if err := p.Client.Get(ctx, key, secret); err != nil {
+		return "", "", "", fmt.Errorf(
+			"K8s secret %q not found in namespace %q: %w\n"+
+				"Run 'oms beta install argocd --deploy-dc-config' first to create registry credentials",
 			ociCredentialSecretName, ociCredentialNamespace, err,
 		)
 	}
 
+	baseURL := string(secret.Data["url"])
 	username = string(secret.Data["username"])
 	password = string(secret.Data["password"])
-	if username == "" || password == "" {
-		return "", "", fmt.Errorf(
-			"K8s secret %q in namespace %q is missing username or password fields",
+
+	if baseURL == "" || username == "" || password == "" {
+		return "", "", "", fmt.Errorf(
+			"K8s secret %q in namespace %q is missing required fields (url, username, or password)",
 			ociCredentialSecretName, ociCredentialNamespace,
 		)
 	}
 
-	log.Printf("Using credentials from K8s secret %q\n", ociCredentialSecretName)
-	return username, password, nil
+	chartURL = "oci://" + baseURL + "/" + pcAppsReleaseName
+	log.Printf("Using credentials from K8s secret %q (registry: %s)\n", ociCredentialSecretName, baseURL)
+	return chartURL, username, password, nil
 }
 
 // Install authenticates against the OCI registry and installs or upgrades the
-// pc-apps Helm chart.
+// pc-applications Helm chart.
 func (p *PCApps) Install(ctx context.Context) error {
-	host, releaseName, err := parseOCIChartURL(p.ChartURL)
-	if err != nil {
-		return err
-	}
-
 	// Validate values files before any network calls so local errors fail fast.
-	values, err := LoadAndMergeValues(p.ValuesFiles)
+	valueOpts := values.Options{ValueFiles: p.ValuesFiles}
+	vals, err := valueOpts.MergeValues(getter.All(cli.New()))
 	if err != nil {
 		return fmt.Errorf("loading values files: %w", err)
 	}
 
-	username, password, err := p.resolveCredentials(ctx)
+	chartURL, username, password, err := p.resolveFromSecret(ctx)
 	if err != nil {
 		return err
 	}
 
-	log.Printf("Authenticating against OCI registry %q...\n", host)
-	if err := p.Helm.LoginRegistry(ctx, host, username, password); err != nil {
+	parsed, err := url.Parse(chartURL)
+	if err != nil {
+		return fmt.Errorf("parsing chart URL %q: %w", chartURL, err)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("chart URL %q has no host", chartURL)
+	}
+
+	log.Printf("Authenticating against OCI registry %q...\n", parsed.Host)
+	if err := p.Helm.LoginRegistry(ctx, parsed.Host, username, password); err != nil {
 		return fmt.Errorf("registry login failed: %w", err)
 	}
 
 	cfg := ChartConfig{
-		ReleaseName:     releaseName,
-		ChartName:       p.ChartURL,
+		ReleaseName:     pcAppsReleaseName,
+		ChartName:       chartURL,
 		Namespace:       p.Namespace,
 		Version:         p.Version,
-		Values:          values,
+		Values:          vals,
 		CreateNamespace: true,
 	}
 
-	if p.Version != "" {
-		log.Printf("Installing/Upgrading %s (version %s) into namespace %s\n", releaseName, p.Version, p.Namespace)
-	} else {
-		log.Printf("Installing/Upgrading %s (latest) into namespace %s\n", releaseName, p.Namespace)
+	log.Printf("Installing/Upgrading %s (version %s) into namespace %s\n", pcAppsReleaseName, p.Version, p.Namespace)
+	if err := p.Helm.UpgradeChart(ctx, cfg, UpgradeChartOptions{InstallIfNotExist: true}); err != nil {
+		return fmt.Errorf("install/upgrade failed: %w", err)
 	}
 
-	existing, err := p.Helm.FindRelease(p.Namespace, releaseName)
-	if err != nil {
-		return fmt.Errorf("checking existing release: %w", err)
-	}
-
-	if existing != nil {
-		log.Printf("Found existing release %s (chart version %s), upgrading...\n", releaseName, existing.InstalledVersion)
-		if err := p.Helm.UpgradeChart(ctx, cfg, UpgradeChartOptions{}); err != nil {
-			return fmt.Errorf("upgrade failed: %w", err)
-		}
-		fmt.Printf("Successfully upgraded %s\n", releaseName)
-	} else {
-		log.Printf("No existing release found, performing fresh install...\n")
-		if err := p.Helm.InstallChart(ctx, cfg); err != nil {
-			return fmt.Errorf("install failed: %w", err)
-		}
-		fmt.Printf("Successfully installed %s\n", releaseName)
-	}
-
+	fmt.Printf("Successfully installed/upgraded %s\n", pcAppsReleaseName)
 	return nil
-}
-
-// parseOCIChartURL extracts the registry host and chart name from an OCI URL.
-// Example: "oci://ghcr.io/codesphere-cloud/charts/pc-apps" -> ("ghcr.io", "pc-apps", nil)
-func parseOCIChartURL(chartURL string) (host string, chartName string, err error) {
-	if !strings.HasPrefix(chartURL, "oci://") {
-		return "", "", fmt.Errorf("chart URL must start with \"oci://\", got %q", chartURL)
-	}
-
-	// Replace oci:// with https:// for standard URL parsing
-	parsed, err := url.Parse(strings.Replace(chartURL, "oci://", "https://", 1))
-	if err != nil {
-		return "", "", fmt.Errorf("parsing chart URL %q: %w", chartURL, err)
-	}
-
-	host = parsed.Host
-	if host == "" {
-		return "", "", fmt.Errorf("chart URL %q has no host", chartURL)
-	}
-
-	chartName = path.Base(parsed.Path)
-	if chartName == "" || chartName == "." || chartName == "/" {
-		return "", "", fmt.Errorf("chart URL %q has no chart name in path", chartURL)
-	}
-
-	return host, chartName, nil
-}
-
-// LoadAndMergeValues reads multiple YAML values files and deep-merges them in
-// order (later files override earlier ones).
-func LoadAndMergeValues(files []string) (map[string]interface{}, error) {
-	merged := map[string]interface{}{}
-
-	for _, f := range files {
-		data, err := os.ReadFile(f)
-		if err != nil {
-			return nil, fmt.Errorf("reading values file %q: %w", f, err)
-		}
-
-		var vals map[string]interface{}
-		if err := yaml.Unmarshal(data, &vals); err != nil {
-			return nil, fmt.Errorf("parsing values file %q: %w", f, err)
-		}
-
-		merged = deepMerge(merged, vals)
-	}
-
-	return merged, nil
-}
-
-// deepMerge recursively merges src into dst. Values in src take precedence.
-func deepMerge(dst, src map[string]interface{}) map[string]interface{} {
-	for key, srcVal := range src {
-		dstVal, exists := dst[key]
-		if !exists {
-			dst[key] = srcVal
-			continue
-		}
-
-		// If both are maps, recurse
-		srcMap, srcOk := srcVal.(map[string]interface{})
-		dstMap, dstOk := dstVal.(map[string]interface{})
-		if srcOk && dstOk {
-			dst[key] = deepMerge(dstMap, srcMap)
-		} else {
-			dst[key] = srcVal
-		}
-	}
-	return dst
 }

--- a/internal/installer/pc_apps.go
+++ b/internal/installer/pc_apps.go
@@ -1,0 +1,174 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package installer
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PCApps holds the configuration for installing the pc-apps Helm chart from
+// a private OCI registry.
+type PCApps struct {
+	ChartURL    string   // full OCI chart reference, e.g. "oci://ghcr.io/codesphere-cloud/charts/pc-apps"
+	Version     string   // chart version ("" means latest)
+	Namespace   string   // target namespace (default: "argocd")
+	Username    string   // OCI registry username
+	Password    string   // OCI registry password/token
+	ValuesFiles []string // paths to values YAML files, merged in order
+	Helm        HelmClient
+}
+
+// NewPCApps creates a new PCApps installer with a real Helm client.
+func NewPCApps(chartURL, version, namespace, username, password string, valuesFiles []string) (*PCApps, error) {
+	if namespace == "" {
+		namespace = "argocd"
+	}
+
+	helm, err := NewHelmClient(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("creating helm client: %w", err)
+	}
+
+	return &PCApps{
+		ChartURL:    chartURL,
+		Version:     version,
+		Namespace:   namespace,
+		Username:    username,
+		Password:    password,
+		ValuesFiles: valuesFiles,
+		Helm:        helm,
+	}, nil
+}
+
+// Install authenticates against the OCI registry and installs or upgrades the
+// pc-apps Helm chart.
+func (p *PCApps) Install(ctx context.Context) error {
+	host, releaseName, err := parseOCIChartURL(p.ChartURL)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Authenticating against OCI registry %q...\n", host)
+	if err := p.Helm.LoginRegistry(ctx, host, p.Username, p.Password); err != nil {
+		return fmt.Errorf("registry login failed: %w", err)
+	}
+
+	values, err := LoadAndMergeValues(p.ValuesFiles)
+	if err != nil {
+		return fmt.Errorf("loading values files: %w", err)
+	}
+
+	cfg := ChartConfig{
+		ReleaseName:     releaseName,
+		ChartName:       p.ChartURL,
+		Namespace:       p.Namespace,
+		Version:         p.Version,
+		Values:          values,
+		CreateNamespace: true,
+	}
+
+	if p.Version != "" {
+		log.Printf("Installing/Upgrading %s (version %s) into namespace %s\n", releaseName, p.Version, p.Namespace)
+	} else {
+		log.Printf("Installing/Upgrading %s (latest) into namespace %s\n", releaseName, p.Namespace)
+	}
+
+	existing, err := p.Helm.FindRelease(p.Namespace, releaseName)
+	if err != nil {
+		return fmt.Errorf("checking existing release: %w", err)
+	}
+
+	if existing != nil {
+		log.Printf("Found existing release %s (chart version %s), upgrading...\n", releaseName, existing.InstalledVersion)
+		if err := p.Helm.UpgradeChart(ctx, cfg, UpgradeChartOptions{}); err != nil {
+			return fmt.Errorf("upgrade failed: %w", err)
+		}
+		fmt.Printf("Successfully upgraded %s\n", releaseName)
+	} else {
+		log.Printf("No existing release found, performing fresh install...\n")
+		if err := p.Helm.InstallChart(ctx, cfg); err != nil {
+			return fmt.Errorf("install failed: %w", err)
+		}
+		fmt.Printf("Successfully installed %s\n", releaseName)
+	}
+
+	return nil
+}
+
+// parseOCIChartURL extracts the registry host and chart name from an OCI URL.
+// Example: "oci://ghcr.io/codesphere-cloud/charts/pc-apps" -> ("ghcr.io", "pc-apps", nil)
+func parseOCIChartURL(chartURL string) (host string, chartName string, err error) {
+	if !strings.HasPrefix(chartURL, "oci://") {
+		return "", "", fmt.Errorf("chart URL must start with \"oci://\", got %q", chartURL)
+	}
+
+	// Replace oci:// with https:// for standard URL parsing
+	parsed, err := url.Parse(strings.Replace(chartURL, "oci://", "https://", 1))
+	if err != nil {
+		return "", "", fmt.Errorf("parsing chart URL %q: %w", chartURL, err)
+	}
+
+	host = parsed.Host
+	if host == "" {
+		return "", "", fmt.Errorf("chart URL %q has no host", chartURL)
+	}
+
+	chartName = path.Base(parsed.Path)
+	if chartName == "" || chartName == "." || chartName == "/" {
+		return "", "", fmt.Errorf("chart URL %q has no chart name in path", chartURL)
+	}
+
+	return host, chartName, nil
+}
+
+// LoadAndMergeValues reads multiple YAML values files and deep-merges them in
+// order (later files override earlier ones).
+func LoadAndMergeValues(files []string) (map[string]interface{}, error) {
+	merged := map[string]interface{}{}
+
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			return nil, fmt.Errorf("reading values file %q: %w", f, err)
+		}
+
+		var vals map[string]interface{}
+		if err := yaml.Unmarshal(data, &vals); err != nil {
+			return nil, fmt.Errorf("parsing values file %q: %w", f, err)
+		}
+
+		merged = deepMerge(merged, vals)
+	}
+
+	return merged, nil
+}
+
+// deepMerge recursively merges src into dst. Values in src take precedence.
+func deepMerge(dst, src map[string]interface{}) map[string]interface{} {
+	for key, srcVal := range src {
+		dstVal, exists := dst[key]
+		if !exists {
+			dst[key] = srcVal
+			continue
+		}
+
+		// If both are maps, recurse
+		srcMap, srcOk := srcVal.(map[string]interface{})
+		dstMap, dstOk := dstVal.(map[string]interface{})
+		if srcOk && dstOk {
+			dst[key] = deepMerge(dstMap, srcMap)
+		} else {
+			dst[key] = srcVal
+		}
+	}
+	return dst
+}

--- a/internal/installer/pc_apps.go
+++ b/internal/installer/pc_apps.go
@@ -68,7 +68,7 @@ func NewPCApps(c client.Client, version, namespace string, valuesFiles []string)
 // resolveFromSecret reads the OCI registry credentials and chart base URL from
 // the K8s Secret created by "oms beta install argocd --deploy-dc-config".
 // It returns the full OCI chart URL, username, and password.
-func (p *PCApps) resolveFromSecret(ctx context.Context) (chartURL, username, password string, err error) {
+func (p *PCApps) resolveFromSecret(ctx context.Context) (chartURL, username, password string, _ error) {
 	secret := &corev1.Secret{}
 	key := client.ObjectKey{Name: ociCredentialSecretName, Namespace: ociCredentialNamespace}
 	if err := p.client.Get(ctx, key, secret); err != nil {
@@ -90,7 +90,11 @@ func (p *PCApps) resolveFromSecret(ctx context.Context) (chartURL, username, pas
 		)
 	}
 
-	chartURL = "oci://" + baseURL + "/" + pcAppsChartName
+	joined, err := url.JoinPath("oci://"+baseURL, pcAppsChartName)
+	if err != nil {
+		return "", "", "", fmt.Errorf("constructing chart URL: %w", err)
+	}
+	chartURL = joined
 	log.Printf("Using credentials from K8s secret %q (registry: %s)\n", ociCredentialSecretName, baseURL)
 	return chartURL, username, password, nil
 }
@@ -137,7 +141,7 @@ func (p *PCApps) Install(ctx context.Context) error {
 		return fmt.Errorf("install/upgrade failed: %w", err)
 	}
 
-	fmt.Printf("Successfully installed/upgraded %s\n", pcAppsReleaseName)
+	log.Printf("Successfully installed/upgraded %s\n", pcAppsReleaseName)
 	return nil
 }
 

--- a/internal/installer/pc_apps.go
+++ b/internal/installer/pc_apps.go
@@ -77,6 +77,15 @@ func (p *PCApps) resolveCredentials(ctx context.Context) (username, password str
 		return p.Username, p.Password, nil
 	}
 
+	// Partial credentials (one set, the other missing) are treated as an error
+	// to avoid silently falling back with potentially mismatched credentials.
+	if p.Username != "" && p.Password == "" {
+		return "", "", fmt.Errorf("--username was provided but password is missing; set OMS_REPO_PASSWORD or enter it when prompted")
+	}
+	if p.Username == "" && p.Password != "" {
+		return "", "", fmt.Errorf("password was provided but --username is missing")
+	}
+
 	secret, err := p.Clientset.CoreV1().Secrets(ociCredentialNamespace).Get(ctx, ociCredentialSecretName, metav1.GetOptions{})
 	if err != nil {
 		return "", "", fmt.Errorf(

--- a/internal/installer/pc_apps_test.go
+++ b/internal/installer/pc_apps_test.go
@@ -267,8 +267,6 @@ var _ = Describe("PCApps.Install", func() {
 		It("returns an error for non-existent values file", func() {
 			pcApps.ValuesFiles = []string{"/nonexistent/values.yaml"}
 
-			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", username, password).Return(nil)
-
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("reading values file"))
@@ -279,8 +277,6 @@ var _ = Describe("PCApps.Install", func() {
 			Expect(os.WriteFile(badFile, []byte("{{invalid yaml"), 0644)).To(Succeed())
 
 			pcApps.ValuesFiles = []string{badFile}
-
-			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", username, password).Return(nil)
 
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())

--- a/internal/installer/pc_apps_test.go
+++ b/internal/installer/pc_apps_test.go
@@ -70,12 +70,7 @@ var _ = Describe("PCApps.Install", func() {
 				WithScheme(scheme).
 				WithObjects(newSecret()).
 				Build()
-			pcApps = &installer.PCApps{
-				Version:   version,
-				Namespace: namespace,
-				Helm:      helmMock,
-				Client:    fakeClient,
-			}
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil)
 		})
 
 		It("reads credentials from K8s secret and calls UpgradeChart with InstallIfNotExist", func() {
@@ -109,12 +104,7 @@ var _ = Describe("PCApps.Install", func() {
 				WithScheme(scheme).
 				WithObjects(newSecret()).
 				Build()
-			pcApps = &installer.PCApps{
-				Version:   version,
-				Namespace: namespace,
-				Helm:      helmMock,
-				Client:    fakeClient,
-			}
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil)
 		})
 
 		It("returns an error without attempting install", func() {
@@ -133,12 +123,7 @@ var _ = Describe("PCApps.Install", func() {
 			fakeClient = fake.NewClientBuilder().
 				WithScheme(scheme).
 				Build()
-			pcApps = &installer.PCApps{
-				Version:   version,
-				Namespace: namespace,
-				Helm:      helmMock,
-				Client:    fakeClient,
-			}
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil)
 		})
 
 		It("returns a clear error", func() {
@@ -166,12 +151,7 @@ var _ = Describe("PCApps.Install", func() {
 				WithScheme(scheme).
 				WithObjects(secret).
 				Build()
-			pcApps = &installer.PCApps{
-				Version:   version,
-				Namespace: namespace,
-				Helm:      helmMock,
-				Client:    fakeClient,
-			}
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil)
 		})
 
 		It("returns an error about missing fields", func() {
@@ -206,13 +186,7 @@ var _ = Describe("PCApps.Install", func() {
 			overlay := filepath.Join(tmpDir, "overlay.yaml")
 			Expect(os.WriteFile(overlay, []byte("foo: overridden\nnested:\n  b: 99\n  c: 3\n"), 0644)).To(Succeed())
 
-			pcApps = &installer.PCApps{
-				Version:     version,
-				Namespace:   namespace,
-				ValuesFiles: []string{base, overlay},
-				Helm:        helmMock,
-				Client:      fakeClient,
-			}
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{base, overlay})
 
 			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).Return(nil)
 			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
@@ -231,13 +205,7 @@ var _ = Describe("PCApps.Install", func() {
 		})
 
 		It("returns an error for non-existent values file", func() {
-			pcApps = &installer.PCApps{
-				Version:     version,
-				Namespace:   namespace,
-				ValuesFiles: []string{"/nonexistent/values.yaml"},
-				Helm:        helmMock,
-				Client:      fakeClient,
-			}
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{"/nonexistent/values.yaml"})
 
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())
@@ -248,13 +216,7 @@ var _ = Describe("PCApps.Install", func() {
 			badFile := filepath.Join(tmpDir, "bad.yaml")
 			Expect(os.WriteFile(badFile, []byte("{{invalid yaml"), 0644)).To(Succeed())
 
-			pcApps = &installer.PCApps{
-				Version:     version,
-				Namespace:   namespace,
-				ValuesFiles: []string{badFile},
-				Helm:        helmMock,
-				Client:      fakeClient,
-			}
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{badFile})
 
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())

--- a/internal/installer/pc_apps_test.go
+++ b/internal/installer/pc_apps_test.go
@@ -237,7 +237,7 @@ var _ = Describe("PCApps.Install", func() {
 		})
 
 		AfterEach(func() {
-			os.RemoveAll(tmpDir)
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
 		})
 
 		It("merges multiple values files in order", func() {
@@ -299,7 +299,7 @@ var _ = Describe("LoadAndMergeValues", func() {
 	})
 
 	AfterEach(func() {
-		os.RemoveAll(tmpDir)
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 	})
 
 	It("returns empty map for no files", func() {

--- a/internal/installer/pc_apps_test.go
+++ b/internal/installer/pc_apps_test.go
@@ -6,7 +6,6 @@ package installer_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -80,7 +79,7 @@ var _ = Describe("PCApps.Install", func() {
 					cfg.ChartName == expectedChartURL &&
 					cfg.Namespace == namespace &&
 					cfg.Version == version &&
-					cfg.CreateNamespace == true
+					cfg.CreateNamespace
 			}), installer.UpgradeChartOptions{InstallIfNotExist: true}).Return(nil)
 
 			err := pcApps.Install(context.Background())
@@ -195,9 +194,9 @@ var _ = Describe("PCApps.Install", func() {
 					return false
 				}
 				return cfg.Values["foo"] == "overridden" &&
-					fmt.Sprint(nested["a"]) == "1" &&
-					fmt.Sprint(nested["b"]) == "99" &&
-					fmt.Sprint(nested["c"]) == "3"
+					nested["a"].(float64) == 1 &&
+					nested["b"].(float64) == 99 &&
+					nested["c"].(float64) == 3
 			}), installer.UpgradeChartOptions{InstallIfNotExist: true}).Return(nil)
 
 			err := pcApps.Install(context.Background())

--- a/internal/installer/pc_apps_test.go
+++ b/internal/installer/pc_apps_test.go
@@ -6,6 +6,7 @@ package installer_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -15,110 +16,109 @@ import (
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("PCApps.Install", func() {
 	const (
-		chartURL  = "oci://ghcr.io/codesphere-cloud/charts/pc-apps"
 		version   = "1.2.3"
 		namespace = "argocd"
-		username  = "CodesphereBot"
-		password  = "super-secret-token"
+
+		// Values matching the K8s secret template from argocd_resources.go
+		secretURL      = "ghcr.io/codesphere-cloud/charts"
+		secretUsername = "github"
+		secretPassword = "super-secret-token"
+
+		// Derived from the secret
+		expectedChartURL = "oci://ghcr.io/codesphere-cloud/charts/pc-applications"
 	)
 
 	var (
-		helmMock  *installer.MockHelmClient
-		clientset *fake.Clientset
-		pcApps    *installer.PCApps
+		helmMock   *installer.MockHelmClient
+		fakeClient client.Client
+		pcApps     *installer.PCApps
+		scheme     *runtime.Scheme
 	)
 
-	BeforeEach(func() {
-		helmMock = installer.NewMockHelmClient(GinkgoT())
-		clientset = fake.NewClientset()
-		pcApps = &installer.PCApps{
-			ChartURL:  chartURL,
-			Version:   version,
-			Namespace: namespace,
-			Username:  username,
-			Password:  password,
-			Helm:      helmMock,
-			Clientset: clientset,
+	newSecret := func() *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "argocd-codesphere-oci-read",
+				Namespace: "argocd",
+			},
+			Data: map[string][]byte{
+				"url":      []byte(secretURL),
+				"username": []byte(secretUsername),
+				"password": []byte(secretPassword),
+			},
 		}
+	}
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+
+		helmMock = installer.NewMockHelmClient(GinkgoT())
 	})
 
-	Context("fresh install (no existing release)", func() {
+	Context("successful install (secret exists)", func() {
 		BeforeEach(func() {
-			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", username, password).Return(nil)
-			helmMock.EXPECT().FindRelease(namespace, "pc-apps").Return(nil, nil)
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(newSecret()).
+				Build()
+			pcApps = &installer.PCApps{
+				Version:   version,
+				Namespace: namespace,
+				Helm:      helmMock,
+				Client:    fakeClient,
+			}
 		})
 
-		It("logs in to registry and installs the chart", func() {
-			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
-				return cfg.ReleaseName == "pc-apps" &&
-					cfg.ChartName == chartURL &&
+		It("reads credentials from K8s secret and calls UpgradeChart with InstallIfNotExist", func() {
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).Return(nil)
+			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				return cfg.ReleaseName == "pc-applications" &&
+					cfg.ChartName == expectedChartURL &&
 					cfg.Namespace == namespace &&
 					cfg.Version == version &&
 					cfg.CreateNamespace == true
-			})).Return(nil)
-
-			err := pcApps.Install(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("installs latest when version is empty", func() {
-			pcApps.Version = ""
-			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
-				return cfg.Version == ""
-			})).Return(nil)
-
-			err := pcApps.Install(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("returns an error when InstallChart fails", func() {
-			helmMock.EXPECT().InstallChart(mock.Anything, mock.Anything).
-				Return(errors.New("timeout"))
-
-			err := pcApps.Install(context.Background())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("install failed"))
-		})
-	})
-
-	Context("upgrade (existing release found)", func() {
-		BeforeEach(func() {
-			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", username, password).Return(nil)
-			helmMock.EXPECT().FindRelease(namespace, "pc-apps").Return(&installer.ReleaseInfo{
-				Name:             "pc-apps",
-				InstalledVersion: "1.0.0",
-			}, nil)
-		})
-
-		It("upgrades the existing release", func() {
-			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
-				return cfg.ReleaseName == "pc-apps" &&
-					cfg.ChartName == chartURL &&
-					cfg.Version == version
-			}), installer.UpgradeChartOptions{}).Return(nil)
+			}), installer.UpgradeChartOptions{InstallIfNotExist: true}).Return(nil)
 
 			err := pcApps.Install(context.Background())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("returns an error when UpgradeChart fails", func() {
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).Return(nil)
 			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.Anything, mock.Anything).
 				Return(errors.New("upgrade conflict"))
 
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("upgrade failed"))
+			Expect(err.Error()).To(ContainSubstring("install/upgrade failed"))
 		})
 	})
 
 	Context("registry login failure", func() {
+		BeforeEach(func() {
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(newSecret()).
+				Build()
+			pcApps = &installer.PCApps{
+				Version:   version,
+				Namespace: namespace,
+				Helm:      helmMock,
+				Client:    fakeClient,
+			}
+		})
+
 		It("returns an error without attempting install", func() {
-			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", username, password).
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).
 				Return(errors.New("invalid credentials"))
 
 			err := pcApps.Install(context.Background())
@@ -127,67 +127,18 @@ var _ = Describe("PCApps.Install", func() {
 		})
 	})
 
-	Context("invalid chart URL", func() {
-		It("rejects URLs without oci:// prefix", func() {
-			pcApps.ChartURL = "https://ghcr.io/codesphere-cloud/charts/pc-apps"
-
-			err := pcApps.Install(context.Background())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("must start with \"oci://\""))
-		})
-
-		It("rejects URLs with no host", func() {
-			pcApps.ChartURL = "oci:///charts/pc-apps"
-
-			err := pcApps.Install(context.Background())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("no host"))
-		})
-	})
-
-	Context("credential fallback from K8s secret", func() {
-		const (
-			secretUsername = "github"
-			secretPassword = "token-from-k8s-secret"
-		)
-
+	Context("no K8s secret", func() {
 		BeforeEach(func() {
-			// No explicit credentials
-			pcApps.Username = ""
-			pcApps.Password = ""
-
-			// Create the K8s secret that "install argocd" would have created
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd-codesphere-oci-read",
-					Namespace: "argocd",
-				},
-				Data: map[string][]byte{
-					"username": []byte(secretUsername),
-					"password": []byte(secretPassword),
-				},
+			// No objects in the fake client
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+			pcApps = &installer.PCApps{
+				Version:   version,
+				Namespace: namespace,
+				Helm:      helmMock,
+				Client:    fakeClient,
 			}
-			_, err := clientset.CoreV1().Secrets("argocd").Create(
-				context.Background(), secret, metav1.CreateOptions{},
-			)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("reads credentials from the K8s secret and installs successfully", func() {
-			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).Return(nil)
-			helmMock.EXPECT().FindRelease(namespace, "pc-apps").Return(nil, nil)
-			helmMock.EXPECT().InstallChart(mock.Anything, mock.Anything).Return(nil)
-
-			err := pcApps.Install(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Context("no credentials and no K8s secret", func() {
-		BeforeEach(func() {
-			pcApps.Username = ""
-			pcApps.Password = ""
-			// clientset has no secrets
 		})
 
 		It("returns a clear error suggesting how to fix", func() {
@@ -200,30 +151,33 @@ var _ = Describe("PCApps.Install", func() {
 
 	Context("K8s secret exists but missing fields", func() {
 		BeforeEach(func() {
-			pcApps.Username = ""
-			pcApps.Password = ""
-
-			// Secret exists but with empty data
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "argocd-codesphere-oci-read",
 					Namespace: "argocd",
 				},
 				Data: map[string][]byte{
-					"username": []byte("github"),
+					"url":      []byte(secretURL),
+					"username": []byte(secretUsername),
 					// password is missing
 				},
 			}
-			_, err := clientset.CoreV1().Secrets("argocd").Create(
-				context.Background(), secret, metav1.CreateOptions{},
-			)
-			Expect(err).ToNot(HaveOccurred())
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(secret).
+				Build()
+			pcApps = &installer.PCApps{
+				Version:   version,
+				Namespace: namespace,
+				Helm:      helmMock,
+				Client:    fakeClient,
+			}
 		})
 
 		It("returns an error about missing fields", func() {
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("missing username or password"))
+			Expect(err.Error()).To(ContainSubstring("missing required fields"))
 		})
 	})
 
@@ -234,99 +188,77 @@ var _ = Describe("PCApps.Install", func() {
 			var err error
 			tmpDir, err = os.MkdirTemp("", "pc-apps-test-*")
 			Expect(err).ToNot(HaveOccurred())
+
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(newSecret()).
+				Build()
 		})
 
 		AfterEach(func() {
 			Expect(os.RemoveAll(tmpDir)).To(Succeed())
 		})
 
-		It("merges multiple values files in order", func() {
+		It("merges multiple values files and passes them to the chart config", func() {
 			base := filepath.Join(tmpDir, "base.yaml")
 			Expect(os.WriteFile(base, []byte("foo: bar\nnested:\n  a: 1\n  b: 2\n"), 0644)).To(Succeed())
 
 			overlay := filepath.Join(tmpDir, "overlay.yaml")
 			Expect(os.WriteFile(overlay, []byte("foo: overridden\nnested:\n  b: 99\n  c: 3\n"), 0644)).To(Succeed())
 
-			pcApps.ValuesFiles = []string{base, overlay}
+			pcApps = &installer.PCApps{
+				Version:     version,
+				Namespace:   namespace,
+				ValuesFiles: []string{base, overlay},
+				Helm:        helmMock,
+				Client:      fakeClient,
+			}
 
-			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", username, password).Return(nil)
-			helmMock.EXPECT().FindRelease(namespace, "pc-apps").Return(nil, nil)
-			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
-				nested, ok := cfg.Values["nested"].(map[string]interface{})
-				return ok &&
-					cfg.Values["foo"] == "overridden" &&
-					nested["a"] == 1 &&
-					nested["b"] == 99 &&
-					nested["c"] == 3
-			})).Return(nil)
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).Return(nil)
+			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				nested, ok := cfg.Values["nested"].(map[string]any)
+				if !ok {
+					return false
+				}
+				return cfg.Values["foo"] == "overridden" &&
+					fmt.Sprint(nested["a"]) == "1" &&
+					fmt.Sprint(nested["b"]) == "99" &&
+					fmt.Sprint(nested["c"]) == "3"
+			}), installer.UpgradeChartOptions{InstallIfNotExist: true}).Return(nil)
 
 			err := pcApps.Install(context.Background())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("returns an error for non-existent values file", func() {
-			pcApps.ValuesFiles = []string{"/nonexistent/values.yaml"}
+			pcApps = &installer.PCApps{
+				Version:     version,
+				Namespace:   namespace,
+				ValuesFiles: []string{"/nonexistent/values.yaml"},
+				Helm:        helmMock,
+				Client:      fakeClient,
+			}
 
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("reading values file"))
+			Expect(err.Error()).To(ContainSubstring("loading values files"))
 		})
 
 		It("returns an error for invalid YAML in values file", func() {
 			badFile := filepath.Join(tmpDir, "bad.yaml")
 			Expect(os.WriteFile(badFile, []byte("{{invalid yaml"), 0644)).To(Succeed())
 
-			pcApps.ValuesFiles = []string{badFile}
+			pcApps = &installer.PCApps{
+				Version:     version,
+				Namespace:   namespace,
+				ValuesFiles: []string{badFile},
+				Helm:        helmMock,
+				Client:      fakeClient,
+			}
 
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("parsing values file"))
+			Expect(err.Error()).To(ContainSubstring("loading values files"))
 		})
-	})
-})
-
-var _ = Describe("LoadAndMergeValues", func() {
-	var tmpDir string
-
-	BeforeEach(func() {
-		var err error
-		tmpDir, err = os.MkdirTemp("", "merge-values-test-*")
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		Expect(os.RemoveAll(tmpDir)).To(Succeed())
-	})
-
-	It("returns empty map for no files", func() {
-		result, err := installer.LoadAndMergeValues(nil)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(BeEmpty())
-	})
-
-	It("returns values from a single file", func() {
-		f := filepath.Join(tmpDir, "values.yaml")
-		Expect(os.WriteFile(f, []byte("key: value\n"), 0644)).To(Succeed())
-
-		result, err := installer.LoadAndMergeValues([]string{f})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result["key"]).To(Equal("value"))
-	})
-
-	It("deep merges nested maps from multiple files", func() {
-		f1 := filepath.Join(tmpDir, "a.yaml")
-		Expect(os.WriteFile(f1, []byte("top:\n  a: 1\n  b: 2\n"), 0644)).To(Succeed())
-
-		f2 := filepath.Join(tmpDir, "b.yaml")
-		Expect(os.WriteFile(f2, []byte("top:\n  b: 99\n  c: 3\n"), 0644)).To(Succeed())
-
-		result, err := installer.LoadAndMergeValues([]string{f1, f2})
-		Expect(err).ToNot(HaveOccurred())
-
-		top, ok := result["top"].(map[string]interface{})
-		Expect(ok).To(BeTrue())
-		Expect(top["a"]).To(Equal(1))
-		Expect(top["b"]).To(Equal(99))
-		Expect(top["c"]).To(Equal(3))
 	})
 })

--- a/internal/installer/pc_apps_test.go
+++ b/internal/installer/pc_apps_test.go
@@ -1,0 +1,248 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package installer_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/codesphere-cloud/oms/internal/installer"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ = Describe("PCApps.Install", func() {
+	const (
+		chartURL  = "oci://ghcr.io/codesphere-cloud/charts/pc-apps"
+		version   = "1.2.3"
+		namespace = "argocd"
+		username  = "CodesphereBot"
+		password  = "super-secret-token"
+	)
+
+	var (
+		helmMock *installer.MockHelmClient
+		pcApps   *installer.PCApps
+	)
+
+	BeforeEach(func() {
+		helmMock = installer.NewMockHelmClient(GinkgoT())
+		pcApps = &installer.PCApps{
+			ChartURL:  chartURL,
+			Version:   version,
+			Namespace: namespace,
+			Username:  username,
+			Password:  password,
+			Helm:      helmMock,
+		}
+	})
+
+	Context("fresh install (no existing release)", func() {
+		BeforeEach(func() {
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", username, password).Return(nil)
+			helmMock.EXPECT().FindRelease(namespace, "pc-apps").Return(nil, nil)
+		})
+
+		It("logs in to registry and installs the chart", func() {
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				return cfg.ReleaseName == "pc-apps" &&
+					cfg.ChartName == chartURL &&
+					cfg.Namespace == namespace &&
+					cfg.Version == version &&
+					cfg.CreateNamespace == true
+			})).Return(nil)
+
+			err := pcApps.Install(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("installs latest when version is empty", func() {
+			pcApps.Version = ""
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				return cfg.Version == ""
+			})).Return(nil)
+
+			err := pcApps.Install(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error when InstallChart fails", func() {
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.Anything).
+				Return(errors.New("timeout"))
+
+			err := pcApps.Install(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("install failed"))
+		})
+	})
+
+	Context("upgrade (existing release found)", func() {
+		BeforeEach(func() {
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", username, password).Return(nil)
+			helmMock.EXPECT().FindRelease(namespace, "pc-apps").Return(&installer.ReleaseInfo{
+				Name:             "pc-apps",
+				InstalledVersion: "1.0.0",
+			}, nil)
+		})
+
+		It("upgrades the existing release", func() {
+			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				return cfg.ReleaseName == "pc-apps" &&
+					cfg.ChartName == chartURL &&
+					cfg.Version == version
+			}), installer.UpgradeChartOptions{}).Return(nil)
+
+			err := pcApps.Install(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error when UpgradeChart fails", func() {
+			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.Anything, mock.Anything).
+				Return(errors.New("upgrade conflict"))
+
+			err := pcApps.Install(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("upgrade failed"))
+		})
+	})
+
+	Context("registry login failure", func() {
+		It("returns an error without attempting install", func() {
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", username, password).
+				Return(errors.New("invalid credentials"))
+
+			err := pcApps.Install(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("registry login failed"))
+		})
+	})
+
+	Context("invalid chart URL", func() {
+		It("rejects URLs without oci:// prefix", func() {
+			pcApps.ChartURL = "https://ghcr.io/codesphere-cloud/charts/pc-apps"
+
+			err := pcApps.Install(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must start with \"oci://\""))
+		})
+
+		It("rejects URLs with no host", func() {
+			pcApps.ChartURL = "oci:///charts/pc-apps"
+
+			err := pcApps.Install(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no host"))
+		})
+	})
+
+	Context("values files", func() {
+		var tmpDir string
+
+		BeforeEach(func() {
+			var err error
+			tmpDir, err = os.MkdirTemp("", "pc-apps-test-*")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(tmpDir)
+		})
+
+		It("merges multiple values files in order", func() {
+			base := filepath.Join(tmpDir, "base.yaml")
+			Expect(os.WriteFile(base, []byte("foo: bar\nnested:\n  a: 1\n  b: 2\n"), 0644)).To(Succeed())
+
+			overlay := filepath.Join(tmpDir, "overlay.yaml")
+			Expect(os.WriteFile(overlay, []byte("foo: overridden\nnested:\n  b: 99\n  c: 3\n"), 0644)).To(Succeed())
+
+			pcApps.ValuesFiles = []string{base, overlay}
+
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", username, password).Return(nil)
+			helmMock.EXPECT().FindRelease(namespace, "pc-apps").Return(nil, nil)
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				nested, ok := cfg.Values["nested"].(map[string]interface{})
+				return ok &&
+					cfg.Values["foo"] == "overridden" &&
+					nested["a"] == 1 &&
+					nested["b"] == 99 &&
+					nested["c"] == 3
+			})).Return(nil)
+
+			err := pcApps.Install(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error for non-existent values file", func() {
+			pcApps.ValuesFiles = []string{"/nonexistent/values.yaml"}
+
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", username, password).Return(nil)
+
+			err := pcApps.Install(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("reading values file"))
+		})
+
+		It("returns an error for invalid YAML in values file", func() {
+			badFile := filepath.Join(tmpDir, "bad.yaml")
+			Expect(os.WriteFile(badFile, []byte("{{invalid yaml"), 0644)).To(Succeed())
+
+			pcApps.ValuesFiles = []string{badFile}
+
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", username, password).Return(nil)
+
+			err := pcApps.Install(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("parsing values file"))
+		})
+	})
+})
+
+var _ = Describe("LoadAndMergeValues", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "merge-values-test-*")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	It("returns empty map for no files", func() {
+		result, err := installer.LoadAndMergeValues(nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeEmpty())
+	})
+
+	It("returns values from a single file", func() {
+		f := filepath.Join(tmpDir, "values.yaml")
+		Expect(os.WriteFile(f, []byte("key: value\n"), 0644)).To(Succeed())
+
+		result, err := installer.LoadAndMergeValues([]string{f})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result["key"]).To(Equal("value"))
+	})
+
+	It("deep merges nested maps from multiple files", func() {
+		f1 := filepath.Join(tmpDir, "a.yaml")
+		Expect(os.WriteFile(f1, []byte("top:\n  a: 1\n  b: 2\n"), 0644)).To(Succeed())
+
+		f2 := filepath.Join(tmpDir, "b.yaml")
+		Expect(os.WriteFile(f2, []byte("top:\n  b: 99\n  c: 3\n"), 0644)).To(Succeed())
+
+		result, err := installer.LoadAndMergeValues([]string{f1, f2})
+		Expect(err).ToNot(HaveOccurred())
+
+		top, ok := result["top"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(top["a"]).To(Equal(1))
+		Expect(top["b"]).To(Equal(99))
+		Expect(top["c"]).To(Equal(3))
+	})
+})

--- a/internal/installer/pc_apps_test.go
+++ b/internal/installer/pc_apps_test.go
@@ -13,6 +13,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 var _ = Describe("PCApps.Install", func() {
@@ -25,12 +28,14 @@ var _ = Describe("PCApps.Install", func() {
 	)
 
 	var (
-		helmMock *installer.MockHelmClient
-		pcApps   *installer.PCApps
+		helmMock  *installer.MockHelmClient
+		clientset *fake.Clientset
+		pcApps    *installer.PCApps
 	)
 
 	BeforeEach(func() {
 		helmMock = installer.NewMockHelmClient(GinkgoT())
+		clientset = fake.NewClientset()
 		pcApps = &installer.PCApps{
 			ChartURL:  chartURL,
 			Version:   version,
@@ -38,6 +43,7 @@ var _ = Describe("PCApps.Install", func() {
 			Username:  username,
 			Password:  password,
 			Helm:      helmMock,
+			Clientset: clientset,
 		}
 	})
 
@@ -136,6 +142,88 @@ var _ = Describe("PCApps.Install", func() {
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no host"))
+		})
+	})
+
+	Context("credential fallback from K8s secret", func() {
+		const (
+			secretUsername = "github"
+			secretPassword = "token-from-k8s-secret"
+		)
+
+		BeforeEach(func() {
+			// No explicit credentials
+			pcApps.Username = ""
+			pcApps.Password = ""
+
+			// Create the K8s secret that "install argocd" would have created
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd-codesphere-oci-read",
+					Namespace: "argocd",
+				},
+				Data: map[string][]byte{
+					"username": []byte(secretUsername),
+					"password": []byte(secretPassword),
+				},
+			}
+			_, err := clientset.CoreV1().Secrets("argocd").Create(
+				context.Background(), secret, metav1.CreateOptions{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("reads credentials from the K8s secret and installs successfully", func() {
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).Return(nil)
+			helmMock.EXPECT().FindRelease(namespace, "pc-apps").Return(nil, nil)
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.Anything).Return(nil)
+
+			err := pcApps.Install(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("no credentials and no K8s secret", func() {
+		BeforeEach(func() {
+			pcApps.Username = ""
+			pcApps.Password = ""
+			// clientset has no secrets
+		})
+
+		It("returns a clear error suggesting how to fix", func() {
+			err := pcApps.Install(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("argocd-codesphere-oci-read"))
+			Expect(err.Error()).To(ContainSubstring("oms beta install argocd"))
+		})
+	})
+
+	Context("K8s secret exists but missing fields", func() {
+		BeforeEach(func() {
+			pcApps.Username = ""
+			pcApps.Password = ""
+
+			// Secret exists but with empty data
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd-codesphere-oci-read",
+					Namespace: "argocd",
+				},
+				Data: map[string][]byte{
+					"username": []byte("github"),
+					// password is missing
+				},
+			}
+			_, err := clientset.CoreV1().Secrets("argocd").Create(
+				context.Background(), secret, metav1.CreateOptions{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error about missing fields", func() {
+			err := pcApps.Install(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing username or password"))
 		})
 	})
 

--- a/internal/installer/pc_apps_test.go
+++ b/internal/installer/pc_apps_test.go
@@ -141,7 +141,7 @@ var _ = Describe("PCApps.Install", func() {
 			}
 		})
 
-		It("returns a clear error suggesting how to fix", func() {
+		It("returns a clear error", func() {
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("argocd-codesphere-oci-read"))


### PR DESCRIPTION
## Summary

Adds a new `oms beta install pc-apps` CLI command that installs/upgrades the pc-applications Helm chart from a private OCI registry. The chart deploys ArgoCD Application resources that manage platform components.

## Key Design Decisions

- **Credentials from K8s Secret** — registry URL and credentials are read from the K8s Secret `argocd-codesphere-oci-read` (created by `oms beta install argocd --deploy-dc-config`). No manual auth flags needed.
- **Eager registry login** — `LoginRegistry` performs the real OCI login immediately so bad credentials fail fast with a clear error
- **Values file merging** — multiple `-f` files are merged in order using Helm's built-in values merge, allowing base + overlay patterns

## Usage

```bash
# Install a specific version (version is required)
oms beta install pc-apps --version 1.2.3

# Install with custom values files
oms beta install pc-apps --version 1.0.0 -f base.yaml -f dc-overlay.yaml

# Install into a custom namespace
oms beta install pc-apps --version 1.0.0 --namespace custom-ns
```

## Changes

- `cli/cmd/pc_apps.go` — Cobra command with flags: `--version` (required), `--namespace`, `--values`/`-f`
- `cli/cmd/beta_install.go` — Registers pc-apps under `oms beta install`
- `internal/installer/pc_apps.go` — Install/upgrade logic reading credentials from K8s Secret and merging values files
- `internal/installer/helm_client.go` — Adds `LoginRegistry` to `HelmClient` interface; performs eager OCI login and reuses the authenticated registry client
- `internal/installer/pc_apps_test.go` — Tests covering install, registry login failure, missing secret, missing fields, and values merging
- `internal/installer/mocks.go` — Updated generated mocks for `HelmClient`