### PR TITLE
fix(vault-creator): replace / with . to be a valid K8s secret

### DIFF
--- a/internal/installer/vault_secret_creator.go
+++ b/internal/installer/vault_secret_creator.go
@@ -26,15 +26,9 @@ func NewVaultSecretCreator(c client.Client) *VaultSecretCreator {
 // CreateSecretFromVault decrypts a SOPS-encrypted vault file and creates or
 // updates a Kubernetes secret with its contents in the target cluster.
 //
-// vaultFile is the path to the SOPS-encrypted prod.vault.yaml.
-// ageKeyPath is the path to the age private key used for decryption; if empty,
-// SOPS falls back to the SOPS_AGE_KEY / SOPS_AGE_KEY_FILE env vars and the
-// default key location (~/.config/sops/age/keys.txt).
-// namespace and secretName identify the target Kubernetes secret.
-//
 // Each vault entry is mapped to one or more secret keys:
 //   - File entries produce a single key equal to the entry name.
-//   - Field entries produce "entryName/password" and, when present, "entryName/username".
+//   - Field entries produce "entryName.password" and, when present, "entryName.username".
 func (v *VaultSecretCreator) CreateSecretFromVault(ctx context.Context, vaultFile, ageKeyPath, namespace, secretName string) error {
 	decrypted, err := DecryptFileWithSOPS(vaultFile, ageKeyPath)
 	if err != nil {
@@ -73,16 +67,16 @@ func (v *VaultSecretCreator) CreateSecretFromVault(ctx context.Context, vaultFil
 
 // vaultToSecretData converts the entries of an InstallVault into Kubernetes secret data.
 // File entries produce a single key equal to the entry name containing the file content.
-// Field entries produce "entryName/password" and, when a username is present, "entryName/username".
+// Field entries produce "entryName.password" and, when a username is present, "entryName.username".
 func vaultToSecretData(vault *files.InstallVault) (map[string][]byte, error) {
 	data := make(map[string][]byte)
 	for _, entry := range vault.Secrets {
 		if entry.File != nil {
 			data[entry.Name] = []byte(entry.File.Content)
 		} else if entry.Fields != nil {
-			data[entry.Name+"/password"] = []byte(entry.Fields.Password)
+			data[entry.Name+".password"] = []byte(entry.Fields.Password)
 			if entry.Fields.Username != "" {
-				data[entry.Name+"/username"] = []byte(entry.Fields.Username)
+				data[entry.Name+".username"] = []byte(entry.Fields.Username)
 			}
 		}
 	}

--- a/internal/installer/vault_secret_creator_test.go
+++ b/internal/installer/vault_secret_creator_test.go
@@ -29,8 +29,8 @@ var _ = Describe("vaultToSecretData", func() {
 		}
 		data, err := vaultToSecretData(vault)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(data).To(HaveKeyWithValue("dbAdmin/password", []byte("s3cr3t")))
-		Expect(data).NotTo(HaveKey("dbAdmin/username"))
+		Expect(data).To(HaveKeyWithValue("dbAdmin.password", []byte("s3cr3t")))
+		Expect(data).NotTo(HaveKey("dbAdmin.username"))
 	})
 
 	It("stores field entry with username and password under entryName/username and entryName/password", func() {
@@ -41,8 +41,8 @@ var _ = Describe("vaultToSecretData", func() {
 		}
 		data, err := vaultToSecretData(vault)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(data).To(HaveKeyWithValue("registry/username", []byte("robot")))
-		Expect(data).To(HaveKeyWithValue("registry/password", []byte("token123")))
+		Expect(data).To(HaveKeyWithValue("registry.username", []byte("robot")))
+		Expect(data).To(HaveKeyWithValue("registry.password", []byte("token123")))
 	})
 
 	It("handles a mix of file and field entries", func() {
@@ -55,8 +55,8 @@ var _ = Describe("vaultToSecretData", func() {
 		data, err := vaultToSecretData(vault)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(data).To(HaveKey("sshKey"))
-		Expect(data).To(HaveKey("git/username"))
-		Expect(data).To(HaveKey("git/password"))
+		Expect(data).To(HaveKey("git.username"))
+		Expect(data).To(HaveKey("git.password"))
 		Expect(data).To(HaveLen(3))
 	})
 
@@ -77,6 +77,6 @@ var _ = Describe("vaultToSecretData", func() {
 		data, err := vaultToSecretData(vault)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(data).NotTo(HaveKey("empty"))
-		Expect(data).To(HaveKey("real/password"))
+		Expect(data).To(HaveKey("real.password"))
 	})
 })


### PR DESCRIPTION
The current vault secret creator creates a invalid secret key as `/` is not allowed in k8s secret keys.