### PR TITLE
fix(installer/node): fs.inotify.max_user_instances not configured

### DIFF
--- a/internal/bootstrap/gcp/gcp_test.go
+++ b/internal/bootstrap/gcp/gcp_test.go
@@ -1152,11 +1152,18 @@ var _ = Describe("GCP Bootstrapper", func() {
 
 			It("fails when ConfigureMemoryMap fails", func() {
 				mock.InOrder(
-					nodeClient.EXPECT().RunCommand(mock.Anything, "root", mock.Anything).Return(nil).Times(1),                // hasSysctlLine (grep exists)
-					nodeClient.EXPECT().RunCommand(mock.Anything, "root", mock.Anything).Return(nil).Times(1),                // isSysctlActive (grep exists) -> properly configured!
-					nodeClient.EXPECT().RunCommand(mock.Anything, "root", mock.Anything).Return(fmt.Errorf("ouch")).Times(1), // hasSysctlLine (grep doesn't exist)
-					nodeClient.EXPECT().RunCommand(mock.Anything, "root", mock.Anything).Return(fmt.Errorf("ouch")).Times(1), // hasSysctlLine grep
-					nodeClient.EXPECT().RunCommand(mock.Anything, "root", mock.Anything).Return(fmt.Errorf("ouch")).Times(1), // tee command fails
+					// HasInotifyWatchesConfigured: all 4 checks pass → skip ConfigureInotifyWatches
+					nodeClient.EXPECT().RunCommand(mock.Anything, "root", "sudo grep -E '^fs.inotify.max_user_watches=1048576' /etc/sysctl.conf >/dev/null 2>&1").Return(nil).Once(),
+					nodeClient.EXPECT().RunCommand(mock.Anything, "root", "sudo sysctl -n fs.inotify.max_user_watches | grep -q '^1048576$'").Return(nil).Once(),
+					nodeClient.EXPECT().RunCommand(mock.Anything, "root", "sudo grep -E '^fs.inotify.max_user_instances=8192' /etc/sysctl.conf >/dev/null 2>&1").Return(nil).Once(),
+					nodeClient.EXPECT().RunCommand(mock.Anything, "root", "sudo sysctl -n fs.inotify.max_user_instances | grep -q '^8192$'").Return(nil).Once(),
+
+					// HasMemoryMapConfigured: line not found → returns false → call ConfigureMemoryMap
+					nodeClient.EXPECT().RunCommand(mock.Anything, "root", "sudo grep -E '^vm.max_map_count=262144' /etc/sysctl.conf >/dev/null 2>&1").Return(fmt.Errorf("not found")).Once(),
+
+					// ConfigureMemoryMap → configureSysctlLine: line not found → tee fails
+					nodeClient.EXPECT().RunCommand(mock.Anything, "root", "sudo grep -E '^vm.max_map_count=262144' /etc/sysctl.conf >/dev/null 2>&1").Return(fmt.Errorf("not found")).Once(),
+					nodeClient.EXPECT().RunCommand(mock.Anything, "root", "echo 'vm.max_map_count=262144' | sudo tee -a /etc/sysctl.conf").Return(fmt.Errorf("ouch")).Once(),
 				)
 
 				err := bs.EnsureHostsConfigured()

--- a/internal/installer/node/node.go
+++ b/internal/installer/node/node.go
@@ -361,7 +361,7 @@ func (n *Node) isSysctlActive(key, expected string) bool {
 }
 
 // configureSysctlLine appends a specific line to /etc/sysctl.conf and applies the settings on the remote node via SSH
-func (n *Node) configureSysctlLines(line string) error {
+func (n *Node) configureSysctlLine(line string) error {
 	if !n.hasSysctlLine(line) {
 		cmd := fmt.Sprintf("echo '%s' | sudo tee -a /etc/sysctl.conf", line)
 		if err := n.RunSSHCommand("root", cmd); err != nil {

--- a/internal/installer/node/node.go
+++ b/internal/installer/node/node.go
@@ -274,11 +274,23 @@ func (n *Node) EnableRootLogin() error {
 }
 
 func (n *Node) HasInotifyWatchesConfigured() bool {
-	return n.hasSysctlLine("fs.inotify.max_user_watches=1048576") && n.isSysctlActive("fs.inotify.max_user_watches", "1048576")
+	return n.hasSysctlLine("fs.inotify.max_user_watches=1048576") &&
+	    n.isSysctlActive("fs.inotify.max_user_watches", "1048576") &&
+	    n.hasSysctlLine("fs.inotify.max_user_instances=8192") &&
+	    n.isSysctlActive("fs.inotify.max_user_instances", "8192")
 }
 
 func (n *Node) ConfigureInotifyWatches() error {
-	return n.configureSysctlLine("fs.inotify.max_user_watches=1048576")
+	lines := []string{
+		"fs.inotify.max_user_instances=8192",
+		"fs.inotify.max_user_watches=1048576",
+	}
+	for _, ln := range lines {
+        err := n.configureSysctlLine(ln)
+		if err != nil {
+			return fmt.Errorf("failed to configure systctl line '%s': %w", ln, err)
+		}
+	}
 }
 
 func (n *Node) HasMemoryMapConfigured() bool {
@@ -349,7 +361,7 @@ func (n *Node) isSysctlActive(key, expected string) bool {
 }
 
 // configureSysctlLine appends a specific line to /etc/sysctl.conf and applies the settings on the remote node via SSH
-func (n *Node) configureSysctlLine(line string) error {
+func (n *Node) configureSysctlLines(line string) error {
 	if !n.hasSysctlLine(line) {
 		cmd := fmt.Sprintf("echo '%s' | sudo tee -a /etc/sysctl.conf", line)
 		if err := n.RunSSHCommand("root", cmd); err != nil {

--- a/internal/installer/node/node.go
+++ b/internal/installer/node/node.go
@@ -291,6 +291,7 @@ func (n *Node) ConfigureInotifyWatches() error {
 			return fmt.Errorf("failed to configure systctl line '%s': %w", ln, err)
 		}
 	}
+	return nil
 }
 
 func (n *Node) HasMemoryMapConfigured() bool {

--- a/internal/installer/node/node.go
+++ b/internal/installer/node/node.go
@@ -275,23 +275,17 @@ func (n *Node) EnableRootLogin() error {
 
 func (n *Node) HasInotifyWatchesConfigured() bool {
 	return n.hasSysctlLine("fs.inotify.max_user_watches=1048576") &&
-	    n.isSysctlActive("fs.inotify.max_user_watches", "1048576") &&
-	    n.hasSysctlLine("fs.inotify.max_user_instances=8192") &&
-	    n.isSysctlActive("fs.inotify.max_user_instances", "8192")
+		n.isSysctlActive("fs.inotify.max_user_watches", "1048576") &&
+		n.hasSysctlLine("fs.inotify.max_user_instances=8192") &&
+		n.isSysctlActive("fs.inotify.max_user_instances", "8192")
 }
 
 func (n *Node) ConfigureInotifyWatches() error {
 	lines := []string{
-		"fs.inotify.max_user_instances=8192",
 		"fs.inotify.max_user_watches=1048576",
+		"fs.inotify.max_user_instances=8192",
 	}
-	for _, ln := range lines {
-        err := n.configureSysctlLine(ln)
-		if err != nil {
-			return fmt.Errorf("failed to configure systctl line '%s': %w", ln, err)
-		}
-	}
-	return nil
+	return n.configureSysctlLines(lines)
 }
 
 func (n *Node) HasMemoryMapConfigured() bool {
@@ -299,7 +293,7 @@ func (n *Node) HasMemoryMapConfigured() bool {
 }
 
 func (n *Node) ConfigureMemoryMap() error {
-	return n.configureSysctlLine("vm.max_map_count=262144")
+	return n.configureSysctlLines([]string{"vm.max_map_count=262144"})
 }
 
 // HasFile checks if a file exists on the remote node via SSH
@@ -362,11 +356,13 @@ func (n *Node) isSysctlActive(key, expected string) bool {
 }
 
 // configureSysctlLine appends a specific line to /etc/sysctl.conf and applies the settings on the remote node via SSH
-func (n *Node) configureSysctlLine(line string) error {
-	if !n.hasSysctlLine(line) {
-		cmd := fmt.Sprintf("echo '%s' | sudo tee -a /etc/sysctl.conf", line)
-		if err := n.RunSSHCommand("root", cmd); err != nil {
-			return fmt.Errorf("failed to append to sysctl.conf: %w", err)
+func (n *Node) configureSysctlLines(lines []string) error {
+	for _, line := range lines {
+		if !n.hasSysctlLine(line) {
+			cmd := fmt.Sprintf("echo '%s' | sudo tee -a /etc/sysctl.conf", line)
+			if err := n.RunSSHCommand("root", cmd); err != nil {
+				return fmt.Errorf("failed to append to sysctl.conf: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Looked at the node, and the `inotify.max_user_watches` value is correctly set, but the `inotify.max_user_instances`  param is still set to the (default) 128  instead of `8192` we require.

Set `inotify.max_user_instances` to `8192` during node provisioning.

Task-ID: CU-869d13eeg