### PR TITLE
feat: force-conflicts in pc-application install

### DIFF
--- a/cli/cmd/pc_apps.go
+++ b/cli/cmd/pc_apps.go
@@ -22,9 +22,10 @@ type InstallPCAppsCmd struct {
 
 type InstallPCAppsOpts struct {
 	*GlobalOptions
-	Version     string
-	Namespace   string
-	ValuesFiles []string
+	Version        string
+	Namespace      string
+	ValuesFiles    []string
+	ForceConflicts bool
 }
 
 func (c *InstallPCAppsCmd) RunE(cmd *cobra.Command, args []string) error {
@@ -43,6 +44,7 @@ func (c *InstallPCAppsCmd) RunE(cmd *cobra.Command, args []string) error {
 		c.Opts.Version,
 		c.Opts.Namespace,
 		c.Opts.ValuesFiles,
+		c.Opts.ForceConflicts,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize pc-apps installer: %w", err)
@@ -80,6 +82,7 @@ func AddPCAppsCmd(parentCmd *cobra.Command, opts *GlobalOptions) {
 	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Version, "version", "", "Chart version to install (required)")
 	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Namespace, "namespace", "argocd", "Target namespace for the Helm release")
 	pcApps.cmd.Flags().StringArrayVarP(&pcApps.Opts.ValuesFiles, "values", "f", nil, "Path to values YAML file (can be specified multiple times, merged in order)")
+	pcApps.cmd.Flags().BoolVar(&pcApps.Opts.ForceConflicts, "force-conflicts", false, "Force field ownership conflicts during install or upgrade (sets server-side apply ForceConflicts)")
 	pcApps.cmd.RunE = pcApps.RunE
 
 	util.MarkFlagRequired(pcApps.cmd, "version")

--- a/cli/cmd/pc_apps.go
+++ b/cli/cmd/pc_apps.go
@@ -77,6 +77,7 @@ func AddPCAppsCmd(parentCmd *cobra.Command, opts *GlobalOptions) {
 			{Cmd: "--version 1.0.0", Desc: "Install a specific version"},
 			{Cmd: "--version 1.0.0 -f base.yaml -f dc-overlay.yaml", Desc: "Install with custom values files"},
 			{Cmd: "--version 1.0.0 --namespace custom-ns", Desc: "Install into a custom namespace"},
+			{Cmd: "--version 1.0.0 --force-conflicts", Desc: "Force SSA ownership conflicts during install or upgrade"},
 		}),
 	}
 	pcApps.cmd.Flags().StringVar(&pcApps.Opts.Version, "version", "", "Chart version to install (required)")

--- a/docs/oms_beta_install_pc-apps.md
+++ b/docs/oms_beta_install_pc-apps.md
@@ -28,11 +28,15 @@ $ oms beta install pc-apps --version 1.0.0 -f base.yaml -f dc-overlay.yaml
 # Install into a custom namespace
 $ oms beta install pc-apps --version 1.0.0 --namespace custom-ns
 
+# Force SSA ownership conflicts during install or upgrade
+$ oms beta install pc-apps --version 1.0.0 --force-conflicts
+
 ```
 
 ### Options
 
 ```
+      --force-conflicts      Force field ownership conflicts during install or upgrade (sets server-side apply ForceConflicts)
   -h, --help                 help for pc-apps
       --namespace string     Target namespace for the Helm release (default "argocd")
   -f, --values stringArray   Path to values YAML file (can be specified multiple times, merged in order)

