### PR TITLE
feat(bootstrap): use oms to install k0s instead of PC-installer

### DIFF
--- a/internal/bootstrap/gcp/gcp.go
+++ b/internal/bootstrap/gcp/gcp.go
@@ -83,6 +83,10 @@ type GCPBootstrapper struct {
 	NodeClient   node.NodeClient
 	PortalClient portal.Portal
 	GitHubClient github.GitHubClient
+
+	// packageFilename is the Codesphere installer package filename on the jumpbox,
+	// populated by EnsureCodespherePackage and reused by the k0s and Codesphere install steps.
+	packageFilename string
 }
 
 type CodesphereEnvironment struct {
@@ -332,6 +336,16 @@ func (b *GCPBootstrapper) Bootstrap() error {
 	}
 
 	if b.Env.InstallVersion != "" || b.Env.InstallLocal != "" {
+		err = b.stlog.Step("Ensure Codesphere package on jumpbox", b.EnsureCodespherePackage)
+		if err != nil {
+			return fmt.Errorf("failed to ensure Codesphere package on jumpbox: %w", err)
+		}
+
+		err = b.stlog.Step("Install k0s", b.InstallK0s)
+		if err != nil {
+			return fmt.Errorf("failed to install k0s: %w", err)
+		}
+
 		err = b.stlog.Step("Install Codesphere", b.InstallCodesphere)
 		if err != nil {
 			return fmt.Errorf("failed to install Codesphere: %w", err)
@@ -958,13 +972,30 @@ func (b *GCPBootstrapper) EnsureDNSRecords() error {
 	return nil
 }
 
-func (b *GCPBootstrapper) InstallCodesphere() error {
+// EnsureCodespherePackage downloads or copies the Codesphere installer package onto the
+// jumpbox and records its filename for the subsequent k0s and Codesphere install steps.
+func (b *GCPBootstrapper) EnsureCodespherePackage() error {
 	fullPackageFilename, err := b.ensureCodespherePackageOnJumpbox()
 	if err != nil {
 		return fmt.Errorf("failed to ensure Codesphere package on jumpbox: %w", err)
 	}
+	b.packageFilename = fullPackageFilename
+	return nil
+}
 
-	err = b.runInstallCommand(fullPackageFilename)
+// InstallK0s deploys the k0s cluster from the jumpbox using the Codesphere package's
+// bundled k0s binary. The bootstrap now owns cluster creation (instead of the installer's
+// internal "kubernetes" step, which is skipped in runInstallCommand), so this must run
+// before the Codesphere application install. EnsureCodespherePackage must run first.
+func (b *GCPBootstrapper) InstallK0s() error {
+	b.stlog.Logf("Installing k0s cluster...")
+	installCmd := fmt.Sprintf("oms install k0s --install-config %s --package %s",
+		remoteInstallConfigPath, b.packageFilename)
+	return b.Env.Jumpbox.RunSSHCommand("root", installCmd)
+}
+
+func (b *GCPBootstrapper) InstallCodesphere() error {
+	err := b.runInstallCommand(b.packageFilename)
 	if err != nil {
 		return fmt.Errorf("failed to install Codesphere from jumpbox: %w", err)
 	}
@@ -1015,7 +1046,11 @@ func (b *GCPBootstrapper) runInstallCommand(packageFilename string) error {
 }
 
 func (b *GCPBootstrapper) generateSkipStepsArg() string {
-	skipSteps := b.Env.InstallSkipSteps
+	skipSteps := append([]string{}, b.Env.InstallSkipSteps...)
+	// The k0s cluster is created by the standalone "Install k0s" bootstrap step, so the
+	// installer must skip its own "kubernetes" (cluster creation) step. The post-cluster
+	// component steps (set-up-cluster, codesphere, ms-backends) still run.
+	skipSteps = append(skipSteps, "kubernetes")
 	if b.Env.RegistryType == RegistryTypeGitHub {
 		skipSteps = append(skipSteps, "load-container-images")
 	}

--- a/internal/bootstrap/gcp/gcp_test.go
+++ b/internal/bootstrap/gcp/gcp_test.go
@@ -1273,28 +1273,31 @@ var _ = Describe("GCP Bootstrapper", func() {
 		})
 	})
 
-	Describe("InstallCodesphere", func() {
+	Describe("Package, k0s and Codesphere install", func() {
 		BeforeEach(func() {
 			csEnv.InstallVersion = "v1.2.3"
 			csEnv.InstallHash = "abc1234567890"
 		})
-		Describe("Valid InstallCodesphere", func() {
+		Describe("Valid install sequence", func() {
 			Context("Direct GitHub access", func() {
 				BeforeEach(func() {
 					csEnv.GitHubPAT = "fake-pat"
 					csEnv.RegistryUser = "fake-user"
 					csEnv.RegistryType = "github"
 				})
-				It("downloads and installs lite package", func() {
+				It("downloads the package, installs k0s and installs the lite package", func() {
 					// Expect download package
 					nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms download package -f installer-lite.tar.gz -H abc1234567890 v1.2.3").Return(nil)
+					Expect(bs.EnsureCodespherePackage()).To(Succeed())
 
-					// Expect install codesphere
+					// Expect standalone k0s install before Codesphere
+					nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install k0s --install-config /etc/codesphere/config.yaml --package v1.2.3-abc1234567890-installer-lite.tar.gz").Return(nil)
+					Expect(bs.InstallK0s()).To(Succeed())
+
+					// Expect install codesphere with the kubernetes step skipped
 					nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root",
-						"oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p v1.2.3-abc1234567890-installer-lite.tar.gz -s load-container-images").Return(nil)
-
-					err := bs.InstallCodesphere()
-					Expect(err).NotTo(HaveOccurred())
+						"oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p v1.2.3-abc1234567890-installer-lite.tar.gz -s kubernetes,load-container-images").Return(nil)
+					Expect(bs.InstallCodesphere()).To(Succeed())
 				})
 			})
 
@@ -1303,24 +1306,27 @@ var _ = Describe("GCP Bootstrapper", func() {
 					// Simulate that ValidateInput has populated the hash
 					csEnv.InstallHash = "def9876543210"
 				})
-				It("downloads and installs codesphere", func() {
-					// Expect download package
+				It("downloads the package, installs k0s and installs codesphere", func() {
 					nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms download package -f installer.tar.gz -H def9876543210 v1.2.3").Return(nil)
+					Expect(bs.EnsureCodespherePackage()).To(Succeed())
 
-					// Expect install codesphere
-					nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p v1.2.3-def9876543210-installer.tar.gz").Return(nil)
+					nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install k0s --install-config /etc/codesphere/config.yaml --package v1.2.3-def9876543210-installer.tar.gz").Return(nil)
+					Expect(bs.InstallK0s()).To(Succeed())
 
-					err := bs.InstallCodesphere()
-					Expect(err).NotTo(HaveOccurred())
+					nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p v1.2.3-def9876543210-installer.tar.gz -s kubernetes").Return(nil)
+					Expect(bs.InstallCodesphere()).To(Succeed())
 				})
 			})
 
-			It("downloads and installs codesphere with hash", func() {
+			It("downloads, installs k0s and codesphere with hash", func() {
 				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms download package -f installer.tar.gz -H abc1234567890 v1.2.3").Return(nil)
-				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p v1.2.3-abc1234567890-installer.tar.gz").Return(nil)
+				Expect(bs.EnsureCodespherePackage()).To(Succeed())
 
-				err := bs.InstallCodesphere()
-				Expect(err).NotTo(HaveOccurred())
+				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install k0s --install-config /etc/codesphere/config.yaml --package v1.2.3-abc1234567890-installer.tar.gz").Return(nil)
+				Expect(bs.InstallK0s()).To(Succeed())
+
+				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p v1.2.3-abc1234567890-installer.tar.gz -s kubernetes").Return(nil)
+				Expect(bs.InstallCodesphere()).To(Succeed())
 			})
 
 			Context("with local package", func() {
@@ -1333,13 +1339,16 @@ var _ = Describe("GCP Bootstrapper", func() {
 					BeforeEach(func() {
 						csEnv.RegistryType = gcp.RegistryTypeGitHub
 					})
-					It("installs codesphere from local package", func() {
+					It("installs k0s and codesphere from local package", func() {
 						nodeClient.EXPECT().CopyFile(mock.Anything, csEnv.InstallLocal, "/root/local-installer-lite.tar.gz").Return(nil)
-						nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root",
-							"oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p local-installer-lite.tar.gz -s load-container-images").Return(nil)
+						Expect(bs.EnsureCodespherePackage()).To(Succeed())
 
-						err := bs.InstallCodesphere()
-						Expect(err).NotTo(HaveOccurred())
+						nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install k0s --install-config /etc/codesphere/config.yaml --package local-installer-lite.tar.gz").Return(nil)
+						Expect(bs.InstallK0s()).To(Succeed())
+
+						nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root",
+							"oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p local-installer-lite.tar.gz -s kubernetes,load-container-images").Return(nil)
+						Expect(bs.InstallCodesphere()).To(Succeed())
 					})
 				})
 				Context("using the local registry", func() {
@@ -1347,13 +1356,16 @@ var _ = Describe("GCP Bootstrapper", func() {
 						csEnv.RegistryType = gcp.RegistryTypeLocalContainer
 						csEnv.InstallLocal = "fake-installer-lite.tar.gz"
 					})
-					It("installs codesphere from local package", func() {
+					It("installs k0s and codesphere from local package", func() {
 						nodeClient.EXPECT().CopyFile(mock.Anything, csEnv.InstallLocal, "/root/local-installer.tar.gz").Return(nil)
-						nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root",
-							"oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p local-installer.tar.gz").Return(nil)
+						Expect(bs.EnsureCodespherePackage()).To(Succeed())
 
-						err := bs.InstallCodesphere()
-						Expect(err).NotTo(HaveOccurred())
+						nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install k0s --install-config /etc/codesphere/config.yaml --package local-installer.tar.gz").Return(nil)
+						Expect(bs.InstallK0s()).To(Succeed())
+
+						nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root",
+							"oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p local-installer.tar.gz -s kubernetes").Return(nil)
+						Expect(bs.InstallCodesphere()).To(Succeed())
 					})
 				})
 			})
@@ -1365,8 +1377,8 @@ var _ = Describe("GCP Bootstrapper", func() {
 					// Simulate that ValidateInput has not populated the hash
 					csEnv.InstallHash = ""
 				})
-				It("fails", func() {
-					err := bs.InstallCodesphere()
+				It("fails to ensure the package", func() {
+					err := bs.EnsureCodespherePackage()
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("install hash must be set when install version is set"))
 				})
@@ -1377,8 +1389,8 @@ var _ = Describe("GCP Bootstrapper", func() {
 					csEnv.InstallVersion = ""
 					csEnv.InstallHash = ""
 				})
-				It("fails", func() {
-					err := bs.InstallCodesphere()
+				It("fails to ensure the package", func() {
+					err := bs.EnsureCodespherePackage()
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("either install version or a local package must be specified"))
 				})
@@ -1387,14 +1399,27 @@ var _ = Describe("GCP Bootstrapper", func() {
 			It("fails when download package fails", func() {
 				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms download package -f installer.tar.gz -H abc1234567890 v1.2.3").Return(fmt.Errorf("download error"))
 
-				err := bs.InstallCodesphere()
+				err := bs.EnsureCodespherePackage()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to download Codesphere package from jumpbox"))
 			})
 
+			It("fails when k0s install fails", func() {
+				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms download package -f installer.tar.gz -H abc1234567890 v1.2.3").Return(nil).Once()
+				Expect(bs.EnsureCodespherePackage()).To(Succeed())
+
+				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install k0s --install-config /etc/codesphere/config.yaml --package v1.2.3-abc1234567890-installer.tar.gz").Return(fmt.Errorf("k0s error")).Once()
+
+				err := bs.InstallK0s()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("k0s error"))
+			})
+
 			It("fails when install codesphere fails", func() {
 				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms download package -f installer.tar.gz -H abc1234567890 v1.2.3").Return(nil).Once()
-				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p v1.2.3-abc1234567890-installer.tar.gz").Return(fmt.Errorf("install error")).Once()
+				Expect(bs.EnsureCodespherePackage()).To(Succeed())
+
+				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p v1.2.3-abc1234567890-installer.tar.gz -s kubernetes").Return(fmt.Errorf("install error")).Once()
 
 				err := bs.InstallCodesphere()
 				Expect(err).To(HaveOccurred())

--- a/internal/bootstrap/gcp/mocks.go
+++ b/internal/bootstrap/gcp/mocks.go
@@ -67,7 +67,7 @@ type MockGCPClientManager_AssignIAMRole_Call struct {
 //   - saEmail string
 //   - saProjectID string
 //   - roles []string
-func (_e *MockGCPClientManager_Expecter) AssignIAMRole(projectID interface{}, saEmail interface{}, saProjectID interface{}, roles interface{}) *MockGCPClientManager_AssignIAMRole_Call {
+func (_e *MockGCPClientManager_Expecter) AssignIAMRole(projectID any, saEmail any, saProjectID any, roles any) *MockGCPClientManager_AssignIAMRole_Call {
 	return &MockGCPClientManager_AssignIAMRole_Call{Call: _e.mock.On("AssignIAMRole", projectID, saEmail, saProjectID, roles)}
 }
 
@@ -144,7 +144,7 @@ type MockGCPClientManager_CreateAddress_Call struct {
 //   - projectID string
 //   - region string
 //   - address *computepb.Address
-func (_e *MockGCPClientManager_Expecter) CreateAddress(projectID interface{}, region interface{}, address interface{}) *MockGCPClientManager_CreateAddress_Call {
+func (_e *MockGCPClientManager_Expecter) CreateAddress(projectID any, region any, address any) *MockGCPClientManager_CreateAddress_Call {
 	return &MockGCPClientManager_CreateAddress_Call{Call: _e.mock.On("CreateAddress", projectID, region, address)}
 }
 
@@ -218,7 +218,7 @@ type MockGCPClientManager_CreateArtifactRegistry_Call struct {
 //   - projectID string
 //   - region string
 //   - repoName string
-func (_e *MockGCPClientManager_Expecter) CreateArtifactRegistry(projectID interface{}, region interface{}, repoName interface{}) *MockGCPClientManager_CreateArtifactRegistry_Call {
+func (_e *MockGCPClientManager_Expecter) CreateArtifactRegistry(projectID any, region any, repoName any) *MockGCPClientManager_CreateArtifactRegistry_Call {
 	return &MockGCPClientManager_CreateArtifactRegistry_Call{Call: _e.mock.On("CreateArtifactRegistry", projectID, region, repoName)}
 }
 
@@ -280,7 +280,7 @@ type MockGCPClientManager_CreateFirewallRule_Call struct {
 // CreateFirewallRule is a helper method to define mock.On call
 //   - projectID string
 //   - rule *computepb.Firewall
-func (_e *MockGCPClientManager_Expecter) CreateFirewallRule(projectID interface{}, rule interface{}) *MockGCPClientManager_CreateFirewallRule_Call {
+func (_e *MockGCPClientManager_Expecter) CreateFirewallRule(projectID any, rule any) *MockGCPClientManager_CreateFirewallRule_Call {
 	return &MockGCPClientManager_CreateFirewallRule_Call{Call: _e.mock.On("CreateFirewallRule", projectID, rule)}
 }
 
@@ -338,7 +338,7 @@ type MockGCPClientManager_CreateInstance_Call struct {
 //   - projectID string
 //   - zone string
 //   - instance *computepb.Instance
-func (_e *MockGCPClientManager_Expecter) CreateInstance(projectID interface{}, zone interface{}, instance interface{}) *MockGCPClientManager_CreateInstance_Call {
+func (_e *MockGCPClientManager_Expecter) CreateInstance(projectID any, zone any, instance any) *MockGCPClientManager_CreateInstance_Call {
 	return &MockGCPClientManager_CreateInstance_Call{Call: _e.mock.On("CreateInstance", projectID, zone, instance)}
 }
 
@@ -411,7 +411,7 @@ type MockGCPClientManager_CreateProject_Call struct {
 //   - projectName string
 //   - displayName string
 //   - labels map[string]string
-func (_e *MockGCPClientManager_Expecter) CreateProject(parent interface{}, projectName interface{}, displayName interface{}, labels interface{}) *MockGCPClientManager_CreateProject_Call {
+func (_e *MockGCPClientManager_Expecter) CreateProject(parent any, projectName any, displayName any, labels any) *MockGCPClientManager_CreateProject_Call {
 	return &MockGCPClientManager_CreateProject_Call{Call: _e.mock.On("CreateProject", parent, projectName, displayName, labels)}
 }
 
@@ -477,7 +477,7 @@ type MockGCPClientManager_CreateProjectID_Call struct {
 
 // CreateProjectID is a helper method to define mock.On call
 //   - projectName string
-func (_e *MockGCPClientManager_Expecter) CreateProjectID(projectName interface{}) *MockGCPClientManager_CreateProjectID_Call {
+func (_e *MockGCPClientManager_Expecter) CreateProjectID(projectName any) *MockGCPClientManager_CreateProjectID_Call {
 	return &MockGCPClientManager_CreateProjectID_Call{Call: _e.mock.On("CreateProjectID", projectName)}
 }
 
@@ -543,7 +543,7 @@ type MockGCPClientManager_CreatePublicCAExternalAccountKey_Call struct {
 
 // CreatePublicCAExternalAccountKey is a helper method to define mock.On call
 //   - projectID string
-func (_e *MockGCPClientManager_Expecter) CreatePublicCAExternalAccountKey(projectID interface{}) *MockGCPClientManager_CreatePublicCAExternalAccountKey_Call {
+func (_e *MockGCPClientManager_Expecter) CreatePublicCAExternalAccountKey(projectID any) *MockGCPClientManager_CreatePublicCAExternalAccountKey_Call {
 	return &MockGCPClientManager_CreatePublicCAExternalAccountKey_Call{Call: _e.mock.On("CreatePublicCAExternalAccountKey", projectID)}
 }
 
@@ -611,7 +611,7 @@ type MockGCPClientManager_CreateServiceAccount_Call struct {
 //   - projectID string
 //   - name string
 //   - displayName string
-func (_e *MockGCPClientManager_Expecter) CreateServiceAccount(projectID interface{}, name interface{}, displayName interface{}) *MockGCPClientManager_CreateServiceAccount_Call {
+func (_e *MockGCPClientManager_Expecter) CreateServiceAccount(projectID any, name any, displayName any) *MockGCPClientManager_CreateServiceAccount_Call {
 	return &MockGCPClientManager_CreateServiceAccount_Call{Call: _e.mock.On("CreateServiceAccount", projectID, name, displayName)}
 }
 
@@ -682,7 +682,7 @@ type MockGCPClientManager_CreateServiceAccountKey_Call struct {
 // CreateServiceAccountKey is a helper method to define mock.On call
 //   - projectID string
 //   - saEmail string
-func (_e *MockGCPClientManager_Expecter) CreateServiceAccountKey(projectID interface{}, saEmail interface{}) *MockGCPClientManager_CreateServiceAccountKey_Call {
+func (_e *MockGCPClientManager_Expecter) CreateServiceAccountKey(projectID any, saEmail any) *MockGCPClientManager_CreateServiceAccountKey_Call {
 	return &MockGCPClientManager_CreateServiceAccountKey_Call{Call: _e.mock.On("CreateServiceAccountKey", projectID, saEmail)}
 }
 
@@ -743,7 +743,7 @@ type MockGCPClientManager_CreateVPC_Call struct {
 //   - subnetName string
 //   - routerName string
 //   - natName string
-func (_e *MockGCPClientManager_Expecter) CreateVPC(projectID interface{}, region interface{}, networkName interface{}, subnetName interface{}, routerName interface{}, natName interface{}) *MockGCPClientManager_CreateVPC_Call {
+func (_e *MockGCPClientManager_Expecter) CreateVPC(projectID any, region any, networkName any, subnetName any, routerName any, natName any) *MockGCPClientManager_CreateVPC_Call {
 	return &MockGCPClientManager_CreateVPC_Call{Call: _e.mock.On("CreateVPC", projectID, region, networkName, subnetName, routerName, natName)}
 }
 
@@ -821,7 +821,7 @@ type MockGCPClientManager_DeleteDNSRecordSets_Call struct {
 //   - projectID string
 //   - zoneName string
 //   - baseDomain string
-func (_e *MockGCPClientManager_Expecter) DeleteDNSRecordSets(projectID interface{}, zoneName interface{}, baseDomain interface{}) *MockGCPClientManager_DeleteDNSRecordSets_Call {
+func (_e *MockGCPClientManager_Expecter) DeleteDNSRecordSets(projectID any, zoneName any, baseDomain any) *MockGCPClientManager_DeleteDNSRecordSets_Call {
 	return &MockGCPClientManager_DeleteDNSRecordSets_Call{Call: _e.mock.On("DeleteDNSRecordSets", projectID, zoneName, baseDomain)}
 }
 
@@ -882,7 +882,7 @@ type MockGCPClientManager_DeleteProject_Call struct {
 
 // DeleteProject is a helper method to define mock.On call
 //   - projectID string
-func (_e *MockGCPClientManager_Expecter) DeleteProject(projectID interface{}) *MockGCPClientManager_DeleteProject_Call {
+func (_e *MockGCPClientManager_Expecter) DeleteProject(projectID any) *MockGCPClientManager_DeleteProject_Call {
 	return &MockGCPClientManager_DeleteProject_Call{Call: _e.mock.On("DeleteProject", projectID)}
 }
 
@@ -934,7 +934,7 @@ type MockGCPClientManager_EnableAPIs_Call struct {
 // EnableAPIs is a helper method to define mock.On call
 //   - projectID string
 //   - apis []string
-func (_e *MockGCPClientManager_Expecter) EnableAPIs(projectID interface{}, apis interface{}) *MockGCPClientManager_EnableAPIs_Call {
+func (_e *MockGCPClientManager_Expecter) EnableAPIs(projectID any, apis any) *MockGCPClientManager_EnableAPIs_Call {
 	return &MockGCPClientManager_EnableAPIs_Call{Call: _e.mock.On("EnableAPIs", projectID, apis)}
 }
 
@@ -991,7 +991,7 @@ type MockGCPClientManager_EnableBilling_Call struct {
 // EnableBilling is a helper method to define mock.On call
 //   - projectID string
 //   - billingAccount string
-func (_e *MockGCPClientManager_Expecter) EnableBilling(projectID interface{}, billingAccount interface{}) *MockGCPClientManager_EnableBilling_Call {
+func (_e *MockGCPClientManager_Expecter) EnableBilling(projectID any, billingAccount any) *MockGCPClientManager_EnableBilling_Call {
 	return &MockGCPClientManager_EnableBilling_Call{Call: _e.mock.On("EnableBilling", projectID, billingAccount)}
 }
 
@@ -1050,7 +1050,7 @@ type MockGCPClientManager_EnsureDNSManagedZone_Call struct {
 //   - zoneName string
 //   - dnsName string
 //   - description string
-func (_e *MockGCPClientManager_Expecter) EnsureDNSManagedZone(projectID interface{}, zoneName interface{}, dnsName interface{}, description interface{}) *MockGCPClientManager_EnsureDNSManagedZone_Call {
+func (_e *MockGCPClientManager_Expecter) EnsureDNSManagedZone(projectID any, zoneName any, dnsName any, description any) *MockGCPClientManager_EnsureDNSManagedZone_Call {
 	return &MockGCPClientManager_EnsureDNSManagedZone_Call{Call: _e.mock.On("EnsureDNSManagedZone", projectID, zoneName, dnsName, description)}
 }
 
@@ -1118,7 +1118,7 @@ type MockGCPClientManager_EnsureDNSRecordSets_Call struct {
 //   - projectID string
 //   - zoneName string
 //   - records []*dns.ResourceRecordSet
-func (_e *MockGCPClientManager_Expecter) EnsureDNSRecordSets(projectID interface{}, zoneName interface{}, records interface{}) *MockGCPClientManager_EnsureDNSRecordSets_Call {
+func (_e *MockGCPClientManager_Expecter) EnsureDNSRecordSets(projectID any, zoneName any, records any) *MockGCPClientManager_EnsureDNSRecordSets_Call {
 	return &MockGCPClientManager_EnsureDNSRecordSets_Call{Call: _e.mock.On("EnsureDNSRecordSets", projectID, zoneName, records)}
 }
 
@@ -1192,7 +1192,7 @@ type MockGCPClientManager_GetAddress_Call struct {
 //   - projectID string
 //   - region string
 //   - addressName string
-func (_e *MockGCPClientManager_Expecter) GetAddress(projectID interface{}, region interface{}, addressName interface{}) *MockGCPClientManager_GetAddress_Call {
+func (_e *MockGCPClientManager_Expecter) GetAddress(projectID any, region any, addressName any) *MockGCPClientManager_GetAddress_Call {
 	return &MockGCPClientManager_GetAddress_Call{Call: _e.mock.On("GetAddress", projectID, region, addressName)}
 }
 
@@ -1266,7 +1266,7 @@ type MockGCPClientManager_GetArtifactRegistry_Call struct {
 //   - projectID string
 //   - region string
 //   - repoName string
-func (_e *MockGCPClientManager_Expecter) GetArtifactRegistry(projectID interface{}, region interface{}, repoName interface{}) *MockGCPClientManager_GetArtifactRegistry_Call {
+func (_e *MockGCPClientManager_Expecter) GetArtifactRegistry(projectID any, region any, repoName any) *MockGCPClientManager_GetArtifactRegistry_Call {
 	return &MockGCPClientManager_GetArtifactRegistry_Call{Call: _e.mock.On("GetArtifactRegistry", projectID, region, repoName)}
 }
 
@@ -1338,7 +1338,7 @@ type MockGCPClientManager_GetBillingInfo_Call struct {
 
 // GetBillingInfo is a helper method to define mock.On call
 //   - projectID string
-func (_e *MockGCPClientManager_Expecter) GetBillingInfo(projectID interface{}) *MockGCPClientManager_GetBillingInfo_Call {
+func (_e *MockGCPClientManager_Expecter) GetBillingInfo(projectID any) *MockGCPClientManager_GetBillingInfo_Call {
 	return &MockGCPClientManager_GetBillingInfo_Call{Call: _e.mock.On("GetBillingInfo", projectID)}
 }
 
@@ -1402,7 +1402,7 @@ type MockGCPClientManager_GetInstance_Call struct {
 //   - projectID string
 //   - zone string
 //   - instanceName string
-func (_e *MockGCPClientManager_Expecter) GetInstance(projectID interface{}, zone interface{}, instanceName interface{}) *MockGCPClientManager_GetInstance_Call {
+func (_e *MockGCPClientManager_Expecter) GetInstance(projectID any, zone any, instanceName any) *MockGCPClientManager_GetInstance_Call {
 	return &MockGCPClientManager_GetInstance_Call{Call: _e.mock.On("GetInstance", projectID, zone, instanceName)}
 }
 
@@ -1475,7 +1475,7 @@ type MockGCPClientManager_GetProjectByName_Call struct {
 // GetProjectByName is a helper method to define mock.On call
 //   - folderID string
 //   - displayName string
-func (_e *MockGCPClientManager_Expecter) GetProjectByName(folderID interface{}, displayName interface{}) *MockGCPClientManager_GetProjectByName_Call {
+func (_e *MockGCPClientManager_Expecter) GetProjectByName(folderID any, displayName any) *MockGCPClientManager_GetProjectByName_Call {
 	return &MockGCPClientManager_GetProjectByName_Call{Call: _e.mock.On("GetProjectByName", folderID, displayName)}
 }
 
@@ -1540,7 +1540,7 @@ type MockGCPClientManager_IsOMSManagedProject_Call struct {
 
 // IsOMSManagedProject is a helper method to define mock.On call
 //   - projectID string
-func (_e *MockGCPClientManager_Expecter) IsOMSManagedProject(projectID interface{}) *MockGCPClientManager_IsOMSManagedProject_Call {
+func (_e *MockGCPClientManager_Expecter) IsOMSManagedProject(projectID any) *MockGCPClientManager_IsOMSManagedProject_Call {
 	return &MockGCPClientManager_IsOMSManagedProject_Call{Call: _e.mock.On("IsOMSManagedProject", projectID)}
 }
 
@@ -1594,7 +1594,7 @@ type MockGCPClientManager_RemoveIAMRoleBinding_Call struct {
 //   - saName string
 //   - saProjectID string
 //   - roles []string
-func (_e *MockGCPClientManager_Expecter) RemoveIAMRoleBinding(projectID interface{}, saName interface{}, saProjectID interface{}, roles interface{}) *MockGCPClientManager_RemoveIAMRoleBinding_Call {
+func (_e *MockGCPClientManager_Expecter) RemoveIAMRoleBinding(projectID any, saName any, saProjectID any, roles any) *MockGCPClientManager_RemoveIAMRoleBinding_Call {
 	return &MockGCPClientManager_RemoveIAMRoleBinding_Call{Call: _e.mock.On("RemoveIAMRoleBinding", projectID, saName, saProjectID, roles)}
 }
 
@@ -1662,7 +1662,7 @@ type MockGCPClientManager_StartInstance_Call struct {
 //   - projectID string
 //   - zone string
 //   - instanceName string
-func (_e *MockGCPClientManager_Expecter) StartInstance(projectID interface{}, zone interface{}, instanceName interface{}) *MockGCPClientManager_StartInstance_Call {
+func (_e *MockGCPClientManager_Expecter) StartInstance(projectID any, zone any, instanceName any) *MockGCPClientManager_StartInstance_Call {
 	return &MockGCPClientManager_StartInstance_Call{Call: _e.mock.On("StartInstance", projectID, zone, instanceName)}
 }
 
@@ -1724,7 +1724,7 @@ type MockGCPClientManager_UpdateProject_Call struct {
 // UpdateProject is a helper method to define mock.On call
 //   - projectID string
 //   - labels map[string]string
-func (_e *MockGCPClientManager_Expecter) UpdateProject(projectID interface{}, labels interface{}) *MockGCPClientManager_UpdateProject_Call {
+func (_e *MockGCPClientManager_Expecter) UpdateProject(projectID any, labels any) *MockGCPClientManager_UpdateProject_Call {
 	return &MockGCPClientManager_UpdateProject_Call{Call: _e.mock.On("UpdateProject", projectID, labels)}
 }
 

--- a/internal/codesphere/mocks.go
+++ b/internal/codesphere/mocks.go
@@ -72,7 +72,7 @@ type MockClient_CreateWorkspace_Call struct {
 //   - planID int
 //   - name string
 //   - repoURL *string
-func (_e *MockClient_Expecter) CreateWorkspace(teamID interface{}, planID interface{}, name interface{}, repoURL interface{}) *MockClient_CreateWorkspace_Call {
+func (_e *MockClient_Expecter) CreateWorkspace(teamID any, planID any, name any, repoURL any) *MockClient_CreateWorkspace_Call {
 	return &MockClient_CreateWorkspace_Call{Call: _e.mock.On("CreateWorkspace", teamID, planID, name, repoURL)}
 }
 
@@ -138,7 +138,7 @@ type MockClient_DeleteWorkspace_Call struct {
 
 // DeleteWorkspace is a helper method to define mock.On call
 //   - workspaceID int
-func (_e *MockClient_Expecter) DeleteWorkspace(workspaceID interface{}) *MockClient_DeleteWorkspace_Call {
+func (_e *MockClient_Expecter) DeleteWorkspace(workspaceID any) *MockClient_DeleteWorkspace_Call {
 	return &MockClient_DeleteWorkspace_Call{Call: _e.mock.On("DeleteWorkspace", workspaceID)}
 }
 
@@ -190,7 +190,7 @@ type MockClient_ExecuteCommand_Call struct {
 // ExecuteCommand is a helper method to define mock.On call
 //   - workspaceID int
 //   - command string
-func (_e *MockClient_Expecter) ExecuteCommand(workspaceID interface{}, command interface{}) *MockClient_ExecuteCommand_Call {
+func (_e *MockClient_Expecter) ExecuteCommand(workspaceID any, command any) *MockClient_ExecuteCommand_Call {
 	return &MockClient_ExecuteCommand_Call{Call: _e.mock.On("ExecuteCommand", workspaceID, command)}
 }
 
@@ -358,7 +358,7 @@ type MockClient_SetEnvVar_Call struct {
 //   - workspaceID int
 //   - key string
 //   - value string
-func (_e *MockClient_Expecter) SetEnvVar(workspaceID interface{}, key interface{}, value interface{}) *MockClient_SetEnvVar_Call {
+func (_e *MockClient_Expecter) SetEnvVar(workspaceID any, key any, value any) *MockClient_SetEnvVar_Call {
 	return &MockClient_SetEnvVar_Call{Call: _e.mock.On("SetEnvVar", workspaceID, key, value)}
 }
 
@@ -421,7 +421,7 @@ type MockClient_StartPipeline_Call struct {
 //   - workspaceID int
 //   - profile string
 //   - stage string
-func (_e *MockClient_Expecter) StartPipeline(workspaceID interface{}, profile interface{}, stage interface{}) *MockClient_StartPipeline_Call {
+func (_e *MockClient_Expecter) StartPipeline(workspaceID any, profile any, stage any) *MockClient_StartPipeline_Call {
 	return &MockClient_StartPipeline_Call{Call: _e.mock.On("StartPipeline", workspaceID, profile, stage)}
 }
 
@@ -483,7 +483,7 @@ type MockClient_SyncLandscape_Call struct {
 // SyncLandscape is a helper method to define mock.On call
 //   - workspaceID int
 //   - profile string
-func (_e *MockClient_Expecter) SyncLandscape(workspaceID interface{}, profile interface{}) *MockClient_SyncLandscape_Call {
+func (_e *MockClient_Expecter) SyncLandscape(workspaceID any, profile any) *MockClient_SyncLandscape_Call {
 	return &MockClient_SyncLandscape_Call{Call: _e.mock.On("SyncLandscape", workspaceID, profile)}
 }
 

--- a/internal/github/mocks.go
+++ b/internal/github/mocks.go
@@ -75,7 +75,7 @@ type MockGitHubClient_ListTeamMembersBySlug_Call struct {
 //   - org string
 //   - teamSlug string
 //   - opts *github.TeamListTeamMembersOptions
-func (_e *MockGitHubClient_Expecter) ListTeamMembersBySlug(ctx interface{}, org interface{}, teamSlug interface{}, opts interface{}) *MockGitHubClient_ListTeamMembersBySlug_Call {
+func (_e *MockGitHubClient_Expecter) ListTeamMembersBySlug(ctx any, org any, teamSlug any, opts any) *MockGitHubClient_ListTeamMembersBySlug_Call {
 	return &MockGitHubClient_ListTeamMembersBySlug_Call{Call: _e.mock.On("ListTeamMembersBySlug", ctx, org, teamSlug, opts)}
 }
 
@@ -153,7 +153,7 @@ type MockGitHubClient_ListUserKeys_Call struct {
 // ListUserKeys is a helper method to define mock.On call
 //   - ctx context.Context
 //   - username string
-func (_e *MockGitHubClient_Expecter) ListUserKeys(ctx interface{}, username interface{}) *MockGitHubClient_ListUserKeys_Call {
+func (_e *MockGitHubClient_Expecter) ListUserKeys(ctx any, username any) *MockGitHubClient_ListUserKeys_Call {
 	return &MockGitHubClient_ListUserKeys_Call{Call: _e.mock.On("ListUserKeys", ctx, username)}
 }
 

--- a/internal/installer/mocks.go
+++ b/internal/installer/mocks.go
@@ -62,7 +62,7 @@ type MockArgoCDResources_ApplyAll_Call struct {
 
 // ApplyAll is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockArgoCDResources_Expecter) ApplyAll(ctx interface{}) *MockArgoCDResources_ApplyAll_Call {
+func (_e *MockArgoCDResources_Expecter) ApplyAll(ctx any) *MockArgoCDResources_ApplyAll_Call {
 	return &MockArgoCDResources_ApplyAll_Call{Call: _e.mock.On("ApplyAll", ctx)}
 }
 
@@ -149,7 +149,7 @@ type MockConfigManager_ParseConfigYaml_Call struct {
 
 // ParseConfigYaml is a helper method to define mock.On call
 //   - configPath string
-func (_e *MockConfigManager_Expecter) ParseConfigYaml(configPath interface{}) *MockConfigManager_ParseConfigYaml_Call {
+func (_e *MockConfigManager_Expecter) ParseConfigYaml(configPath any) *MockConfigManager_ParseConfigYaml_Call {
 	return &MockConfigManager_ParseConfigYaml_Call{Call: _e.mock.On("ParseConfigYaml", configPath)}
 }
 
@@ -227,7 +227,7 @@ type MockInstallConfigManager_ApplyProfile_Call struct {
 
 // ApplyProfile is a helper method to define mock.On call
 //   - profile string
-func (_e *MockInstallConfigManager_Expecter) ApplyProfile(profile interface{}) *MockInstallConfigManager_ApplyProfile_Call {
+func (_e *MockInstallConfigManager_Expecter) ApplyProfile(profile any) *MockInstallConfigManager_ApplyProfile_Call {
 	return &MockInstallConfigManager_ApplyProfile_Call{Call: _e.mock.On("ApplyProfile", profile)}
 }
 
@@ -458,7 +458,7 @@ type MockInstallConfigManager_LoadInstallConfigFromFile_Call struct {
 
 // LoadInstallConfigFromFile is a helper method to define mock.On call
 //   - configPath string
-func (_e *MockInstallConfigManager_Expecter) LoadInstallConfigFromFile(configPath interface{}) *MockInstallConfigManager_LoadInstallConfigFromFile_Call {
+func (_e *MockInstallConfigManager_Expecter) LoadInstallConfigFromFile(configPath any) *MockInstallConfigManager_LoadInstallConfigFromFile_Call {
 	return &MockInstallConfigManager_LoadInstallConfigFromFile_Call{Call: _e.mock.On("LoadInstallConfigFromFile", configPath)}
 }
 
@@ -509,7 +509,7 @@ type MockInstallConfigManager_LoadVaultFromFile_Call struct {
 
 // LoadVaultFromFile is a helper method to define mock.On call
 //   - vaultPath string
-func (_e *MockInstallConfigManager_Expecter) LoadVaultFromFile(vaultPath interface{}) *MockInstallConfigManager_LoadVaultFromFile_Call {
+func (_e *MockInstallConfigManager_Expecter) LoadVaultFromFile(vaultPath any) *MockInstallConfigManager_LoadVaultFromFile_Call {
 	return &MockInstallConfigManager_LoadVaultFromFile_Call{Call: _e.mock.On("LoadVaultFromFile", vaultPath)}
 }
 
@@ -697,7 +697,7 @@ type MockInstallConfigManager_WriteInstallConfig_Call struct {
 // WriteInstallConfig is a helper method to define mock.On call
 //   - configPath string
 //   - withComments bool
-func (_e *MockInstallConfigManager_Expecter) WriteInstallConfig(configPath interface{}, withComments interface{}) *MockInstallConfigManager_WriteInstallConfig_Call {
+func (_e *MockInstallConfigManager_Expecter) WriteInstallConfig(configPath any, withComments any) *MockInstallConfigManager_WriteInstallConfig_Call {
 	return &MockInstallConfigManager_WriteInstallConfig_Call{Call: _e.mock.On("WriteInstallConfig", configPath, withComments)}
 }
 
@@ -754,7 +754,7 @@ type MockInstallConfigManager_WriteVault_Call struct {
 // WriteVault is a helper method to define mock.On call
 //   - vaultPath string
 //   - withComments bool
-func (_e *MockInstallConfigManager_Expecter) WriteVault(vaultPath interface{}, withComments interface{}) *MockInstallConfigManager_WriteVault_Call {
+func (_e *MockInstallConfigManager_Expecter) WriteVault(vaultPath any, withComments any) *MockInstallConfigManager_WriteVault_Call {
 	return &MockInstallConfigManager_WriteVault_Call{Call: _e.mock.On("WriteVault", vaultPath, withComments)}
 }
 
@@ -849,7 +849,7 @@ type MockHelmClient_FindRelease_Call struct {
 // FindRelease is a helper method to define mock.On call
 //   - namespace string
 //   - releaseName string
-func (_e *MockHelmClient_Expecter) FindRelease(namespace interface{}, releaseName interface{}) *MockHelmClient_FindRelease_Call {
+func (_e *MockHelmClient_Expecter) FindRelease(namespace any, releaseName any) *MockHelmClient_FindRelease_Call {
 	return &MockHelmClient_FindRelease_Call{Call: _e.mock.On("FindRelease", namespace, releaseName)}
 }
 
@@ -907,7 +907,7 @@ type MockHelmClient_InstallChart_Call struct {
 //   - ctx context.Context
 //   - cfg ChartConfig
 //   - opts InstallChartOptions
-func (_e *MockHelmClient_Expecter) InstallChart(ctx interface{}, cfg interface{}, opts interface{}) *MockHelmClient_InstallChart_Call {
+func (_e *MockHelmClient_Expecter) InstallChart(ctx any, cfg any, opts any) *MockHelmClient_InstallChart_Call {
 	return &MockHelmClient_InstallChart_Call{Call: _e.mock.On("InstallChart", ctx, cfg, opts)}
 }
 
@@ -971,7 +971,7 @@ type MockHelmClient_LoginRegistry_Call struct {
 //   - host string
 //   - username string
 //   - password string
-func (_e *MockHelmClient_Expecter) LoginRegistry(ctx interface{}, host interface{}, username interface{}, password interface{}) *MockHelmClient_LoginRegistry_Call {
+func (_e *MockHelmClient_Expecter) LoginRegistry(ctx any, host any, username any, password any) *MockHelmClient_LoginRegistry_Call {
 	return &MockHelmClient_LoginRegistry_Call{Call: _e.mock.On("LoginRegistry", ctx, host, username, password)}
 }
 
@@ -1039,7 +1039,7 @@ type MockHelmClient_UpgradeChart_Call struct {
 //   - ctx context.Context
 //   - cfg ChartConfig
 //   - opts UpgradeChartOptions
-func (_e *MockHelmClient_Expecter) UpgradeChart(ctx interface{}, cfg interface{}, opts interface{}) *MockHelmClient_UpgradeChart_Call {
+func (_e *MockHelmClient_Expecter) UpgradeChart(ctx any, cfg any, opts any) *MockHelmClient_UpgradeChart_Call {
 	return &MockHelmClient_UpgradeChart_Call{Call: _e.mock.On("UpgradeChart", ctx, cfg, opts)}
 }
 
@@ -1138,7 +1138,7 @@ type MockK0sManager_Download_Call struct {
 //   - version string
 //   - force bool
 //   - quiet bool
-func (_e *MockK0sManager_Expecter) Download(version interface{}, force interface{}, quiet interface{}) *MockK0sManager_Download_Call {
+func (_e *MockK0sManager_Expecter) Download(version any, force any, quiet any) *MockK0sManager_Download_Call {
 	return &MockK0sManager_Download_Call{Call: _e.mock.On("Download", version, force, quiet)}
 }
 
@@ -1281,7 +1281,7 @@ type MockK0sctlManager_Apply_Call struct {
 //   - configPath string
 //   - k0sctlPath string
 //   - force bool
-func (_e *MockK0sctlManager_Expecter) Apply(configPath interface{}, k0sctlPath interface{}, force interface{}) *MockK0sctlManager_Apply_Call {
+func (_e *MockK0sctlManager_Expecter) Apply(configPath any, k0sctlPath any, force any) *MockK0sctlManager_Apply_Call {
 	return &MockK0sctlManager_Apply_Call{Call: _e.mock.On("Apply", configPath, k0sctlPath, force)}
 }
 
@@ -1353,7 +1353,7 @@ type MockK0sctlManager_Download_Call struct {
 //   - version string
 //   - force bool
 //   - quiet bool
-func (_e *MockK0sctlManager_Expecter) Download(version interface{}, force interface{}, quiet interface{}) *MockK0sctlManager_Download_Call {
+func (_e *MockK0sctlManager_Expecter) Download(version any, force any, quiet any) *MockK0sctlManager_Download_Call {
 	return &MockK0sctlManager_Download_Call{Call: _e.mock.On("Download", version, force, quiet)}
 }
 
@@ -1468,7 +1468,7 @@ type MockK0sctlManager_Reset_Call struct {
 // Reset is a helper method to define mock.On call
 //   - configPath string
 //   - k0sctlPath string
-func (_e *MockK0sctlManager_Expecter) Reset(configPath interface{}, k0sctlPath interface{}) *MockK0sctlManager_Reset_Call {
+func (_e *MockK0sctlManager_Expecter) Reset(configPath any, k0sctlPath any) *MockK0sctlManager_Reset_Call {
 	return &MockK0sctlManager_Reset_Call{Call: _e.mock.On("Reset", configPath, k0sctlPath)}
 }
 
@@ -1551,7 +1551,7 @@ type MockPackageManager_Extract_Call struct {
 
 // Extract is a helper method to define mock.On call
 //   - force bool
-func (_e *MockPackageManager_Expecter) Extract(force interface{}) *MockPackageManager_Extract_Call {
+func (_e *MockPackageManager_Expecter) Extract(force any) *MockPackageManager_Extract_Call {
 	return &MockPackageManager_Extract_Call{Call: _e.mock.On("Extract", force)}
 }
 
@@ -1603,7 +1603,7 @@ type MockPackageManager_ExtractDependency_Call struct {
 // ExtractDependency is a helper method to define mock.On call
 //   - file string
 //   - force bool
-func (_e *MockPackageManager_Expecter) ExtractDependency(file interface{}, force interface{}) *MockPackageManager_ExtractDependency_Call {
+func (_e *MockPackageManager_Expecter) ExtractDependency(file any, force any) *MockPackageManager_ExtractDependency_Call {
 	return &MockPackageManager_ExtractDependency_Call{Call: _e.mock.On("ExtractDependency", file, force)}
 }
 
@@ -1668,7 +1668,7 @@ type MockPackageManager_ExtractOciImageIndex_Call struct {
 
 // ExtractOciImageIndex is a helper method to define mock.On call
 //   - imagefile string
-func (_e *MockPackageManager_Expecter) ExtractOciImageIndex(imagefile interface{}) *MockPackageManager_ExtractOciImageIndex_Call {
+func (_e *MockPackageManager_Expecter) ExtractOciImageIndex(imagefile any) *MockPackageManager_ExtractOciImageIndex_Call {
 	return &MockPackageManager_ExtractOciImageIndex_Call{Call: _e.mock.On("ExtractOciImageIndex", imagefile)}
 }
 
@@ -1775,7 +1775,7 @@ type MockPackageManager_GetBaseimagePath_Call struct {
 // GetBaseimagePath is a helper method to define mock.On call
 //   - baseimage string
 //   - force bool
-func (_e *MockPackageManager_Expecter) GetBaseimagePath(baseimage interface{}, force interface{}) *MockPackageManager_GetBaseimagePath_Call {
+func (_e *MockPackageManager_Expecter) GetBaseimagePath(baseimage any, force any) *MockPackageManager_GetBaseimagePath_Call {
 	return &MockPackageManager_GetBaseimagePath_Call{Call: _e.mock.On("GetBaseimagePath", baseimage, force)}
 }
 
@@ -1884,7 +1884,7 @@ type MockPackageManager_GetDependencyPath_Call struct {
 
 // GetDependencyPath is a helper method to define mock.On call
 //   - filename string
-func (_e *MockPackageManager_Expecter) GetDependencyPath(filename interface{}) *MockPackageManager_GetDependencyPath_Call {
+func (_e *MockPackageManager_Expecter) GetDependencyPath(filename any) *MockPackageManager_GetDependencyPath_Call {
 	return &MockPackageManager_GetDependencyPath_Call{Call: _e.mock.On("GetDependencyPath", filename)}
 }
 
@@ -1944,7 +1944,7 @@ type MockPackageManager_GetFullImageTag_Call struct {
 
 // GetFullImageTag is a helper method to define mock.On call
 //   - baseimage string
-func (_e *MockPackageManager_Expecter) GetFullImageTag(baseimage interface{}) *MockPackageManager_GetFullImageTag_Call {
+func (_e *MockPackageManager_Expecter) GetFullImageTag(baseimage any) *MockPackageManager_GetFullImageTag_Call {
 	return &MockPackageManager_GetFullImageTag_Call{Call: _e.mock.On("GetFullImageTag", baseimage)}
 }
 

--- a/internal/installer/node/mocks.go
+++ b/internal/installer/node/mocks.go
@@ -62,7 +62,7 @@ type MockNodeClient_CopyFile_Call struct {
 //   - n *Node
 //   - src string
 //   - dst string
-func (_e *MockNodeClient_Expecter) CopyFile(n interface{}, src interface{}, dst interface{}) *MockNodeClient_CopyFile_Call {
+func (_e *MockNodeClient_Expecter) CopyFile(n any, src any, dst any) *MockNodeClient_CopyFile_Call {
 	return &MockNodeClient_CopyFile_Call{Call: _e.mock.On("CopyFile", n, src, dst)}
 }
 
@@ -125,7 +125,7 @@ type MockNodeClient_DownloadFile_Call struct {
 //   - n *Node
 //   - src string
 //   - dst string
-func (_e *MockNodeClient_Expecter) DownloadFile(n interface{}, src interface{}, dst interface{}) *MockNodeClient_DownloadFile_Call {
+func (_e *MockNodeClient_Expecter) DownloadFile(n any, src any, dst any) *MockNodeClient_DownloadFile_Call {
 	return &MockNodeClient_DownloadFile_Call{Call: _e.mock.On("DownloadFile", n, src, dst)}
 }
 
@@ -187,7 +187,7 @@ type MockNodeClient_HasFile_Call struct {
 // HasFile is a helper method to define mock.On call
 //   - n *Node
 //   - filePath string
-func (_e *MockNodeClient_Expecter) HasFile(n interface{}, filePath interface{}) *MockNodeClient_HasFile_Call {
+func (_e *MockNodeClient_Expecter) HasFile(n any, filePath any) *MockNodeClient_HasFile_Call {
 	return &MockNodeClient_HasFile_Call{Call: _e.mock.On("HasFile", n, filePath)}
 }
 
@@ -245,7 +245,7 @@ type MockNodeClient_RunCommand_Call struct {
 //   - n *Node
 //   - username string
 //   - command string
-func (_e *MockNodeClient_Expecter) RunCommand(n interface{}, username interface{}, command interface{}) *MockNodeClient_RunCommand_Call {
+func (_e *MockNodeClient_Expecter) RunCommand(n any, username any, command any) *MockNodeClient_RunCommand_Call {
 	return &MockNodeClient_RunCommand_Call{Call: _e.mock.On("RunCommand", n, username, command)}
 }
 
@@ -307,7 +307,7 @@ type MockNodeClient_WaitReady_Call struct {
 // WaitReady is a helper method to define mock.On call
 //   - n *Node
 //   - timeout time.Duration
-func (_e *MockNodeClient_Expecter) WaitReady(n interface{}, timeout interface{}) *MockNodeClient_WaitReady_Call {
+func (_e *MockNodeClient_Expecter) WaitReady(n any, timeout any) *MockNodeClient_WaitReady_Call {
 	return &MockNodeClient_WaitReady_Call{Call: _e.mock.On("WaitReady", n, timeout)}
 }
 

--- a/internal/portal/mocks.go
+++ b/internal/portal/mocks.go
@@ -64,7 +64,7 @@ type MockHttp_Download_Call struct {
 //   - url string
 //   - file io.Writer
 //   - quiet bool
-func (_e *MockHttp_Expecter) Download(url interface{}, file interface{}, quiet interface{}) *MockHttp_Download_Call {
+func (_e *MockHttp_Expecter) Download(url any, file any, quiet any) *MockHttp_Download_Call {
 	return &MockHttp_Download_Call{Call: _e.mock.On("Download", url, file, quiet)}
 }
 
@@ -136,7 +136,7 @@ type MockHttp_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - url string
-func (_e *MockHttp_Expecter) Get(url interface{}) *MockHttp_Get_Call {
+func (_e *MockHttp_Expecter) Get(url any) *MockHttp_Get_Call {
 	return &MockHttp_Get_Call{Call: _e.mock.On("Get", url)}
 }
 
@@ -200,7 +200,7 @@ type MockHttp_Request_Call struct {
 //   - url string
 //   - method string
 //   - body io.Reader
-func (_e *MockHttp_Expecter) Request(url interface{}, method interface{}, body interface{}) *MockHttp_Request_Call {
+func (_e *MockHttp_Expecter) Request(url any, method any, body any) *MockHttp_Request_Call {
 	return &MockHttp_Request_Call{Call: _e.mock.On("Request", url, method, body)}
 }
 
@@ -292,7 +292,7 @@ type MockPortal_DownloadBuildArtifact_Call struct {
 //   - file io.Writer
 //   - startByte int
 //   - quiet bool
-func (_e *MockPortal_Expecter) DownloadBuildArtifact(product interface{}, build interface{}, file interface{}, startByte interface{}, quiet interface{}) *MockPortal_DownloadBuildArtifact_Call {
+func (_e *MockPortal_Expecter) DownloadBuildArtifact(product any, build any, file any, startByte any, quiet any) *MockPortal_DownloadBuildArtifact_Call {
 	return &MockPortal_DownloadBuildArtifact_Call{Call: _e.mock.On("DownloadBuildArtifact", product, build, file, startByte, quiet)}
 }
 
@@ -372,7 +372,7 @@ type MockPortal_GetApiKeyId_Call struct {
 
 // GetApiKeyId is a helper method to define mock.On call
 //   - oldKey string
-func (_e *MockPortal_Expecter) GetApiKeyId(oldKey interface{}) *MockPortal_GetApiKeyId_Call {
+func (_e *MockPortal_Expecter) GetApiKeyId(oldKey any) *MockPortal_GetApiKeyId_Call {
 	return &MockPortal_GetApiKeyId_Call{Call: _e.mock.On("GetApiKeyId", oldKey)}
 }
 
@@ -434,7 +434,7 @@ type MockPortal_GetBuild_Call struct {
 //   - product Product
 //   - version string
 //   - hash string
-func (_e *MockPortal_Expecter) GetBuild(product interface{}, version interface{}, hash interface{}) *MockPortal_GetBuild_Call {
+func (_e *MockPortal_Expecter) GetBuild(product any, version any, hash any) *MockPortal_GetBuild_Call {
 	return &MockPortal_GetBuild_Call{Call: _e.mock.On("GetBuild", product, version, hash)}
 }
 
@@ -560,7 +560,7 @@ type MockPortal_ListBuilds_Call struct {
 // ListBuilds is a helper method to define mock.On call
 //   - product Product
 //   - sort string
-func (_e *MockPortal_Expecter) ListBuilds(product interface{}, sort interface{}) *MockPortal_ListBuilds_Call {
+func (_e *MockPortal_Expecter) ListBuilds(product any, sort any) *MockPortal_ListBuilds_Call {
 	return &MockPortal_ListBuilds_Call{Call: _e.mock.On("ListBuilds", product, sort)}
 }
 
@@ -630,7 +630,7 @@ type MockPortal_RegisterAPIKey_Call struct {
 //   - organization string
 //   - role string
 //   - expiresAt time.Time
-func (_e *MockPortal_Expecter) RegisterAPIKey(owner interface{}, organization interface{}, role interface{}, expiresAt interface{}) *MockPortal_RegisterAPIKey_Call {
+func (_e *MockPortal_Expecter) RegisterAPIKey(owner any, organization any, role any, expiresAt any) *MockPortal_RegisterAPIKey_Call {
 	return &MockPortal_RegisterAPIKey_Call{Call: _e.mock.On("RegisterAPIKey", owner, organization, role, expiresAt)}
 }
 
@@ -696,7 +696,7 @@ type MockPortal_RevokeAPIKey_Call struct {
 
 // RevokeAPIKey is a helper method to define mock.On call
 //   - key string
-func (_e *MockPortal_Expecter) RevokeAPIKey(key interface{}) *MockPortal_RevokeAPIKey_Call {
+func (_e *MockPortal_Expecter) RevokeAPIKey(key any) *MockPortal_RevokeAPIKey_Call {
 	return &MockPortal_RevokeAPIKey_Call{Call: _e.mock.On("RevokeAPIKey", key)}
 }
 
@@ -748,7 +748,7 @@ type MockPortal_UpdateAPIKey_Call struct {
 // UpdateAPIKey is a helper method to define mock.On call
 //   - key string
 //   - expiresAt time.Time
-func (_e *MockPortal_Expecter) UpdateAPIKey(key interface{}, expiresAt interface{}) *MockPortal_UpdateAPIKey_Call {
+func (_e *MockPortal_Expecter) UpdateAPIKey(key any, expiresAt any) *MockPortal_UpdateAPIKey_Call {
 	return &MockPortal_UpdateAPIKey_Call{Call: _e.mock.On("UpdateAPIKey", key, expiresAt)}
 }
 
@@ -805,7 +805,7 @@ type MockPortal_VerifyBuildArtifactDownload_Call struct {
 // VerifyBuildArtifactDownload is a helper method to define mock.On call
 //   - file io.Reader
 //   - download Build
-func (_e *MockPortal_Expecter) VerifyBuildArtifactDownload(file interface{}, download interface{}) *MockPortal_VerifyBuildArtifactDownload_Call {
+func (_e *MockPortal_Expecter) VerifyBuildArtifactDownload(file any, download any) *MockPortal_VerifyBuildArtifactDownload_Call {
 	return &MockPortal_VerifyBuildArtifactDownload_Call{Call: _e.mock.On("VerifyBuildArtifactDownload", file, download)}
 }
 
@@ -899,7 +899,7 @@ type MockHttpClient_Do_Call struct {
 
 // Do is a helper method to define mock.On call
 //   - request *http.Request
-func (_e *MockHttpClient_Expecter) Do(request interface{}) *MockHttpClient_Do_Call {
+func (_e *MockHttpClient_Expecter) Do(request any) *MockHttpClient_Do_Call {
 	return &MockHttpClient_Do_Call{Call: _e.mock.On("Do", request)}
 }
 

--- a/internal/system/mocks.go
+++ b/internal/system/mocks.go
@@ -61,7 +61,7 @@ type MockImageManager_BuildImage_Call struct {
 //   - dockerfile string
 //   - tag string
 //   - buildContext string
-func (_e *MockImageManager_Expecter) BuildImage(dockerfile interface{}, tag interface{}, buildContext interface{}) *MockImageManager_BuildImage_Call {
+func (_e *MockImageManager_Expecter) BuildImage(dockerfile any, tag any, buildContext any) *MockImageManager_BuildImage_Call {
 	return &MockImageManager_BuildImage_Call{Call: _e.mock.On("BuildImage", dockerfile, tag, buildContext)}
 }
 
@@ -122,7 +122,7 @@ type MockImageManager_LoadImage_Call struct {
 
 // LoadImage is a helper method to define mock.On call
 //   - imageTarPath string
-func (_e *MockImageManager_Expecter) LoadImage(imageTarPath interface{}) *MockImageManager_LoadImage_Call {
+func (_e *MockImageManager_Expecter) LoadImage(imageTarPath any) *MockImageManager_LoadImage_Call {
 	return &MockImageManager_LoadImage_Call{Call: _e.mock.On("LoadImage", imageTarPath)}
 }
 
@@ -173,7 +173,7 @@ type MockImageManager_PushImage_Call struct {
 
 // PushImage is a helper method to define mock.On call
 //   - tag string
-func (_e *MockImageManager_Expecter) PushImage(tag interface{}) *MockImageManager_PushImage_Call {
+func (_e *MockImageManager_Expecter) PushImage(tag any) *MockImageManager_PushImage_Call {
 	return &MockImageManager_PushImage_Call{Call: _e.mock.On("PushImage", tag)}
 }
 

--- a/internal/util/mocks.go
+++ b/internal/util/mocks.go
@@ -62,7 +62,7 @@ type MockFileIO_Chmod_Call struct {
 // Chmod is a helper method to define mock.On call
 //   - name string
 //   - mode os.FileMode
-func (_e *MockFileIO_Expecter) Chmod(name interface{}, mode interface{}) *MockFileIO_Chmod_Call {
+func (_e *MockFileIO_Expecter) Chmod(name any, mode any) *MockFileIO_Chmod_Call {
 	return &MockFileIO_Chmod_Call{Call: _e.mock.On("Chmod", name, mode)}
 }
 
@@ -129,7 +129,7 @@ type MockFileIO_Create_Call struct {
 
 // Create is a helper method to define mock.On call
 //   - filename string
-func (_e *MockFileIO_Expecter) Create(filename interface{}) *MockFileIO_Create_Call {
+func (_e *MockFileIO_Expecter) Create(filename any) *MockFileIO_Create_Call {
 	return &MockFileIO_Create_Call{Call: _e.mock.On("Create", filename)}
 }
 
@@ -182,7 +182,7 @@ type MockFileIO_CreateAndWrite_Call struct {
 //   - filePath string
 //   - data []byte
 //   - fileType string
-func (_e *MockFileIO_Expecter) CreateAndWrite(filePath interface{}, data interface{}, fileType interface{}) *MockFileIO_CreateAndWrite_Call {
+func (_e *MockFileIO_Expecter) CreateAndWrite(filePath any, data any, fileType any) *MockFileIO_CreateAndWrite_Call {
 	return &MockFileIO_CreateAndWrite_Call{Call: _e.mock.On("CreateAndWrite", filePath, data, fileType)}
 }
 
@@ -243,7 +243,7 @@ type MockFileIO_Exists_Call struct {
 
 // Exists is a helper method to define mock.On call
 //   - filename string
-func (_e *MockFileIO_Expecter) Exists(filename interface{}) *MockFileIO_Exists_Call {
+func (_e *MockFileIO_Expecter) Exists(filename any) *MockFileIO_Exists_Call {
 	return &MockFileIO_Exists_Call{Call: _e.mock.On("Exists", filename)}
 }
 
@@ -303,7 +303,7 @@ type MockFileIO_IsDirectory_Call struct {
 
 // IsDirectory is a helper method to define mock.On call
 //   - filename string
-func (_e *MockFileIO_Expecter) IsDirectory(filename interface{}) *MockFileIO_IsDirectory_Call {
+func (_e *MockFileIO_Expecter) IsDirectory(filename any) *MockFileIO_IsDirectory_Call {
 	return &MockFileIO_IsDirectory_Call{Call: _e.mock.On("IsDirectory", filename)}
 }
 
@@ -355,7 +355,7 @@ type MockFileIO_MkdirAll_Call struct {
 // MkdirAll is a helper method to define mock.On call
 //   - path string
 //   - perm os.FileMode
-func (_e *MockFileIO_Expecter) MkdirAll(path interface{}, perm interface{}) *MockFileIO_MkdirAll_Call {
+func (_e *MockFileIO_Expecter) MkdirAll(path any, perm any) *MockFileIO_MkdirAll_Call {
 	return &MockFileIO_MkdirAll_Call{Call: _e.mock.On("MkdirAll", path, perm)}
 }
 
@@ -422,7 +422,7 @@ type MockFileIO_Open_Call struct {
 
 // Open is a helper method to define mock.On call
 //   - filename string
-func (_e *MockFileIO_Expecter) Open(filename interface{}) *MockFileIO_Open_Call {
+func (_e *MockFileIO_Expecter) Open(filename any) *MockFileIO_Open_Call {
 	return &MockFileIO_Open_Call{Call: _e.mock.On("Open", filename)}
 }
 
@@ -484,7 +484,7 @@ type MockFileIO_OpenAppend_Call struct {
 
 // OpenAppend is a helper method to define mock.On call
 //   - filename string
-func (_e *MockFileIO_Expecter) OpenAppend(filename interface{}) *MockFileIO_OpenAppend_Call {
+func (_e *MockFileIO_Expecter) OpenAppend(filename any) *MockFileIO_OpenAppend_Call {
 	return &MockFileIO_OpenAppend_Call{Call: _e.mock.On("OpenAppend", filename)}
 }
 
@@ -548,7 +548,7 @@ type MockFileIO_OpenFile_Call struct {
 //   - name string
 //   - flag int
 //   - perm os.FileMode
-func (_e *MockFileIO_Expecter) OpenFile(name interface{}, flag interface{}, perm interface{}) *MockFileIO_OpenFile_Call {
+func (_e *MockFileIO_Expecter) OpenFile(name any, flag any, perm any) *MockFileIO_OpenFile_Call {
 	return &MockFileIO_OpenFile_Call{Call: _e.mock.On("OpenFile", name, flag, perm)}
 }
 
@@ -620,7 +620,7 @@ type MockFileIO_ReadDir_Call struct {
 
 // ReadDir is a helper method to define mock.On call
 //   - dirname string
-func (_e *MockFileIO_Expecter) ReadDir(dirname interface{}) *MockFileIO_ReadDir_Call {
+func (_e *MockFileIO_Expecter) ReadDir(dirname any) *MockFileIO_ReadDir_Call {
 	return &MockFileIO_ReadDir_Call{Call: _e.mock.On("ReadDir", dirname)}
 }
 
@@ -682,7 +682,7 @@ type MockFileIO_ReadFile_Call struct {
 
 // ReadFile is a helper method to define mock.On call
 //   - filename string
-func (_e *MockFileIO_Expecter) ReadFile(filename interface{}) *MockFileIO_ReadFile_Call {
+func (_e *MockFileIO_Expecter) ReadFile(filename any) *MockFileIO_ReadFile_Call {
 	return &MockFileIO_ReadFile_Call{Call: _e.mock.On("ReadFile", filename)}
 }
 
@@ -733,7 +733,7 @@ type MockFileIO_Remove_Call struct {
 
 // Remove is a helper method to define mock.On call
 //   - path string
-func (_e *MockFileIO_Expecter) Remove(path interface{}) *MockFileIO_Remove_Call {
+func (_e *MockFileIO_Expecter) Remove(path any) *MockFileIO_Remove_Call {
 	return &MockFileIO_Remove_Call{Call: _e.mock.On("Remove", path)}
 }
 
@@ -786,7 +786,7 @@ type MockFileIO_WriteFile_Call struct {
 //   - filename string
 //   - data []byte
 //   - perm os.FileMode
-func (_e *MockFileIO_Expecter) WriteFile(filename interface{}, data interface{}, perm interface{}) *MockFileIO_WriteFile_Call {
+func (_e *MockFileIO_Expecter) WriteFile(filename any, data any, perm any) *MockFileIO_WriteFile_Call {
 	return &MockFileIO_WriteFile_Call{Call: _e.mock.On("WriteFile", filename, data, perm)}
 }
 
@@ -869,9 +869,9 @@ type MockTableWriter_AppendHeader_Call struct {
 // AppendHeader is a helper method to define mock.On call
 //   - row table.Row
 //   - configs ...table.RowConfig
-func (_e *MockTableWriter_Expecter) AppendHeader(row interface{}, configs ...interface{}) *MockTableWriter_AppendHeader_Call {
+func (_e *MockTableWriter_Expecter) AppendHeader(row any, configs ...any) *MockTableWriter_AppendHeader_Call {
 	return &MockTableWriter_AppendHeader_Call{Call: _e.mock.On("AppendHeader",
-		append([]interface{}{row}, configs...)...)}
+		append([]any{row}, configs...)...)}
 }
 
 func (_c *MockTableWriter_AppendHeader_Call) Run(run func(row table.Row, configs ...table.RowConfig)) *MockTableWriter_AppendHeader_Call {
@@ -923,9 +923,9 @@ type MockTableWriter_AppendRow_Call struct {
 // AppendRow is a helper method to define mock.On call
 //   - row table.Row
 //   - configs ...table.RowConfig
-func (_e *MockTableWriter_Expecter) AppendRow(row interface{}, configs ...interface{}) *MockTableWriter_AppendRow_Call {
+func (_e *MockTableWriter_Expecter) AppendRow(row any, configs ...any) *MockTableWriter_AppendRow_Call {
 	return &MockTableWriter_AppendRow_Call{Call: _e.mock.On("AppendRow",
-		append([]interface{}{row}, configs...)...)}
+		append([]any{row}, configs...)...)}
 }
 
 func (_c *MockTableWriter_AppendRow_Call) Run(run func(row table.Row, configs ...table.RowConfig)) *MockTableWriter_AppendRow_Call {


### PR DESCRIPTION
## What

Make `oms beta bootstrap-gcp` create the k0s cluster as its own bootstrap step using
`oms install k0s`, instead of relying on the `kubernetes` step inside the
private-cloud-installer.

## Why

Today the k0s cluster is created by the `kubernetes` step *inside*
`oms install codesphere`'s `private-cloud-installer.js`. Decoupling cluster creation from
the Codesphere app install gives the bootstrap a single, explicit, reusable cluster-creation
step (mirroring how the local bootstrapper already separates cluster creation from the
post-cluster component steps `setUpCluster` / `codesphere` / `msBackends`). It also unblocks
a follow-up PR that will install OpenBao against the cluster *before* the app install.

## Changes

- **New `EnsureCodespherePackage` step** — factors the installer-package download/copy out of
  `InstallCodesphere` so the package is on the jumpbox before k0s; the filename is stored on
  the bootstrapper and reused by the later steps.
- **New `InstallK0s` step** — runs `oms install k0s --install-config /etc/codesphere/config.yaml --package <pkg>`
  on the jumpbox. k0sctl uploads the package's bundled k0s binary, so the k0s version stays
  aligned with the Codesphere package.
- **Reordered `Bootstrap()`** install block to: *Ensure Codesphere package → Install k0s →
  Install Codesphere → Run k0s config script* (still gated on `--install-version` /
  `--install-local`).
- **`generateSkipStepsArg()` always skips the installer's `kubernetes` step** now that the
  bootstrap owns cluster creation. The post-cluster steps (`set-up-cluster`, `codesphere`,
  `ms-backends`) still run. The existing `load-container-images` skip for the GitHub registry
  type is preserved.

## Behavior notes

- Applies to **every** GCP bootstrap: k0s is always created by the standalone step and the
  installer always skips `kubernetes`.
- `oms install k0s` on the jumpbox reaches the internal node IPs via the forwarded SSH agent
  (same mechanism the installer's internal k0sctl uses today).
- OpenBao is **out of scope** for this PR.

## Testing

- Unit tests updated/added in `internal/bootstrap/gcp/gcp_test.go` covering the new
  package → k0s → codesphere sequence, the `-s kubernetes[,load-container-images]` skip arg,
  and k0s/package failure paths.
- TODO before merge: end-to-end GCP bootstrap with `--install-version` — confirm `oms install k0s`
  brings all nodes Ready and `oms install codesphere` completes with `--skipStep kubernetes`.
