### PR TITLE
chore: add new managed service providers 

### DIFF
--- a/internal/installer/config_manager_profile.go
+++ b/internal/installer/config_manager_profile.go
@@ -182,6 +182,9 @@ func (g *InstallConfig) applyCommonProperties() {
 			{Name: "s3", Version: "v1"},
 			{Name: "virtual-k8s", Version: "v1"},
 			{Name: "ferretdb", Version: "v0"},
+			{Name: "opensearch", Version: "v0"},
+			{Name: "rabbitmq", Version: "v0"},
+			{Name: "valkey", Version: "v0"},
 		}
 	}
 	if g.Config.Secrets.BaseDir == "" {

--- a/internal/installer/config_manager_profile_test.go
+++ b/internal/installer/config_manager_profile_test.go
@@ -153,7 +153,17 @@ var _ = Describe("ConfigManagerProfile", func() {
 
 					// Managed service config
 					Expect(config.Codesphere.ManagedServices).ToNot(BeNil())
-					Expect(len(config.Codesphere.ManagedServices)).To(Equal(5))
+					Expect(config.Codesphere.ManagedServices).To(ContainElements(
+						files.ManagedServiceConfig{Name: "postgres", Version: "v1"},
+						files.ManagedServiceConfig{Name: "babelfish", Version: "v1"},
+						files.ManagedServiceConfig{Name: "s3", Version: "v1"},
+						files.ManagedServiceConfig{Name: "virtual-k8s", Version: "v1"},
+						files.ManagedServiceConfig{Name: "ferretdb", Version: "v0"},
+						files.ManagedServiceConfig{Name: "opensearch", Version: "v0"},
+						files.ManagedServiceConfig{Name: "rabbitmq", Version: "v0"},
+						files.ManagedServiceConfig{Name: "valkey", Version: "v0"},
+					))
+					Expect(len(config.Codesphere.ManagedServices)).To(Equal(8))
 
 					// Secrets
 					Expect(config.Secrets.BaseDir).To(Equal("/root/secrets"))

--- a/internal/installer/files/config_yaml.go
+++ b/internal/installer/files/config_yaml.go
@@ -549,8 +549,10 @@ type PlanParam struct {
 }
 
 type ManagedServiceBackendsConfig struct {
-	Postgres *PgManagedServiceConfig `yaml:"postgres,omitempty"`
-	S3       *S3ManagedServiceConfig `yaml:"s3,omitempty"`
+	Postgres         *PgManagedServiceConfig         `yaml:"postgres,omitempty"`
+	S3               *S3ManagedServiceConfig         `yaml:"s3,omitempty"`
+	RabbitMqOperator *RabbitMqOperatorConfig         `yaml:"rabbitMqOperator,omitempty"`
+	K8sBackend       *K8sBackendManagedServiceConfig `yaml:"k8sBackend,omitempty"`
 }
 
 type MonitoringConfig struct {
@@ -631,7 +633,15 @@ type PgManagedServiceConfig struct {
 	Override ChartOverride `yaml:"override,omitempty"`
 }
 
+type K8sBackendManagedServiceConfig struct {
+	Override ChartOverride `yaml:"override,omitempty"`
+}
+
 type S3ManagedServiceConfig struct {
+	Override ChartOverride `yaml:"override,omitempty"`
+}
+
+type RabbitMqOperatorConfig struct {
 	Override ChartOverride `yaml:"override,omitempty"`
 }
 

--- a/internal/installer/resource_profiles.go
+++ b/internal/installer/resource_profiles.go
@@ -222,6 +222,21 @@ func applyNoRequestsProfile(config *files.RootConfig) {
 		},
 	})
 
+	if config.ManagedServiceBackends.K8sBackend == nil {
+		config.ManagedServiceBackends.K8sBackend = &files.K8sBackendManagedServiceConfig{}
+	}
+	config.ManagedServiceBackends.K8sBackend.Override = util.DeepMergeMaps(config.ManagedServiceBackends.K8sBackend.Override, map[string]any{
+		"replicas": 1,
+		"resources": map[string]any{
+			"requests": zeroRequests(),
+		},
+	})
+
+	// TODO(CU-869dm2x7t): update rabbitmq operator chart to make replicas and resources configurable via helm values
+	if config.ManagedServiceBackends.RabbitMqOperator == nil {
+		config.ManagedServiceBackends.RabbitMqOperator = &files.RabbitMqOperatorConfig{}
+	}
+
 	serviceProfiles := map[string]any{}
 	for _, serviceName := range []string{
 		"auth_service",

--- a/internal/installer/resource_profiles_test.go
+++ b/internal/installer/resource_profiles_test.go
@@ -87,6 +87,8 @@ var _ = Describe("ApplyResourceProfile", func() {
 			Expect(config.ManagedServiceBackends).NotTo(BeNil())
 			Expect(config.ManagedServiceBackends.Postgres).NotTo(BeNil())
 			Expect(config.ManagedServiceBackends.S3).NotTo(BeNil())
+			Expect(config.ManagedServiceBackends.K8sBackend).NotTo(BeNil())
+			Expect(config.ManagedServiceBackends.RabbitMqOperator).NotTo(BeNil())
 
 			trustManager := MustMap[any](config.Cluster.TrustManager.Override["trust-manager"])
 			AssertZeroRequests(MustMap[any](trustManager["resources"])["requests"])
@@ -106,6 +108,13 @@ var _ = Describe("ApplyResourceProfile", func() {
 			managedS3 := config.ManagedServiceBackends.S3.Override
 			Expect(managedS3["replicas"]).To(Equal(1))
 			AssertZeroRequests(MustMap[any](managedS3["resources"])["requests"])
+
+			managedK8sBackend := config.ManagedServiceBackends.K8sBackend.Override
+			Expect(managedK8sBackend["replicas"]).To(Equal(1))
+			AssertZeroRequests(MustMap[any](managedK8sBackend["resources"])["requests"])
+
+			// TODO(CU-869dm2x7t): add assertions for rabbitmq operator once it's updated to support resource and replica configuration
+			Expect(config.ManagedServiceBackends.RabbitMqOperator.Override).To(BeNil())
 		})
 	})
 


### PR DESCRIPTION
We have 3 new providers (rabbitmq, valkey, opensearch) in PoC state which we would like to be able to early QA towards a preview state. This PR adds the new providers to `config.managedServices` and the new required components to `config.managedServiceBackends`. 