### PR TITLE
feat(bootstrap): enable ferretdb managed service provider

### DIFF
--- a/internal/bootstrap/gcp/gcp_test.go
+++ b/internal/bootstrap/gcp/gcp_test.go
@@ -263,7 +263,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 				Expect(cpNode.GetInternalIP()).To(Equal("10.0.0.1"))
 			}
 
-			Expect(len(bs.Env.InstallConfig.Codesphere.ManagedServices)).To(Equal(4))
+			Expect(len(bs.Env.InstallConfig.Codesphere.ManagedServices)).To(Equal(5))
 		})
 	})
 
@@ -605,16 +605,16 @@ var _ = Describe("GCP Bootstrapper", func() {
 				Expect(err).To(MatchError(ContainSubstring("prometheus remote write username and password must both be set when remote write URL is specified")))
 			})
 		})
-        Context("When Prometheus remote write URL is set but only password is missing", func() {
-    		BeforeEach(func() {
-   				csEnv.PrometheusRemoteWriteURL = "https://prometheus.example.com/api/v1/write"
-   				csEnv.PrometheusRemoteWriteUser = "prom-user"
-   			})
-           It("returns an error", func() {
-    			err := bs.ValidateInput()
-    			Expect(err).To(MatchError(ContainSubstring("prometheus remote write username and password must both be set when remote write URL is specified")))
-   			})
-        })
+		Context("When Prometheus remote write URL is set but only password is missing", func() {
+			BeforeEach(func() {
+				csEnv.PrometheusRemoteWriteURL = "https://prometheus.example.com/api/v1/write"
+				csEnv.PrometheusRemoteWriteUser = "prom-user"
+			})
+			It("returns an error", func() {
+				err := bs.ValidateInput()
+				Expect(err).To(MatchError(ContainSubstring("prometheus remote write username and password must both be set when remote write URL is specified")))
+			})
+		})
 		Context("When Prometheus remote write credentials are set but URL is missing", func() {
 			BeforeEach(func() {
 				csEnv.PrometheusRemoteWriteUser = "prom-user"

--- a/internal/installer/config_manager_profile.go
+++ b/internal/installer/config_manager_profile.go
@@ -181,6 +181,7 @@ func (g *InstallConfig) applyCommonProperties() {
 			{Name: "babelfish", Version: "v1"},
 			{Name: "s3", Version: "v1"},
 			{Name: "virtual-k8s", Version: "v1"},
+			{Name: "ferretdb", Version: "v0"},
 		}
 	}
 	if g.Config.Secrets.BaseDir == "" {

--- a/internal/installer/config_manager_profile_test.go
+++ b/internal/installer/config_manager_profile_test.go
@@ -153,7 +153,7 @@ var _ = Describe("ConfigManagerProfile", func() {
 
 					// Managed service config
 					Expect(config.Codesphere.ManagedServices).ToNot(BeNil())
-					Expect(len(config.Codesphere.ManagedServices)).To(Equal(4))
+					Expect(len(config.Codesphere.ManagedServices)).To(Equal(5))
 
 					// Secrets
 					Expect(config.Secrets.BaseDir).To(Equal("/root/secrets"))


### PR DESCRIPTION
Because we need to QA this new preview provider and release if approved during QA. 