### PR TITLE
feat(argocd): expose --force-conflicts, --values, and --repo flags with OCI support

### DIFF
--- a/cli/cmd/argocd.go
+++ b/cli/cmd/argocd.go
@@ -23,6 +23,9 @@ type InstallArgoCDOpts struct {
 	GitPassword      string
 	RegistryPassword string
 	FullInstall      bool
+	ForceConflicts   bool
+	RepoURL          string
+	ValueFiles       []string
 }
 
 func (c *InstallArgoCDCmd) RunE(_ *cobra.Command, args []string) error {
@@ -39,7 +42,7 @@ func (c *InstallArgoCDCmd) RunE(_ *cobra.Command, args []string) error {
 			}
 		}
 	}
-	install, err := installer.NewArgoCD(c.Opts.Version, c.Opts.DatacenterId, c.Opts.RegistryPassword, c.Opts.GitPassword, c.Opts.FullInstall)
+	install, err := installer.NewArgoCD(c.Opts.Version, c.Opts.DatacenterId, c.Opts.RegistryPassword, c.Opts.GitPassword, c.Opts.FullInstall, c.Opts.ForceConflicts, c.Opts.RepoURL, c.Opts.ValueFiles)
 	if err != nil {
 		return fmt.Errorf("failed to initialize ArgoCD installer: %w", err)
 	}
