### PR TITLE
fix: support unenrypted vault files for templating

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -67,7 +67,7 @@ License URL: https://gitea.com/gitea/go-sdk/src/tag/gitea/v0.25.1/gitea/LICENSE
 Module: dario.cat/mergo
 Version: v1.0.2
 License: BSD-3-Clause
-License URL: Unknown
+License URL: https://github.com/imdario/mergo/blob/v1.0.2/LICENSE
  
 ----------
 Module: filippo.io/age

--- a/internal/installer/config_template_test.go
+++ b/internal/installer/config_template_test.go
@@ -110,7 +110,7 @@ codesphere:
 		Expect(string(rendered)).To(ContainSubstring(`apiToken: "super-secret-token"`))
 	})
 
-	It("rejects unencrypted prod.vault.yaml files", func() {
+	It("supports unencrypted prod.vault.yaml files", func() {
 		tempDir := GinkgoT().TempDir()
 		vaultPath := filepath.Join(tempDir, "prod.vault.yaml")
 
@@ -120,8 +120,6 @@ codesphere:
 
 		_, err = installer.LoadVaultData(vaultPath, "")
 
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("is not SOPS-encrypted"))
+		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/internal/installer/vault_templating_secret_store.go
+++ b/internal/installer/vault_templating_secret_store.go
@@ -124,16 +124,16 @@ func LoadVaultData(vaultPath, ageKeyPath string) (*files.InstallVault, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect vault file %s: %w", vaultPath, err)
 	}
-	if !encrypted {
-		return nil, fmt.Errorf("vault file %s is not SOPS-encrypted", vaultPath)
+
+	if encrypted {
+		decrypted, err := DecryptFileWithSOPS(vaultPath, ageKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decrypt vault.yaml: %w", err)
+		}
+		data = decrypted
 	}
 
-	decrypted, err := DecryptFileWithSOPS(vaultPath, ageKeyPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt vault.yaml: %w", err)
-	}
-
-	vault, err := parseVaultData(decrypted)
+	vault, err := parseVaultData(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse decrypted vault.yaml: %w", err)
 	}

--- a/internal/tmpl/NOTICE
+++ b/internal/tmpl/NOTICE
@@ -67,7 +67,7 @@ License URL: https://gitea.com/gitea/go-sdk/src/tag/gitea/v0.25.1/gitea/LICENSE
 Module: dario.cat/mergo
 Version: v1.0.2
 License: BSD-3-Clause
-License URL: Unknown
+License URL: https://github.com/imdario/mergo/blob/v1.0.2/LICENSE
  
 ----------
 Module: filippo.io/age


### PR DESCRIPTION
This is hotfix to support recovery of bootstrapped GCP projects, where the vault has been encrypted before loading the vault for templating. We should discuss if we want to change the way of recovering the vault (decrypt on jumphost and download vs. download age_key.txt and decrypt when needed).