### PR TITLE
feat(config.yaml): add operations.skip option to config.yaml

### DIFF
--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -239,10 +239,16 @@ func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm
 	archivePath := filepath.Join(pm.GetWorkDir(), "deps.tar.gz")
 
 	cmdArgs := []string{installerPath, "--archive", archivePath, "--config", c.Opts.Config, "--privKey", c.Opts.PrivKey}
-	if len(c.Opts.SkipSteps) > 0 {
-		for _, step := range c.Opts.SkipSteps {
-			cmdArgs = append(cmdArgs, "--skipStep", step)
-		}
+	if len(config.Operations.Skip) > 0 && len(c.Opts.SkipSteps) > 0 {
+		return fmt.Errorf("skipped steps can either be defined in config.yaml under `.operations.skip` or supplied via `--skip-step` flag, but not both")
+	}
+
+	for _, step := range config.Operations.Skip {
+		cmdArgs = append(cmdArgs, "--skipStep", step)
+	}
+
+	for _, step := range c.Opts.SkipSteps {
+		cmdArgs = append(cmdArgs, "--skipStep", step)
 	}
 
 	if c.Opts.CodesphereOnly {

--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -239,12 +239,14 @@ func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm
 	archivePath := filepath.Join(pm.GetWorkDir(), "deps.tar.gz")
 
 	cmdArgs := []string{installerPath, "--archive", archivePath, "--config", c.Opts.Config, "--privKey", c.Opts.PrivKey}
-	if len(config.Operations.Skip) > 0 && len(c.Opts.SkipSteps) > 0 {
-		return fmt.Errorf("skipped steps can either be defined in config.yaml under `.operations.skip` or supplied via `--skip-step` flag, but not both")
-	}
+	if config.Operations != nil {
+		if len(config.Operations.Skip) > 0 && len(c.Opts.SkipSteps) > 0 {
+			return fmt.Errorf("skipped steps can either be defined in config.yaml under `.operations.skip` or supplied via `--skip-step` flag, but not both")
+		}
 
-	for _, step := range config.Operations.Skip {
-		cmdArgs = append(cmdArgs, "--skipStep", step)
+		for _, step := range config.Operations.Skip {
+			cmdArgs = append(cmdArgs, "--skipStep", step)
+		}
 	}
 
 	for _, step := range c.Opts.SkipSteps {

--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -267,24 +267,21 @@ func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm
 		executableSteps[step] = false
 	}
 
+	executedSteps := []string{}
 	for step, executed := range executableSteps {
 		if !executed {
 			cmdArgs = append(cmdArgs, "--skipStep", step)
-		}
-	}
-
-	executedSteps := []string{}
-	for step, executed := range executableSteps {
-		if executed {
+		} else {
 			executedSteps = append(executedSteps, step)
 		}
 	}
+
 	sort.Strings(executedSteps)
 
 	prompt := installer.NewPrompter(!c.Opts.AutoApprove)
 	msg := fmt.Sprintf("The following steps will be executed: %s. Type \"yes\" to continue.", strings.Join(executedSteps, ", "))
 	if prompt.String(msg, "yes") != "yes" {
-		return fmt.Errorf("Installation aborted")
+		return fmt.Errorf("installation aborted")
 	}
 
 	if c.Opts.CodesphereOnly {

--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -43,6 +43,7 @@ type InstallCodesphereOpts struct {
 	SkipSteps        []string
 	CodesphereOnly   bool
 	DirectConnection bool
+	AutoApprove      bool
 }
 
 func (c *InstallCodesphereCmd) RunE(_ *cobra.Command, args []string) error {
@@ -88,6 +89,7 @@ func AddInstallCodesphereCmd(install *cobra.Command, opts *GlobalOptions) {
 	codesphere.cmd.Flags().StringSliceVarP(&codesphere.Opts.SkipSteps, "skip-steps", "s", []string{}, "Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, kubernetes")
 	codesphere.cmd.Flags().BoolVar(&codesphere.Opts.CodesphereOnly, "codesphere-only", false, "Install only Codesphere without dependencies")
 	codesphere.cmd.Flags().BoolVar(&codesphere.Opts.DirectConnection, "direct-connection", false, "Use direct connection for installation, requires having access to the cluster nodes from your machine")
+	codesphere.cmd.Flags().BoolVar(&codesphere.Opts.AutoApprove, "auto-approve", true, "Auto approve confirmation prompts with default values")
 
 	util.MarkFlagRequired(codesphere.cmd, "package")
 	util.MarkFlagRequired(codesphere.cmd, "config")
@@ -279,9 +281,9 @@ func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm
 	}
 	sort.Strings(executedSteps)
 
-	prompt := installer.NewPrompter(true)
+	prompt := installer.NewPrompter(!c.Opts.AutoApprove)
 	msg := fmt.Sprintf("The following steps will be executed: %s. Type \"yes\" to continue.", strings.Join(executedSteps, ", "))
-	if prompt.String(msg, "no") != "yes" {
+	if prompt.String(msg, "yes") != "yes" {
 		return fmt.Errorf("Installation aborted")
 	}
 

--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/codesphere-cloud/cs-go/pkg/io"
@@ -276,6 +277,7 @@ func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm
 	for step, _ := range skippableSteps {
 		executedSteps = append(executedSteps, step)
 	}
+	sort.Strings(executedSteps)
 
 	prompt := installer.NewPrompter(true)
 	msg := fmt.Sprintf("The following steps will be executed: %s. Type \"yes\" to continue.", strings.Join(executedSteps, ", "))

--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -239,18 +239,54 @@ func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm
 	archivePath := filepath.Join(pm.GetWorkDir(), "deps.tar.gz")
 
 	cmdArgs := []string{installerPath, "--archive", archivePath, "--config", c.Opts.Config, "--privKey", c.Opts.PrivKey}
+
+	skippableSteps := map[string]struct{}{
+		"copy-dependencies":     {},
+		"extract-dependencies":  {},
+		"load-container-images": {},
+		"sops":                  {},
+		"docker":                {},
+		"postgres":              {},
+		"ceph":                  {},
+		"kubernetes":            {},
+		"set-up-cluster":        {},
+		"codesphere":            {},
+		"ms-backends":           {},
+	}
+	skippedSteps := []string{}
+
 	if config.Operations != nil {
 		if len(config.Operations.Skip) > 0 && len(c.Opts.SkipSteps) > 0 {
 			return fmt.Errorf("skipped steps can either be defined in config.yaml under `.operations.skip` or supplied via `--skip-step` flag, but not both")
 		}
 
 		for _, step := range config.Operations.Skip {
-			cmdArgs = append(cmdArgs, "--skipStep", step)
+			skippedSteps = append(skippedSteps, step)
 		}
 	}
 
-	for _, step := range c.Opts.SkipSteps {
+	if len(c.Opts.SkipSteps) > 0 {
+		for _, step := range c.Opts.SkipSteps {
+			skippedSteps = append(skippedSteps, step)
+		}
+	}
+
+	for _, step := range skippedSteps {
 		cmdArgs = append(cmdArgs, "--skipStep", step)
+		if _, ok := skippableSteps[step]; ok {
+			delete(skippableSteps, step)
+		}
+	}
+
+	executedSteps := []string{}
+	for component, _ := range skippableSteps {
+		executedSteps = append(executedSteps, component)
+	}
+
+	prompt := installer.NewPrompter(true)
+	msg := fmt.Sprintf("The following steps will be executed: %s. Type \"yes\" to continue.", strings.Join(executedSteps, ", "))
+	if prompt.String(msg, "no") != "yes" {
+		return fmt.Errorf("Installation aborted")
 	}
 
 	if c.Opts.CodesphereOnly {

--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -253,25 +253,19 @@ func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm
 		"codesphere":            {},
 		"ms-backends":           {},
 	}
-	skippedSteps := []string{}
 
+	skippedSteps := map[string]struct{}{}
 	if config.Operations != nil {
-		if len(config.Operations.Skip) > 0 && len(c.Opts.SkipSteps) > 0 {
-			return fmt.Errorf("skipped steps can either be defined in config.yaml under `.operations.skip` or supplied via `--skip-step` flag, but not both")
-		}
-
 		for _, step := range config.Operations.Skip {
-			skippedSteps = append(skippedSteps, step)
+			skippedSteps[step] = struct{}{}
 		}
 	}
 
-	if len(c.Opts.SkipSteps) > 0 {
-		for _, step := range c.Opts.SkipSteps {
-			skippedSteps = append(skippedSteps, step)
-		}
+	for _, step := range c.Opts.SkipSteps {
+		skippedSteps[step] = struct{}{}
 	}
 
-	for _, step := range skippedSteps {
+	for step, _ := range skippedSteps {
 		cmdArgs = append(cmdArgs, "--skipStep", step)
 		if _, ok := skippableSteps[step]; ok {
 			delete(skippableSteps, step)
@@ -279,8 +273,8 @@ func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm
 	}
 
 	executedSteps := []string{}
-	for component, _ := range skippableSteps {
-		executedSteps = append(executedSteps, component)
+	for step, _ := range skippableSteps {
+		executedSteps = append(executedSteps, step)
 	}
 
 	prompt := installer.NewPrompter(true)

--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -243,41 +243,41 @@ func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm
 
 	cmdArgs := []string{installerPath, "--archive", archivePath, "--config", c.Opts.Config, "--privKey", c.Opts.PrivKey}
 
-	skippableSteps := map[string]struct{}{
-		"copy-dependencies":     {},
-		"extract-dependencies":  {},
-		"load-container-images": {},
-		"sops":                  {},
-		"docker":                {},
-		"postgres":              {},
-		"ceph":                  {},
-		"kubernetes":            {},
-		"set-up-cluster":        {},
-		"codesphere":            {},
-		"ms-backends":           {},
+	executableSteps := map[string]bool{
+		"copy-dependencies":     true,
+		"extract-dependencies":  true,
+		"load-container-images": true,
+		"sops":                  true,
+		"docker":                true,
+		"postgres":              true,
+		"ceph":                  true,
+		"kubernetes":            true,
+		"set-up-cluster":        true,
+		"codesphere":            true,
+		"ms-backends":           true,
 	}
 
-	skippedSteps := map[string]struct{}{}
 	if config.Operations != nil {
 		for _, step := range config.Operations.Skip {
-			skippedSteps[step] = struct{}{}
+			executableSteps[step] = false
 		}
 	}
 
 	for _, step := range c.Opts.SkipSteps {
-		skippedSteps[step] = struct{}{}
+		executableSteps[step] = false
 	}
 
-	for step, _ := range skippedSteps {
-		cmdArgs = append(cmdArgs, "--skipStep", step)
-		if _, ok := skippableSteps[step]; ok {
-			delete(skippableSteps, step)
+	for step, executed := range executableSteps {
+		if !executed {
+			cmdArgs = append(cmdArgs, "--skipStep", step)
 		}
 	}
 
 	executedSteps := []string{}
-	for step, _ := range skippableSteps {
-		executedSteps = append(executedSteps, step)
+	for step, executed := range executableSteps {
+		if executed {
+			executedSteps = append(executedSteps, step)
+		}
 	}
 	sort.Strings(executedSteps)
 

--- a/cli/cmd/install_codesphere_test.go
+++ b/cli/cmd/install_codesphere_test.go
@@ -403,6 +403,55 @@ var _ = Describe("InstallCodesphereCmd", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("invalid image tag format"))
 			})
+
+			It("fails when skipped steps are defined in both config.yaml and cli args", func() {
+				mockPackageManager := installer.NewMockPackageManager(GinkgoT())
+				mockConfigManager := installer.NewMockConfigManager(GinkgoT())
+				mockImageManager := system.NewMockImageManager(GinkgoT())
+				mockFileIO := util.NewMockFileIO(GinkgoT())
+
+				c.Opts.Config = "valid-config.yaml"
+				c.Opts.SkipSteps = []string{"kubernetes"}
+				config := files.RootConfig{
+					Operations: &files.OperationsConfig{
+						Skip: []string{"ceph"},
+					},
+				}
+
+				mockConfigManager.EXPECT().ParseConfigYaml("valid-config.yaml").Return(config, nil)
+
+				// Setup temp dir for node executable check (because os.Chmod uses real FS)
+				tempDir, err := os.MkdirTemp("", "test-install")
+				Expect(err).To(BeNil())
+				defer func() {
+					_ = os.RemoveAll(tempDir)
+				}()
+
+				// Create dummy node file
+				nodeFile := filepath.Join(tempDir, "node")
+				err = os.WriteFile(nodeFile, []byte("#!/bin/sh\nexit 0"), 0755)
+				Expect(err).To(BeNil())
+
+				mockPackageManager.EXPECT().Extract(false).Return(nil)
+				mockPackageManager.EXPECT().GetWorkDir().Return(tempDir).Maybe()
+				mockPackageManager.EXPECT().FileIO().Return(mockFileIO).Maybe()
+				mockFileIO.EXPECT().Exists(tempDir).Return(true)
+
+				// Create complete mock directory entries with all required files
+				mockEntries := []os.DirEntry{
+					&MockDirEntry{name: "deps.tar.gz", isDir: false},
+					&MockDirEntry{name: "node", isDir: false},
+					&MockDirEntry{name: "private-cloud-installer.js", isDir: false},
+					&MockDirEntry{name: "kubectl", isDir: false},
+				}
+				mockFileIO.EXPECT().ReadDir(tempDir).Return(mockEntries, nil)
+
+				mockPackageManager.EXPECT().ExtractDependency("bom.json", false).Return(nil)
+
+				err = c.ExtractAndInstall(mockPackageManager, mockConfigManager, mockImageManager, "linux", "amd64")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("skipped steps can either be defined in config.yaml under `.operations.skip` or supplied via `--skip-step` flag, but not both"))
+			})
 		})
 	})
 

--- a/cli/cmd/install_codesphere_test.go
+++ b/cli/cmd/install_codesphere_test.go
@@ -403,55 +403,6 @@ var _ = Describe("InstallCodesphereCmd", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("invalid image tag format"))
 			})
-
-			It("fails when skipped steps are defined in both config.yaml and cli args", func() {
-				mockPackageManager := installer.NewMockPackageManager(GinkgoT())
-				mockConfigManager := installer.NewMockConfigManager(GinkgoT())
-				mockImageManager := system.NewMockImageManager(GinkgoT())
-				mockFileIO := util.NewMockFileIO(GinkgoT())
-
-				c.Opts.Config = "valid-config.yaml"
-				c.Opts.SkipSteps = []string{"kubernetes"}
-				config := files.RootConfig{
-					Operations: &files.OperationsConfig{
-						Skip: []string{"ceph"},
-					},
-				}
-
-				mockConfigManager.EXPECT().ParseConfigYaml("valid-config.yaml").Return(config, nil)
-
-				// Setup temp dir for node executable check (because os.Chmod uses real FS)
-				tempDir, err := os.MkdirTemp("", "test-install")
-				Expect(err).To(BeNil())
-				defer func() {
-					_ = os.RemoveAll(tempDir)
-				}()
-
-				// Create dummy node file
-				nodeFile := filepath.Join(tempDir, "node")
-				err = os.WriteFile(nodeFile, []byte("#!/bin/sh\nexit 0"), 0755)
-				Expect(err).To(BeNil())
-
-				mockPackageManager.EXPECT().Extract(false).Return(nil)
-				mockPackageManager.EXPECT().GetWorkDir().Return(tempDir).Maybe()
-				mockPackageManager.EXPECT().FileIO().Return(mockFileIO).Maybe()
-				mockFileIO.EXPECT().Exists(tempDir).Return(true)
-
-				// Create complete mock directory entries with all required files
-				mockEntries := []os.DirEntry{
-					&MockDirEntry{name: "deps.tar.gz", isDir: false},
-					&MockDirEntry{name: "node", isDir: false},
-					&MockDirEntry{name: "private-cloud-installer.js", isDir: false},
-					&MockDirEntry{name: "kubectl", isDir: false},
-				}
-				mockFileIO.EXPECT().ReadDir(tempDir).Return(mockEntries, nil)
-
-				mockPackageManager.EXPECT().ExtractDependency("bom.json", false).Return(nil)
-
-				err = c.ExtractAndInstall(mockPackageManager, mockConfigManager, mockImageManager, "linux", "amd64")
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("skipped steps can either be defined in config.yaml under `.operations.skip` or supplied via `--skip-step` flag, but not both"))
-			})
 		})
 	})
 

--- a/docs/oms_install_codesphere.md
+++ b/docs/oms_install_codesphere.md
@@ -25,6 +25,7 @@ $ oms install codesphere -p codesphere-v1.2.3-installer-lite.tar.gz -k <path-to-
 ### Options
 
 ```
+      --auto-approve         Auto approve confirmation prompts with default values (default true)
       --codesphere-only      Install only Codesphere without dependencies
   -c, --config string        Path to the Codesphere Private Cloud configuration file (yaml)
       --direct-connection    Use direct connection for installation, requires having access to the cluster nodes from your machine

--- a/internal/installer/files/config_yaml.go
+++ b/internal/installer/files/config_yaml.go
@@ -66,7 +66,7 @@ type RootConfig struct {
 }
 
 type OperationsConfig struct {
-	Skip []string
+	Skip []string `yaml:"skip"`
 }
 
 type DatacenterConfig struct {

--- a/internal/installer/files/config_yaml.go
+++ b/internal/installer/files/config_yaml.go
@@ -62,6 +62,11 @@ type RootConfig struct {
 	MetalLB                *MetalLBConfig                `yaml:"metallb,omitempty"`
 	Codesphere             CodesphereConfig              `yaml:"codesphere"`
 	ManagedServiceBackends *ManagedServiceBackendsConfig `yaml:"managedServiceBackends,omitempty"`
+	Operations             *OperationsConfig             `yaml:"operations,omitempty"`
+}
+
+type OperationsConfig struct {
+	Skip []string
 }
 
 type DatacenterConfig struct {


### PR DESCRIPTION
One can now add steps to skip into `config.yaml` under `operations.skip` as a list of string. The steps to be skipped can be defined both in `config.yaml` and cli args, and all those steps will be merged. An interactive prompt can be turned on by running the cli with `--auto-approve=false` to confirm the steps to be skipped.