@@ -68,6 +71,9 @@ func AddArgoCDCmd(parentCmd *cobra.Command, opts *GlobalOptions) {
 	argocd.cmd.Flags().StringVar(&argocd.Opts.DatacenterId, "dc-id", "", "Codesphere Datacenter ID where this ArgoCD is installed")
 	argocd.cmd.Flags().StringVarP(&argocd.Opts.Version, "version", "v", "", "Version of the ArgoCD helm chart to install")
 	argocd.cmd.Flags().BoolVar(&argocd.Opts.FullInstall, "deploy-dc-config", false, "Install Codesphere-managed resources (AppProjects, Repo Creds, ...) after installing the chart")
+	argocd.cmd.Flags().StringArrayVarP(&argocd.Opts.ValueFiles, "values", "f", nil, "Specify values in a YAML file (can be specified multiple times)")
+	argocd.cmd.Flags().BoolVar(&argocd.Opts.ForceConflicts, "force-conflicts", false, "Force field ownership conflicts during upgrade (sets server-side apply ForceConflicts)")
+	argocd.cmd.Flags().StringVar(&argocd.Opts.RepoURL, "repo", "", "Helm chart repository URL; supports HTTP (default: https://argoproj.github.io/argo-helm) and OCI (e.g. oci://ghcr.io/argoproj/argo-helm)")
 	argocd.cmd.RunE = argocd.RunE
 
 	AddCmd(parentCmd, argocd.cmd)

--- a/docs/oms_beta_install_argocd.md
+++ b/docs/oms_beta_install_argocd.md
@@ -26,9 +26,12 @@ $ oms install ArgoCD --version <version>
 ```
       --dc-id string               Codesphere Datacenter ID where this ArgoCD is installed
       --deploy-dc-config           Install Codesphere-managed resources (AppProjects, Repo Creds, ...) after installing the chart
+      --force-conflicts            Force field ownership conflicts during upgrade (sets server-side apply ForceConflicts)
       --git-password string        Password/token to read from the git repo where ArgoCD Application manifests are stored
   -h, --help                       help for argocd
       --registry-password string   Password/token to read from the OCI registry (e.g. ghcr.io) where Helm chart artifacts are stored
+      --repo string                Helm chart repository URL; supports HTTP (default: https://argoproj.github.io/argo-helm) and OCI (e.g. oci://ghcr.io/argoproj/argo-helm)
+  -f, --values stringArray         Specify values in a YAML file (can be specified multiple times)
   -v, --version string             Version of the ArgoCD helm chart to install
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/google/go-github/v74 v74.0.0
-	github.com/google/go-github/v88 v88.0.0
 	github.com/lib/pq v1.12.3
 	github.com/rook/rook/pkg/apis v0.0.0-20260526191009-8dd1778655f0
 )
@@ -554,6 +553,7 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/go-github/v88 v88.0.0 // indirect
 	github.com/google/go-licenses/v2 v2.0.1 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/licenseclassifier/v2 v2.0.0 // indirect

--- a/internal/installer/argocd.go
+++ b/internal/installer/argocd.go
@@ -8,24 +8,32 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/cli"
+	"helm.sh/helm/v4/pkg/cli/values"
+	"helm.sh/helm/v4/pkg/getter"
 )
+
+const argoCDDefaultRepoURL = "https://argoproj.github.io/argo-helm"
 
 // ArgoCD holds the user-facing configuration for the install/upgrade command.
 type ArgoCD struct {
-	Version      string
-	DatacenterId string
-	OciPassword  string
-	GitPassword  string
-	FullInstall  bool
-	Helm         HelmClient // inject a real or mock client
-	Resources    ArgoCDResources
+	Version        string
+	DatacenterId   string
+	OciPassword    string
+	GitPassword    string
+	FullInstall    bool
+	ForceConflicts bool
+	RepoURL        string // defaults to argoCDDefaultRepoURL if empty
+	ValueFiles     []string
+	Helm           HelmClient // inject a real or mock client
+	Resources      ArgoCDResources
 }
 
-func NewArgoCD(version string, dcId string, passwordOCI string, passwordGit string, fullInstall bool) (*ArgoCD, error) {
+func NewArgoCD(version string, dcId string, passwordOCI string, passwordGit string, fullInstall bool, forceConflicts bool, repoURL string, valueFiles []string) (*ArgoCD, error) {
 	settings := cli.New()
 	actionConfig := new(action.Configuration)
 	if err := actionConfig.Init(settings.RESTClientGetter(), "argocd", os.Getenv("HELM_DRIVER")); err != nil {
@@ -41,13 +49,16 @@ func NewArgoCD(version string, dcId string, passwordOCI string, passwordGit stri
 		return nil, fmt.Errorf("init argocd resources client failed: %w", err)
 	}
 	return &ArgoCD{
-		Version:      version,
-		DatacenterId: dcId,
-		OciPassword:  passwordOCI,
-		GitPassword:  passwordGit,
-		FullInstall:  fullInstall,
-		Helm:         helm,
-		Resources:    resources,
+		Version:        version,
+		DatacenterId:   dcId,
+		OciPassword:    passwordOCI,
+		GitPassword:    passwordGit,
+		FullInstall:    fullInstall,
+		ForceConflicts: forceConflicts,
+		RepoURL:        repoURL,
+		ValueFiles:     valueFiles,
+		Helm:           helm,
+		Resources:      resources,
 	}, nil
 }
 
@@ -62,18 +73,23 @@ func (a *ArgoCD) Install() error {
 
 	ctx := context.Background()
 
+	vals, err := (&values.Options{
+		ValueFiles: a.ValueFiles,
+		Values:     []string{"dex.enabled=false"},
+	}).MergeValues(getter.All(cli.New()))
+	if err != nil {
+		return fmt.Errorf("loading values files: %w", err)
+	}
+
+	chartName, repoURL := a.resolveChartRef("argo-cd")
 	cfg := ChartConfig{
 		ReleaseName:     "argocd",
-		ChartName:       "argo-cd",
-		RepoURL:         "https://argoproj.github.io/argo-helm",
+		ChartName:       chartName,
+		RepoURL:         repoURL,
 		Namespace:       "argocd",
 		Version:         a.Version,
 		CreateNamespace: true,
-		Values: map[string]interface{}{
-			"dex": map[string]interface{}{
-				"enabled": false,
-			},
-		},
+		Values:          vals,
 	}
 
 	existing, err := a.Helm.FindRelease(cfg.Namespace, cfg.ReleaseName)
@@ -107,7 +123,7 @@ func (a *ArgoCD) Install() error {
 func (a *ArgoCD) install(ctx context.Context, cfg ChartConfig) error {
 	log.Println("No existing ArgoCD release found, performing fresh install")
 
-	if err := a.Helm.InstallChart(ctx, cfg); err != nil {
+	if err := a.Helm.InstallChart(ctx, cfg, InstallChartOptions{ForceConflicts: a.ForceConflicts}); err != nil {
 		return err
 	}
 
@@ -145,7 +161,7 @@ func (a *ArgoCD) upgrade(ctx context.Context, cfg ChartConfig, existing *Release
 		log.Printf("Upgrading ArgoCD from %s to latest\n", existing.InstalledVersion)
 	}
 
-	if err := a.Helm.UpgradeChart(ctx, cfg, UpgradeChartOptions{}); err != nil {
+	if err := a.Helm.UpgradeChart(ctx, cfg, UpgradeChartOptions{ForceConflicts: a.ForceConflicts}); err != nil {
 		return err
 	}
 
@@ -155,6 +171,21 @@ func (a *ArgoCD) upgrade(ctx context.Context, cfg ChartConfig, existing *Release
 		fmt.Println("Successfully upgraded Argo CD to the latest chart version")
 	}
 	return nil
+}
+
+// resolveChartRef returns the (chartName, repoURL) pair to use in ChartConfig.
+// For OCI repos the full reference is passed as chartName and repoURL is empty,
+// because helm's LocateChart expects "oci://<registry>/<repo>/<chart>" as the
+// chart name with no separate RepoURL.
+func (a *ArgoCD) resolveChartRef(chartName string) (string, string) {
+	repoURL := a.RepoURL
+	if repoURL == "" {
+		repoURL = argoCDDefaultRepoURL
+	}
+	if strings.HasPrefix(repoURL, "oci://") {
+		return strings.TrimRight(repoURL, "/") + "/" + chartName, ""
+	}
+	return chartName, repoURL
 }
 
 func (a *ArgoCD) showPostInstallHints() {

--- a/internal/installer/argocd.go
+++ b/internal/installer/argocd.go
@@ -7,11 +7,10 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"helm.sh/helm/v4/pkg/action"
+	"helm.sh/helm/v4/pkg/chart/common/util"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/cli/values"
 	"helm.sh/helm/v4/pkg/getter"
@@ -34,11 +33,6 @@ type ArgoCD struct {
 }
 
 func NewArgoCD(version string, dcId string, passwordOCI string, passwordGit string, fullInstall bool, forceConflicts bool, repoURL string, valueFiles []string) (*ArgoCD, error) {
-	settings := cli.New()
-	actionConfig := new(action.Configuration)
-	if err := actionConfig.Init(settings.RESTClientGetter(), "argocd", os.Getenv("HELM_DRIVER")); err != nil {
-		return nil, fmt.Errorf("init helm client failed: %w", err)
-	}
 	helm, err := NewHelmClient("argocd")
 	if err != nil {
 		return nil, fmt.Errorf("init helm client failed: %w", err)
@@ -65,6 +59,10 @@ func NewArgoCD(version string, dcId string, passwordOCI string, passwordGit stri
 // Install is the top-level orchestrator. It delegates every Helm interaction
 // to the HelmClient interface, keeping this function short and testable.
 func (a *ArgoCD) Install() error {
+	if err := a.validateRepoURL(); err != nil {
+		return err
+	}
+
 	if a.Version != "" {
 		log.Printf("Installing/Upgrading ArgoCD helm chart version %s\n", a.Version)
 	} else {
@@ -75,11 +73,17 @@ func (a *ArgoCD) Install() error {
 
 	vals, err := (&values.Options{
 		ValueFiles: a.ValueFiles,
-		Values:     []string{"dex.enabled=false"},
 	}).MergeValues(getter.All(cli.New()))
 	if err != nil {
 		return fmt.Errorf("loading values files: %w", err)
 	}
+
+	// Apply our defaults underneath the user-provided values so value files can
+	// override them. MergeTables gives precedence to dst (the user values).
+	defaults := map[string]any{
+		"dex": map[string]any{"enabled": false},
+	}
+	vals = util.MergeTables(vals, defaults)
 
 	chartName, repoURL := a.resolveChartRef("argo-cd")
 	cfg := ChartConfig{
@@ -171,6 +175,19 @@ func (a *ArgoCD) upgrade(ctx context.Context, cfg ChartConfig, existing *Release
 		fmt.Println("Successfully upgraded Argo CD to the latest chart version")
 	}
 	return nil
+}
+
+// validateRepoURL ensures a non-empty RepoURL uses a supported scheme.
+func (a *ArgoCD) validateRepoURL() error {
+	if a.RepoURL == "" {
+		return nil
+	}
+	for _, prefix := range []string{"http://", "https://", "oci://"} {
+		if strings.HasPrefix(a.RepoURL, prefix) {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid repo URL %q: must start with http://, https://, or oci://", a.RepoURL)
 }
 
 // resolveChartRef returns the (chartName, repoURL) pair to use in ChartConfig.

--- a/internal/installer/argocd_test.go
+++ b/internal/installer/argocd_test.go
@@ -37,7 +37,7 @@ var _ = Describe("ArgoCD.Install", func() {
 					cfg.ReleaseName == "argocd" &&
 					cfg.Namespace == "argocd" &&
 					cfg.CreateNamespace == true
-			})).Return(nil)
+			}), mock.Anything).Return(nil)
 
 			err := a.Install()
 			Expect(err).ToNot(HaveOccurred())
@@ -47,7 +47,7 @@ var _ = Describe("ArgoCD.Install", func() {
 			helmMock.EXPECT().FindRelease("argocd", "argocd").Return(nil, nil)
 			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
 				return cfg.Version == ""
-			})).Return(nil)
+			}), mock.Anything).Return(nil)
 
 			a = &installer.ArgoCD{Version: "", Helm: helmMock}
 
@@ -56,7 +56,7 @@ var _ = Describe("ArgoCD.Install", func() {
 		})
 
 		It("returns an error when InstallChart fails", func() {
-			helmMock.EXPECT().InstallChart(mock.Anything, mock.Anything).
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.Anything, mock.Anything).
 				Return(errors.New("chart not found"))
 
 			err := a.Install()
@@ -144,7 +144,7 @@ var _ = Describe("ArgoCD.Install", func() {
 			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
 				return cfg.ChartName == "argo-cd" &&
 					cfg.RepoURL == "https://argoproj.github.io/argo-helm"
-			})).Return(nil)
+			}), mock.Anything).Return(nil)
 
 			a = &installer.ArgoCD{Version: "7.0.0", Helm: helmMock}
 
@@ -157,7 +157,7 @@ var _ = Describe("ArgoCD.Install", func() {
 			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
 				dex, ok := cfg.Values["dex"].(map[string]interface{})
 				return ok && dex["enabled"] == false
-			})).Return(nil)
+			}), mock.Anything).Return(nil)
 
 			a = &installer.ArgoCD{Version: "7.0.0", Helm: helmMock}
 
@@ -169,7 +169,7 @@ var _ = Describe("ArgoCD.Install", func() {
 	Context("full installation", func() {
 		BeforeEach(func() {
 			helmMock.EXPECT().FindRelease("argocd", "argocd").Return(nil, nil)
-			helmMock.EXPECT().InstallChart(mock.Anything, mock.Anything).Return(nil)
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		})
 		It("installs extra ArgoCD resources when FullInstall option in true", func() {
 			argoCDResourcesMock.EXPECT().ApplyAll(mock.Anything).Return(nil)
@@ -181,6 +181,60 @@ var _ = Describe("ArgoCD.Install", func() {
 		It("does not install extra ArgoCD resources when FullInstall option in false", func() {
 			a.FullInstall = false
 
+			err := a.Install()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("ForceConflicts", func() {
+		It("passes ForceConflicts=true to InstallChart on a fresh install", func() {
+			helmMock.EXPECT().FindRelease("argocd", "argocd").Return(nil, nil)
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.Anything, mock.MatchedBy(func(opts installer.InstallChartOptions) bool {
+				return opts.ForceConflicts == true
+			})).Return(nil)
+
+			a.ForceConflicts = true
+			err := a.Install()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("passes ForceConflicts=true to UpgradeChart on an existing release", func() {
+			helmMock.EXPECT().FindRelease("argocd", "argocd").Return(&installer.ReleaseInfo{
+				Name: "argocd", InstalledVersion: "6.0.0",
+			}, nil)
+			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.Anything, mock.MatchedBy(func(opts installer.UpgradeChartOptions) bool {
+				return opts.ForceConflicts == true
+			})).Return(nil)
+
+			a.ForceConflicts = true
+			err := a.Install()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("RepoURL", func() {
+		BeforeEach(func() {
+			helmMock.EXPECT().FindRelease("argocd", "argocd").Return(nil, nil)
+		})
+
+		It("uses a custom HTTP repo URL", func() {
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				return cfg.RepoURL == "https://my.repo/helm" &&
+					cfg.ChartName == "argo-cd"
+			}), mock.Anything).Return(nil)
+
+			a.RepoURL = "https://my.repo/helm"
+			err := a.Install()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("builds the full OCI chart reference and clears RepoURL", func() {
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				return cfg.ChartName == "oci://ghcr.io/argoproj/argo-helm/argo-cd" &&
+					cfg.RepoURL == ""
+			}), mock.Anything).Return(nil)
+
+			a.RepoURL = "oci://ghcr.io/argoproj/argo-helm"
 			err := a.Install()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/internal/installer/argocd_test.go
+++ b/internal/installer/argocd_test.go
@@ -5,12 +5,21 @@ package installer_test
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 
 	"github.com/codesphere-cloud/oms/internal/installer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 )
+
+// writeValuesFile writes content to a temp YAML file and returns its path.
+func writeValuesFile(content string) string {
+	path := filepath.Join(GinkgoT().TempDir(), "values.yaml")
+	Expect(os.WriteFile(path, []byte(content), 0o600)).To(Succeed())
+	return path
+}
 
 var _ = Describe("ArgoCD.Install", func() {
 
@@ -164,6 +173,94 @@ var _ = Describe("ArgoCD.Install", func() {
 			err := a.Install()
 			Expect(err).ToNot(HaveOccurred())
 		})
+	})
+
+	Context("values overrides", func() {
+		BeforeEach(func() {
+			helmMock.EXPECT().FindRelease("argocd", "argocd").Return(nil, nil)
+		})
+
+		It("lets a value file override the dex.enabled default", func() {
+			valuesFile := writeValuesFile("dex:\n  enabled: true\n")
+
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				dex, ok := cfg.Values["dex"].(map[string]interface{})
+				return ok && dex["enabled"] == true
+			}), mock.Anything).Return(nil)
+
+			a = &installer.ArgoCD{Version: "7.0.0", Helm: helmMock, ValueFiles: []string{valuesFile}}
+
+			err := a.Install()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("keeps the dex.enabled default when the value file does not set it", func() {
+			valuesFile := writeValuesFile("server:\n  replicas: 2\n")
+
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				dex, ok := cfg.Values["dex"].(map[string]interface{})
+				if !ok || dex["enabled"] != false {
+					return false
+				}
+				server, ok := cfg.Values["server"].(map[string]interface{})
+				return ok && server["replicas"] == float64(2)
+			}), mock.Anything).Return(nil)
+
+			a = &installer.ArgoCD{Version: "7.0.0", Helm: helmMock, ValueFiles: []string{valuesFile}}
+
+			err := a.Install()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("merges values from multiple files with later files taking precedence", func() {
+			first := writeValuesFile("dex:\n  enabled: true\nserver:\n  replicas: 1\n")
+			second := writeValuesFile("server:\n  replicas: 3\n")
+
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				dex, ok := cfg.Values["dex"].(map[string]interface{})
+				if !ok || dex["enabled"] != true {
+					return false
+				}
+				server, ok := cfg.Values["server"].(map[string]interface{})
+				return ok && server["replicas"] == float64(3)
+			}), mock.Anything).Return(nil)
+
+			a = &installer.ArgoCD{Version: "7.0.0", Helm: helmMock, ValueFiles: []string{first, second}}
+
+			err := a.Install()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("RepoURL validation", func() {
+		DescribeTable("accepts supported schemes",
+			func(repoURL string) {
+				helmMock.EXPECT().FindRelease("argocd", "argocd").Return(nil, nil)
+				helmMock.EXPECT().InstallChart(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				a = &installer.ArgoCD{Version: "7.0.0", Helm: helmMock, RepoURL: repoURL}
+
+				err := a.Install()
+				Expect(err).ToNot(HaveOccurred())
+			},
+			Entry("empty (uses default)", ""),
+			Entry("http", "http://my.repo/helm"),
+			Entry("https", "https://my.repo/helm"),
+			Entry("oci", "oci://ghcr.io/argoproj/argo-helm"),
+		)
+
+		DescribeTable("rejects unsupported schemes without touching helm",
+			func(repoURL string) {
+				a = &installer.ArgoCD{Version: "7.0.0", Helm: helmMock, RepoURL: repoURL}
+
+				err := a.Install()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("must start with http://, https://, or oci://"))
+			},
+			Entry("ftp", "ftp://my.repo/helm"),
+			Entry("no scheme", "my.repo/helm"),
+			Entry("git ssh", "git@github.com:argoproj/argo-helm.git"),
+		)
 	})
 
 	Context("full installation", func() {

--- a/internal/installer/helm_client.go
+++ b/internal/installer/helm_client.go
@@ -37,8 +37,13 @@ type ChartConfig struct {
 	CreateNamespace bool
 }
 
+type InstallChartOptions struct {
+	ForceConflicts bool
+}
+
 type UpgradeChartOptions struct {
 	InstallIfNotExist bool
+	ForceConflicts    bool
 }
 
 // HelmClient is the seam that makes the Helm SDK mockable.
@@ -51,7 +56,7 @@ type HelmClient interface {
 	FindRelease(namespace, releaseName string) (*ReleaseInfo, error)
 
 	// InstallChart performs a fresh Helm install and returns an error on failure.
-	InstallChart(ctx context.Context, cfg ChartConfig) error
+	InstallChart(ctx context.Context, cfg ChartConfig, opts InstallChartOptions) error
 
 	// UpgradeChart upgrades an existing Helm release and returns an error on failure.
 	UpgradeChart(ctx context.Context, cfg ChartConfig, opts UpgradeChartOptions) error
@@ -122,7 +127,6 @@ func (h *helmClient) FindRelease(namespace, releaseName string) (*ReleaseInfo, e
 
 	listClient := action.NewList(env.actionConfig)
 	listClient.Filter = "^" + releaseName + "$"
-	listClient.Deployed = true
 	listClient.SetStateMask()
 
 	releases, err := listClient.Run()
@@ -155,7 +159,7 @@ func (h *helmClient) FindRelease(namespace, releaseName string) (*ReleaseInfo, e
 	return nil, nil // no release found
 }
 
-func (h *helmClient) InstallChart(ctx context.Context, cfg ChartConfig) error {
+func (h *helmClient) InstallChart(ctx context.Context, cfg ChartConfig, opts InstallChartOptions) error {
 	env, err := h.newHelmEnv(cfg.Namespace)
 	if err != nil {
 		return err
@@ -170,6 +174,7 @@ func (h *helmClient) InstallChart(ctx context.Context, cfg ChartConfig) error {
 	installClient.Version = cfg.Version
 	installClient.RepoURL = cfg.RepoURL
 	installClient.Timeout = 5 * time.Minute
+	installClient.ForceConflicts = opts.ForceConflicts
 
 	chartPath, err := installClient.LocateChart(cfg.ChartName, env.settings)
 	if err != nil {
@@ -196,7 +201,7 @@ func (h *helmClient) UpgradeChart(ctx context.Context, cfg ChartConfig, opts Upg
 			return err
 		}
 		if rel == nil {
-			return h.InstallChart(ctx, cfg)
+			return h.InstallChart(ctx, cfg, InstallChartOptions{ForceConflicts: opts.ForceConflicts})
 		}
 	}
 
@@ -211,6 +216,7 @@ func (h *helmClient) UpgradeChart(ctx context.Context, cfg ChartConfig, opts Upg
 	upgradeClient.Version = cfg.Version
 	upgradeClient.RepoURL = cfg.RepoURL
 	upgradeClient.Timeout = 5 * time.Minute
+	upgradeClient.ForceConflicts = opts.ForceConflicts
 
 	chartPath, err := upgradeClient.LocateChart(cfg.ChartName, env.settings)
 	if err != nil {
@@ -229,3 +235,4 @@ func (h *helmClient) UpgradeChart(ctx context.Context, cfg ChartConfig, opts Upg
 
 	return nil
 }
+

--- a/internal/installer/helm_client.go
+++ b/internal/installer/helm_client.go
@@ -127,6 +127,10 @@ func (h *helmClient) FindRelease(namespace, releaseName string) (*ReleaseInfo, e
 
 	listClient := action.NewList(env.actionConfig)
 	listClient.Filter = "^" + releaseName + "$"
+	listClient.Deployed = true
+	// Also include failed releases in the search, since a failed release with the same name would block installation of a new release with that name.
+	// We want to detect that case and be able to update the failed release.
+	listClient.Failed = true
 	listClient.SetStateMask()
 
 	releases, err := listClient.Run()

--- a/internal/installer/mocks.go
+++ b/internal/installer/mocks.go
@@ -882,16 +882,16 @@ func (_c *MockHelmClient_FindRelease_Call) RunAndReturn(run func(namespace strin
 }
 
 // InstallChart provides a mock function for the type MockHelmClient
-func (_mock *MockHelmClient) InstallChart(ctx context.Context, cfg ChartConfig) error {
-	ret := _mock.Called(ctx, cfg)
+func (_mock *MockHelmClient) InstallChart(ctx context.Context, cfg ChartConfig, opts InstallChartOptions) error {
+	ret := _mock.Called(ctx, cfg, opts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for InstallChart")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ChartConfig) error); ok {
-		r0 = returnFunc(ctx, cfg)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ChartConfig, InstallChartOptions) error); ok {
+		r0 = returnFunc(ctx, cfg, opts)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -906,11 +906,12 @@ type MockHelmClient_InstallChart_Call struct {
 // InstallChart is a helper method to define mock.On call
 //   - ctx context.Context
 //   - cfg ChartConfig
-func (_e *MockHelmClient_Expecter) InstallChart(ctx interface{}, cfg interface{}) *MockHelmClient_InstallChart_Call {
-	return &MockHelmClient_InstallChart_Call{Call: _e.mock.On("InstallChart", ctx, cfg)}
+//   - opts InstallChartOptions
+func (_e *MockHelmClient_Expecter) InstallChart(ctx interface{}, cfg interface{}, opts interface{}) *MockHelmClient_InstallChart_Call {
+	return &MockHelmClient_InstallChart_Call{Call: _e.mock.On("InstallChart", ctx, cfg, opts)}
 }
 
-func (_c *MockHelmClient_InstallChart_Call) Run(run func(ctx context.Context, cfg ChartConfig)) *MockHelmClient_InstallChart_Call {
+func (_c *MockHelmClient_InstallChart_Call) Run(run func(ctx context.Context, cfg ChartConfig, opts InstallChartOptions)) *MockHelmClient_InstallChart_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -920,9 +921,14 @@ func (_c *MockHelmClient_InstallChart_Call) Run(run func(ctx context.Context, cf
 		if args[1] != nil {
 			arg1 = args[1].(ChartConfig)
 		}
+		var arg2 InstallChartOptions
+		if args[2] != nil {
+			arg2 = args[2].(InstallChartOptions)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -933,7 +939,7 @@ func (_c *MockHelmClient_InstallChart_Call) Return(err error) *MockHelmClient_In
 	return _c
 }
 
-func (_c *MockHelmClient_InstallChart_Call) RunAndReturn(run func(ctx context.Context, cfg ChartConfig) error) *MockHelmClient_InstallChart_Call {
+func (_c *MockHelmClient_InstallChart_Call) RunAndReturn(run func(ctx context.Context, cfg ChartConfig, opts InstallChartOptions) error) *MockHelmClient_InstallChart_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -557,4 +557,3 @@ func (o *OpenBaoInstaller) GetDRBackupExists() bool {
 func (o *OpenBaoInstaller) GetUnsealSecret() *corev1.Secret {
 	return o.unsealSecret
 }
-


### PR DESCRIPTION
- Add InstallChartOptions struct with ForceConflicts field to the HelmClient interface
- Replace hardcoded ForceConflicts=true in UpgradeChart with a configurable option
- Propagate ForceConflicts through install and upgrade paths in the ArgoCD installer
- Add --force-conflicts and --values/-f flags to the argocd CLI command
- Add --repo flag to configure the Helm chart repository (HTTP or OCI)
- Auto-detect OCI repos (oci:// prefix) and build the full chart reference accordingly