### PR TITLE
fix(renovate): only execute postUpgradeTasks for go dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["github>codesphere-cloud/renovate-config:go-config"],
   "packageRules": [
     {
-      "matchPackageNames": ["*"],
+      "matchManagers": ["gomod"],
       "postUpgradeTasks": {
           "commands": [
             "go mod tidy",


### PR DESCRIPTION
The current behavior throws errors for Renovate when trying to run `go mod tidy` for example for github actions dependencies. This change only executes the `postUpgradeTasks` for go dependencies.