### PR TITLE
fix(argocd): propagate argocd installer init errors

### DIFF
--- a/cli/cmd/argocd.go
+++ b/cli/cmd/argocd.go
@@ -41,7 +41,7 @@ func (c *InstallArgoCDCmd) RunE(_ *cobra.Command, args []string) error {
 	}
 	install, err := installer.NewArgoCD(c.Opts.Version, c.Opts.DatacenterId, c.Opts.RegistryPassword, c.Opts.GitPassword, c.Opts.FullInstall)
 	if err != nil {
-		return fmt.Errorf("failed to initialize ArgoCD installer")
+		return fmt.Errorf("failed to initialize ArgoCD installer: %w", err)
 	}
 	err = install.Install()
 	if err != nil {

--- a/internal/installer/argocd.go
+++ b/internal/installer/argocd.go
@@ -33,12 +33,12 @@ func NewArgoCD(version string, dcId string, passwordOCI string, passwordGit stri
 	}
 	helm, err := NewHelmClient("argocd")
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("init helm client failed: %w", err)
 	}
 
 	resources, err := NewArgoCDResources(dcId, passwordOCI, passwordGit)
 	if err != nil {
-		return nil, fmt.Errorf("init argocd resources client failed: %v", err)
+		return nil, fmt.Errorf("init argocd resources client failed: %w", err)
 	}
 	return &ArgoCD{
 		Version:      version,


### PR DESCRIPTION
Properly propagate the error to make debugging easier