--- a/internal/installer/pc_apps.go
+++ b/internal/installer/pc_apps.go
@@ -33,17 +33,18 @@ const (
 // PCApps holds the configuration for installing the pc-applications Helm chart
 // from a private OCI registry.
 type PCApps struct {
-	version     string   // chart version (required)
-	namespace   string   // target namespace for the Helm release
-	valuesFiles []string // paths to values YAML files, merged in order
-	helm        HelmClient
-	client      client.Client
+	version        string   // chart version (required)
+	namespace      string   // target namespace for the Helm release
+	valuesFiles    []string // paths to values YAML files, merged in order
+	forceConflicts bool
+	helm           HelmClient
+	client         client.Client
 }
 
 // NewPCApps creates a new PCApps installer. It validates that required fields
 // are non-empty but does not apply defaults — defaults live on the CLI flag
 // declarations only.
-func NewPCApps(c client.Client, version, namespace string, valuesFiles []string) (*PCApps, error) {
+func NewPCApps(c client.Client, version, namespace string, valuesFiles []string, forceConflicts bool) (*PCApps, error) {
 	if version == "" {
 		return nil, errors.New("version is required")
 	}
@@ -57,11 +58,12 @@ func NewPCApps(c client.Client, version, namespace string, valuesFiles []string)
 	}
 
 	return &PCApps{
-		version:     version,
-		namespace:   namespace,
-		valuesFiles: valuesFiles,
-		helm:        helm,
-		client:      c,
+		version:        version,
+		namespace:      namespace,
+		valuesFiles:    valuesFiles,
+		forceConflicts: forceConflicts,
+		helm:           helm,
+		client:         c,
 	}, nil
 }
 
@@ -137,7 +139,10 @@ func (p *PCApps) Install(ctx context.Context) error {
 	}
 
 	log.Printf("Installing/Upgrading %s (version %s) into namespace %s\n", pcAppsReleaseName, p.version, p.namespace)
-	if err := p.helm.UpgradeChart(ctx, cfg, UpgradeChartOptions{InstallIfNotExist: true}); err != nil {
+	if err := p.helm.UpgradeChart(ctx, cfg, UpgradeChartOptions{
+		InstallIfNotExist: true,
+		ForceConflicts:    p.forceConflicts,
+	}); err != nil {
 		return fmt.Errorf("install/upgrade failed: %w", err)
 	}
 
@@ -147,12 +152,13 @@ func (p *PCApps) Install(ctx context.Context) error {
 
 // NewPCAppsForTesting creates a PCApps instance with injected dependencies for
 // use in tests. This avoids exporting struct fields solely for test access.
-func NewPCAppsForTesting(helm HelmClient, c client.Client, version, namespace string, valuesFiles []string) *PCApps {
+func NewPCAppsForTesting(helm HelmClient, c client.Client, version, namespace string, valuesFiles []string, forceConflicts bool) *PCApps {
 	return &PCApps{
-		version:     version,
-		namespace:   namespace,
-		valuesFiles: valuesFiles,
-		helm:        helm,
-		client:      c,
+		version:        version,
+		namespace:      namespace,
+		valuesFiles:    valuesFiles,
+		forceConflicts: forceConflicts,
+		helm:           helm,
+		client:         c,
 	}
 }

--- a/internal/installer/pc_apps_test.go
+++ b/internal/installer/pc_apps_test.go
@@ -88,7 +88,16 @@ var _ = Describe("PCApps.Install", func() {
 
 		It("returns an error when UpgradeChart fails", func() {
 			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).Return(nil)
-			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.Anything, mock.Anything).
+			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				return cfg.ReleaseName == "pc-applications" &&
+					cfg.ChartName == expectedChartURL &&
+					cfg.Namespace == namespace &&
+					cfg.Version == version &&
+					cfg.CreateNamespace
+			}), installer.UpgradeChartOptions{
+				InstallIfNotExist: true,
+				ForceConflicts:    false,
+			}).
 				Return(errors.New("upgrade conflict"))
 
 			err := pcApps.Install(context.Background())

--- a/internal/installer/pc_apps_test.go
+++ b/internal/installer/pc_apps_test.go
@@ -69,7 +69,7 @@ var _ = Describe("PCApps.Install", func() {
 				WithScheme(scheme).
 				WithObjects(newSecret()).
 				Build()
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil)
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, false)
 		})
 
 		It("reads credentials from K8s secret and calls UpgradeChart with InstallIfNotExist", func() {
@@ -103,7 +103,7 @@ var _ = Describe("PCApps.Install", func() {
 				WithScheme(scheme).
 				WithObjects(newSecret()).
 				Build()
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil)
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, false)
 		})
 
 		It("returns an error without attempting install", func() {
@@ -122,7 +122,7 @@ var _ = Describe("PCApps.Install", func() {
 			fakeClient = fake.NewClientBuilder().
 				WithScheme(scheme).
 				Build()
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil)
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, false)
 		})
 
 		It("returns a clear error", func() {
@@ -150,7 +150,7 @@ var _ = Describe("PCApps.Install", func() {
 				WithScheme(scheme).
 				WithObjects(secret).
 				Build()
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil)
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, false)
 		})
 
 		It("returns an error about missing fields", func() {
@@ -185,7 +185,7 @@ var _ = Describe("PCApps.Install", func() {
 			overlay := filepath.Join(tmpDir, "overlay.yaml")
 			Expect(os.WriteFile(overlay, []byte("foo: overridden\nnested:\n  b: 99\n  c: 3\n"), 0644)).To(Succeed())
 
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{base, overlay})
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{base, overlay}, false)
 
 			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).Return(nil)
 			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
@@ -204,7 +204,7 @@ var _ = Describe("PCApps.Install", func() {
 		})
 
 		It("returns an error for non-existent values file", func() {
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{"/nonexistent/values.yaml"})
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{"/nonexistent/values.yaml"}, false)
 
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())
@@ -215,11 +215,32 @@ var _ = Describe("PCApps.Install", func() {
 			badFile := filepath.Join(tmpDir, "bad.yaml")
 			Expect(os.WriteFile(badFile, []byte("{{invalid yaml"), 0644)).To(Succeed())
 
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{badFile})
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{badFile}, false)
 
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("loading values files"))
+		})
+	})
+
+	Context("ForceConflicts", func() {
+		BeforeEach(func() {
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(newSecret()).
+				Build()
+		})
+
+		It("passes ForceConflicts=true to UpgradeChart", func() {
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, true)
+
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).Return(nil)
+			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.Anything, mock.MatchedBy(func(opts installer.UpgradeChartOptions) bool {
+				return opts.InstallIfNotExist && opts.ForceConflicts
+			})).Return(nil)
+
+			err := pcApps.Install(context.Background())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
We had mutliple failed master deploys with the pc-application install conflicting on SSA managed fields.

Since the oms installer should have higher authority than the argo app controller it should be able to force field ownership to itself in the install step.

So we expose a force-conflicts option that alreay exists in the helm client to be used in the oms cli.