### PR TITLE
feat(installer): split codesphere install into infra, dependencies and platform subcommands

### DIFF
--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -4,23 +4,9 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
-	"log"
-	"os"
-	"os/exec"
-	"path"
-	"path/filepath"
-	"runtime"
-	"slices"
-	"sort"
-	"strings"
-
 	"github.com/codesphere-cloud/cs-go/pkg/io"
-	"github.com/codesphere-cloud/oms/internal/configtemplating"
 	"github.com/codesphere-cloud/oms/internal/env"
 	"github.com/codesphere-cloud/oms/internal/installer"
-	"github.com/codesphere-cloud/oms/internal/installer/files"
 	"github.com/codesphere-cloud/oms/internal/system"
 	"github.com/codesphere-cloud/oms/internal/util"
 	"github.com/spf13/cobra"
@@ -46,17 +32,19 @@ type InstallCodesphereOpts struct {
 	AutoApprove      bool
 }
 
-func (c *InstallCodesphereCmd) RunE(_ *cobra.Command, args []string) error {
-	workdir := c.Env.GetOmsWorkdir()
-	pm := installer.NewPackage(workdir, c.Opts.Package)
-	cm := installer.NewConfig()
-	im := system.NewImage(context.Background())
-
-	err := c.ExtractAndInstall(pm, cm, im, runtime.GOOS, runtime.GOARCH)
-	if err != nil {
-		return fmt.Errorf("failed to extract and install package: %w", err)
+func (c *InstallCodesphereCmd) RunE(cmd *cobra.Command, args []string) error {
+	phases := []interface {
+		RunE(*cobra.Command, []string) error
+	}{
+		&InstallCodesphereInfraCmd{Opts: c.Opts, Env: c.Env},
+		&InstallCodesphereDepenciesCmd{Opts: c.Opts, Env: c.Env},
+		&InstallCodespherePlatformCmd{Opts: c.Opts, Env: c.Env},
 	}
-
+	for _, phase := range phases {
+		if err := phase.RunE(cmd, args); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -98,254 +86,41 @@ func AddInstallCodesphereCmd(install *cobra.Command, opts *GlobalOptions) {
 	AddCmd(install, codesphere.cmd)
 
 	codesphere.cmd.RunE = codesphere.RunE
+
+	AddInstallCodesphereInfraCmd(codesphere.cmd, opts)
+	AddInstallCodesphereDepenciesCmd(codesphere.cmd, opts)
+	AddInstallCodespherePlatformCmd(codesphere.cmd, opts)
 }
 
 func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm installer.ConfigManager, im system.ImageManager, goos string, goarch string) error {
-	if goos != "linux" || goarch != "amd64" {
-		return fmt.Errorf("codesphere installation is only supported on Linux amd64. Current platform: %s/%s", goos, goarch)
+	type phaseConfig struct {
+		steps             []string
+		skipImageBuilding bool
 	}
-
-	originalConfig := c.Opts.Config
-	cleanup := func() {}
-	if c.Opts.Vault != "" {
-		store := installer.NewLazyVaultTemplatingSecretStore(c.Opts.Vault, c.Opts.PrivKey)
-		renderedConfig, renderCleanup, err := configtemplating.RenderConfigFileToTemp(c.Opts.Config, store)
-		if err != nil {
-			return fmt.Errorf("failed to render config template: %w", err)
+	phases := []phaseConfig{
+		{steps: installer.InfraSteps, skipImageBuilding: false},
+		{steps: installer.DependenciesSteps, skipImageBuilding: true},
+		{steps: installer.PlatformSteps, skipImageBuilding: true},
+	}
+	for _, phase := range phases {
+		ci := &installer.CodesphereInstaller{
+			ConfigPath:        c.Opts.Config,
+			VaultPath:         c.Opts.Vault,
+			PrivKey:           c.Opts.PrivKey,
+			Force:             c.Opts.Force,
+			SkipSteps:         c.Opts.SkipSteps,
+			AllowedSteps:      phase.steps,
+			SkipImageBuilding: phase.skipImageBuilding,
+			DirectConnection:  c.Opts.DirectConnection,
+			AutoApprove:       c.Opts.AutoApprove,
 		}
-		cleanup = renderCleanup
-		c.Opts.Config = renderedConfig
-	}
-	defer cleanup()
-	defer func() {
-		c.Opts.Config = originalConfig
-	}()
-
-	config, err := cm.ParseConfigYaml(c.Opts.Config)
-	if err != nil {
-		return fmt.Errorf("failed to extract config.yaml: %w", err)
-	}
-	c.warnIfVaultDirDiffersFromSecretsDir(config)
-
-	err = pm.Extract(c.Opts.Force)
-	if err != nil {
-		return fmt.Errorf("failed to extract package to workdir: %w", err)
-	}
-
-	foundFiles, err := c.ListPackageContents(pm)
-	if err != nil {
-		return fmt.Errorf("failed to list available files: %w", err)
-	}
-
-	if !slices.Contains(foundFiles, "deps.tar.gz") {
-		return fmt.Errorf("deps.tar.gz not found in package")
-	}
-	if !slices.Contains(foundFiles, "private-cloud-installer.js") {
-		return fmt.Errorf("private-cloud-installer.js not found in package")
-	}
-	if !slices.Contains(foundFiles, "node") {
-		return fmt.Errorf("node executable not found in package")
-	}
-
-	err = pm.ExtractDependency("bom.json", c.Opts.Force)
-	if err != nil {
-		return fmt.Errorf("failed to extract package to workdir: %w", err)
-	}
-
-	// If workspace image is extended extract bom.json and load workspace image
-	for imageKey, imageConfig := range config.Codesphere.DeployConfig.Images {
-		for flavorKey, flavor := range imageConfig.Flavors {
-			if flavor.Image.Dockerfile != "" && config.Registry != nil && config.Registry.Server != "" {
-				bomRef := flavor.Image.BomRef
-				dockerfile := flavor.Image.Dockerfile
-
-				fullImageTag, err := pm.GetFullImageTag(bomRef)
-				if err != nil {
-					return fmt.Errorf("failed to get full image tag for %s: %w", bomRef, err)
-				}
-
-				// Extract root image name from full tag (e.g. repo/image:tag -> image)
-				parts := strings.Split(fullImageTag, ":")
-				if len(parts) < 2 {
-					return fmt.Errorf("invalid image tag format: %s", fullImageTag)
-				}
-				imageNameAndPath := parts[0]
-				version := parts[1]
-				rootImageName := path.Base(imageNameAndPath)
-
-				// Extract and load root image
-				imagePath := filepath.Join("codesphere", "images", fmt.Sprintf("%s.tar", rootImageName))
-				err = pm.ExtractDependency(imagePath, c.Opts.Force)
-				if err != nil {
-					return fmt.Errorf("failed to extract root image %s: %w", imagePath, err)
-				}
-
-				extractedImagePath := pm.GetDependencyPath(imagePath)
-				err = im.LoadImage(extractedImagePath)
-				if err != nil {
-					return fmt.Errorf("failed to load workspace image from Dockerfile %s: %w", dockerfile, err)
-				}
-				log.Printf("Loaded root image '%s'", extractedImagePath)
-
-				// TODO: This is duplicated from update_dockerfile.go, refactor into shared function
-				dockerfileFile, err := pm.FileIO().Open(dockerfile)
-				if err != nil {
-					return fmt.Errorf("failed to open dockerfile %s: %w", dockerfile, err)
-				}
-				defer util.CloseFileIgnoreError(dockerfileFile)
-
-				dockerfileManager := util.NewDockerfileManager()
-				updatedContent, err := dockerfileManager.UpdateFromStatement(dockerfileFile, fullImageTag)
-				if err != nil {
-					return fmt.Errorf("failed to update FROM statement: %w", err)
-				}
-
-				err = pm.FileIO().WriteFile(dockerfile, []byte(updatedContent), 0644)
-				if err != nil {
-					return fmt.Errorf("failed to write updated dockerfile: %w", err)
-				}
-
-				log.Printf("Successfully updated FROM statement in %s to use %s", dockerfile, fullImageTag)
-				// TODO: End duplicated code
-
-				dockerfileName := filepath.Base(dockerfile)
-				dockerfileDir := filepath.Dir(dockerfile)
-
-				// Determine image tag for build and push
-				registryUrl := strings.TrimRight(config.Registry.Server, "/")
-				buildTag := fmt.Sprintf("%s/%s-%s:%s", registryUrl, imageKey, flavorKey, version)
-
-				err = im.BuildImage(dockerfileName, buildTag, dockerfileDir)
-				if err != nil {
-					return fmt.Errorf("failed to build workspace image from Dockerfile %s: %w", dockerfile, err)
-				}
-
-				log.Printf("Pushing image to %s", buildTag)
-				err = im.PushImage(buildTag)
-				if err != nil {
-					return fmt.Errorf("failed to push image %s: %w", buildTag, err)
-				}
-			}
+		if err := ci.Install(pm, cm, im, goos, goarch); err != nil {
+			return err
 		}
 	}
-
-	// Install codesphere with node
-	nodePath := filepath.Join(pm.GetWorkDir(), "node")
-	err = os.Chmod(nodePath, 0755)
-	if err != nil {
-		return fmt.Errorf("failed to make node executable: %w", err)
-	}
-
-	log.Printf("Using Node.js executable: %s", nodePath)
-	log.Println("Starting private cloud installer script...")
-	installerPath := filepath.Join(pm.GetWorkDir(), "private-cloud-installer.js")
-	archivePath := filepath.Join(pm.GetWorkDir(), "deps.tar.gz")
-
-	cmdArgs := []string{installerPath, "--archive", archivePath, "--config", c.Opts.Config, "--privKey", c.Opts.PrivKey}
-
-	executableSteps := map[string]bool{
-		"copy-dependencies":     true,
-		"extract-dependencies":  true,
-		"load-container-images": true,
-		"sops":                  true,
-		"docker":                true,
-		"postgres":              true,
-		"ceph":                  true,
-		"kubernetes":            true,
-		"set-up-cluster":        true,
-		"codesphere":            true,
-		"ms-backends":           true,
-	}
-
-	if config.Operations != nil {
-		for _, step := range config.Operations.Skip {
-			executableSteps[step] = false
-		}
-	}
-
-	for _, step := range c.Opts.SkipSteps {
-		executableSteps[step] = false
-	}
-
-	executedSteps := []string{}
-	for step, executed := range executableSteps {
-		if !executed {
-			cmdArgs = append(cmdArgs, "--skipStep", step)
-		} else {
-			executedSteps = append(executedSteps, step)
-		}
-	}
-
-	sort.Strings(executedSteps)
-
-	prompt := installer.NewPrompter(!c.Opts.AutoApprove)
-	msg := fmt.Sprintf("The following steps will be executed: %s. Type \"yes\" to continue.", strings.Join(executedSteps, ", "))
-	if prompt.String(msg, "yes") != "yes" {
-		return fmt.Errorf("installation aborted")
-	}
-
-	if c.Opts.CodesphereOnly {
-		cmdArgs = append(cmdArgs, "--codesphereOnly")
-	}
-
-	if c.Opts.DirectConnection {
-		cmdArgs = append(cmdArgs, "--directConnection")
-	}
-
-	cmd := exec.Command(nodePath, cmdArgs...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
-
-	err = cmd.Run()
-	if err != nil {
-		return fmt.Errorf("failed to run installer script: %w", err)
-	}
-	log.Println("Private cloud installer script finished.")
-
 	return nil
 }
 
-func (c *InstallCodesphereCmd) warnIfVaultDirDiffersFromSecretsDir(config files.RootConfig) {
-	if c.Opts.Vault == "" || config.Secrets.BaseDir == "" {
-		return
-	}
-
-	vaultDir, err := filepath.Abs(filepath.Dir(c.Opts.Vault))
-	if err != nil {
-		log.Printf("Warning: failed to resolve vault directory for %s: %v", c.Opts.Vault, err)
-		return
-	}
-
-	secretsDir, err := filepath.Abs(config.Secrets.BaseDir)
-	if err != nil {
-		log.Printf("Warning: failed to resolve configured secrets baseDir %s: %v", config.Secrets.BaseDir, err)
-		return
-	}
-
-	if vaultDir != secretsDir {
-		log.Printf("Warning: config secrets.baseDir (%s) does not match the directory of --vault (%s)", secretsDir, vaultDir)
-	}
-}
-
 func (c *InstallCodesphereCmd) ListPackageContents(pm installer.PackageManager) ([]string, error) {
-	packageDir := pm.GetWorkDir()
-	if !pm.FileIO().Exists(packageDir) {
-		return nil, fmt.Errorf("work dir not found: %s", packageDir)
-	}
-
-	entries, err := pm.FileIO().ReadDir(packageDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read directory contents: %w", err)
-	}
-
-	log.Printf("Listing contents of %s", packageDir)
-	var foundFiles []string
-	for _, entry := range entries {
-		filename := entry.Name()
-		log.Printf("- %s", filename)
-		foundFiles = append(foundFiles, filename)
-	}
-
-	return foundFiles, nil
+	return installer.ListPackageContents(pm)
 }

--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -32,20 +32,14 @@ type InstallCodesphereOpts struct {
 	AutoApprove      bool
 }
 
-func (c *InstallCodesphereCmd) RunE(cmd *cobra.Command, args []string) error {
-	phases := []interface {
-		RunE(*cobra.Command, []string) error
-	}{
-		&InstallCodesphereInfraCmd{Opts: c.Opts, Env: c.Env},
-		&InstallCodesphereDepenciesCmd{Opts: c.Opts, Env: c.Env},
-		&InstallCodespherePlatformCmd{Opts: c.Opts, Env: c.Env},
+func (c *InstallCodesphereCmd) RunE(_ *cobra.Command, _ []string) error {
+	if err := installCodesphereInfra(c.Opts, c.Env); err != nil {
+		return err
 	}
-	for _, phase := range phases {
-		if err := phase.RunE(cmd, args); err != nil {
-			return err
-		}
+	if err := installCodesphereDepencies(c.Opts, c.Env); err != nil {
+		return err
 	}
-	return nil
+	return installCodespherePlatform(c.Opts, c.Env)
 }
 
 func AddInstallCodesphereCmd(install *cobra.Command, opts *GlobalOptions) {
@@ -69,27 +63,27 @@ func AddInstallCodesphereCmd(install *cobra.Command, opts *GlobalOptions) {
 		Opts: &InstallCodesphereOpts{GlobalOptions: opts},
 		Env:  env.NewEnv(),
 	}
-	codesphere.cmd.Flags().StringVarP(&codesphere.Opts.Package, "package", "p", "", "Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from")
-	codesphere.cmd.Flags().BoolVarP(&codesphere.Opts.Force, "force", "f", false, "Enforce package extraction")
-	codesphere.cmd.Flags().StringVarP(&codesphere.Opts.Config, "config", "c", "", "Path to the Codesphere Private Cloud configuration file (yaml)")
-	codesphere.cmd.Flags().StringVar(&codesphere.Opts.Vault, "vault", "prod.vault.yaml", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
-	codesphere.cmd.Flags().StringVarP(&codesphere.Opts.PrivKey, "priv-key", "k", "", "Path to the private key to encrypt/decrypt secrets")
-	codesphere.cmd.Flags().StringSliceVarP(&codesphere.Opts.SkipSteps, "skip-steps", "s", []string{}, "Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, kubernetes")
+	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.Package, "package", "p", "", "Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from")
+	codesphere.cmd.PersistentFlags().BoolVarP(&codesphere.Opts.Force, "force", "f", false, "Enforce package extraction")
+	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.Config, "config", "c", "", "Path to the Codesphere Private Cloud configuration file (yaml)")
+	codesphere.cmd.PersistentFlags().StringVar(&codesphere.Opts.Vault, "vault", "prod.vault.yaml", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
+	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.PrivKey, "priv-key", "k", "", "Path to the private key to encrypt/decrypt secrets")
+	codesphere.cmd.PersistentFlags().StringSliceVarP(&codesphere.Opts.SkipSteps, "skip-steps", "s", []string{}, "Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker")
+	codesphere.cmd.PersistentFlags().BoolVar(&codesphere.Opts.DirectConnection, "direct-connection", false, "Use direct connection for installation, requires having access to the cluster nodes from your machine")
+	codesphere.cmd.PersistentFlags().BoolVar(&codesphere.Opts.AutoApprove, "auto-approve", true, "Auto approve confirmation prompts with default values")
 	codesphere.cmd.Flags().BoolVar(&codesphere.Opts.CodesphereOnly, "codesphere-only", false, "Install only Codesphere without dependencies")
-	codesphere.cmd.Flags().BoolVar(&codesphere.Opts.DirectConnection, "direct-connection", false, "Use direct connection for installation, requires having access to the cluster nodes from your machine")
-	codesphere.cmd.Flags().BoolVar(&codesphere.Opts.AutoApprove, "auto-approve", true, "Auto approve confirmation prompts with default values")
 
-	util.MarkFlagRequired(codesphere.cmd, "package")
-	util.MarkFlagRequired(codesphere.cmd, "config")
-	util.MarkFlagRequired(codesphere.cmd, "priv-key")
+	util.MarkPersistentFlagRequired(codesphere.cmd, "package")
+	util.MarkPersistentFlagRequired(codesphere.cmd, "config")
+	util.MarkPersistentFlagRequired(codesphere.cmd, "priv-key")
 
 	AddCmd(install, codesphere.cmd)
 
 	codesphere.cmd.RunE = codesphere.RunE
 
-	AddInstallCodesphereInfraCmd(codesphere.cmd, opts)
-	AddInstallCodesphereDepenciesCmd(codesphere.cmd, opts)
-	AddInstallCodespherePlatformCmd(codesphere.cmd, opts)
+	AddInstallCodesphereInfraCmd(codesphere.cmd, codesphere.Opts)
+	AddInstallCodesphereDepenciesCmd(codesphere.cmd, codesphere.Opts)
+	AddInstallCodespherePlatformCmd(codesphere.cmd, codesphere.Opts)
 }
 
 func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm installer.ConfigManager, im system.ImageManager, goos string, goarch string) error {

--- a/cli/cmd/install_codesphere_dependencies.go
+++ b/cli/cmd/install_codesphere_dependencies.go
@@ -1,0 +1,81 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/codesphere-cloud/cs-go/pkg/io"
+	"github.com/codesphere-cloud/oms/internal/env"
+	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/system"
+	"github.com/codesphere-cloud/oms/internal/util"
+	"github.com/spf13/cobra"
+)
+
+// InstallCodesphereDepenciesCmd runs the cluster dependency steps (Phase 2).
+type InstallCodesphereDepenciesCmd struct {
+	cmd  *cobra.Command
+	Opts *InstallCodesphereOpts
+	Env  env.Env
+}
+
+func (c *InstallCodesphereDepenciesCmd) RunE(_ *cobra.Command, _ []string) error {
+	workdir := c.Env.GetOmsWorkdir()
+	pm := installer.NewPackage(workdir, c.Opts.Package)
+	cm := installer.NewConfig()
+	im := system.NewImage(context.Background())
+
+	ci := &installer.CodesphereInstaller{
+		ConfigPath:       c.Opts.Config,
+		VaultPath:        c.Opts.Vault,
+		PrivKey:          c.Opts.PrivKey,
+		Force:            c.Opts.Force,
+		SkipSteps:        c.Opts.SkipSteps,
+		AllowedSteps:     installer.DependenciesSteps,
+		DirectConnection: c.Opts.DirectConnection,
+		AutoApprove:      c.Opts.AutoApprove,
+	}
+	if err := ci.Install(pm, cm, im, runtime.GOOS, runtime.GOARCH); err != nil {
+		return fmt.Errorf("failed to install dependencies: %w", err)
+	}
+	return nil
+}
+
+func AddInstallCodesphereDepenciesCmd(codesphere *cobra.Command, opts *GlobalOptions) {
+	deps := InstallCodesphereDepenciesCmd{
+		cmd: &cobra.Command{
+			Use:   "dependencies",
+			Short: "Install Codesphere cluster dependencies (Phase 2)",
+			Long: io.Long(`Install cluster dependencies for a Codesphere instance (Phase 2).
+			Runs steps: set-up-cluster, ms-backends.
+			Requires the infrastructure phase to have completed successfully.`),
+			Example: formatExamples("install codesphere dependencies", []io.Example{
+				{
+					Cmd:  "-p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml",
+					Desc: "Install cluster dependencies only",
+				},
+			}),
+		},
+		Opts: &InstallCodesphereOpts{GlobalOptions: opts},
+		Env:  env.NewEnv(),
+	}
+	deps.cmd.Flags().StringVarP(&deps.Opts.Package, "package", "p", "", "Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from")
+	deps.cmd.Flags().BoolVarP(&deps.Opts.Force, "force", "f", false, "Enforce package extraction")
+	deps.cmd.Flags().StringVarP(&deps.Opts.Config, "config", "c", "", "Path to the Codesphere Private Cloud configuration file (yaml)")
+	deps.cmd.Flags().StringVar(&deps.Opts.Vault, "vault", "prod.vault.yaml", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
+	deps.cmd.Flags().StringVarP(&deps.Opts.PrivKey, "priv-key", "k", "", "Path to the private key to encrypt/decrypt secrets")
+	deps.cmd.Flags().StringSliceVarP(&deps.Opts.SkipSteps, "skip-steps", "s", []string{}, "Dependencies steps to skip. E.g. set-up-cluster, ms-backends")
+	deps.cmd.Flags().BoolVar(&deps.Opts.DirectConnection, "direct-connection", false, "Use direct connection for installation, requires having access to the cluster nodes from your machine")
+	deps.cmd.Flags().BoolVar(&deps.Opts.AutoApprove, "auto-approve", true, "Auto approve confirmation prompts with default values")
+
+	util.MarkFlagRequired(deps.cmd, "package")
+	util.MarkFlagRequired(deps.cmd, "config")
+	util.MarkFlagRequired(deps.cmd, "priv-key")
+
+	AddCmd(codesphere, deps.cmd)
+	deps.cmd.RunE = deps.RunE
+}

--- a/cli/cmd/install_codesphere_dependencies.go
+++ b/cli/cmd/install_codesphere_dependencies.go
@@ -12,7 +12,6 @@ import (
 	"github.com/codesphere-cloud/oms/internal/env"
 	"github.com/codesphere-cloud/oms/internal/installer"
 	"github.com/codesphere-cloud/oms/internal/system"
-	"github.com/codesphere-cloud/oms/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -24,20 +23,24 @@ type InstallCodesphereDepenciesCmd struct {
 }
 
 func (c *InstallCodesphereDepenciesCmd) RunE(_ *cobra.Command, _ []string) error {
-	workdir := c.Env.GetOmsWorkdir()
-	pm := installer.NewPackage(workdir, c.Opts.Package)
+	return installCodesphereDepencies(c.Opts, c.Env)
+}
+
+func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error {
+	workdir := env.GetOmsWorkdir()
+	pm := installer.NewPackage(workdir, opts.Package)
 	cm := installer.NewConfig()
 	im := system.NewImage(context.Background())
 
 	ci := &installer.CodesphereInstaller{
-		ConfigPath:       c.Opts.Config,
-		VaultPath:        c.Opts.Vault,
-		PrivKey:          c.Opts.PrivKey,
-		Force:            c.Opts.Force,
-		SkipSteps:        c.Opts.SkipSteps,
+		ConfigPath:       opts.Config,
+		VaultPath:        opts.Vault,
+		PrivKey:          opts.PrivKey,
+		Force:            opts.Force,
+		SkipSteps:        opts.SkipSteps,
 		AllowedSteps:     installer.DependenciesSteps,
-		DirectConnection: c.Opts.DirectConnection,
-		AutoApprove:      c.Opts.AutoApprove,
+		DirectConnection: opts.DirectConnection,
+		AutoApprove:      opts.AutoApprove,
 	}
 	if err := ci.Install(pm, cm, im, runtime.GOOS, runtime.GOARCH); err != nil {
 		return fmt.Errorf("failed to install dependencies: %w", err)
@@ -45,7 +48,7 @@ func (c *InstallCodesphereDepenciesCmd) RunE(_ *cobra.Command, _ []string) error
 	return nil
 }
 
-func AddInstallCodesphereDepenciesCmd(codesphere *cobra.Command, opts *GlobalOptions) {
+func AddInstallCodesphereDepenciesCmd(codesphere *cobra.Command, opts *InstallCodesphereOpts) {
 	deps := InstallCodesphereDepenciesCmd{
 		cmd: &cobra.Command{
 			Use:   "dependencies",
@@ -60,21 +63,9 @@ func AddInstallCodesphereDepenciesCmd(codesphere *cobra.Command, opts *GlobalOpt
 				},
 			}),
 		},
-		Opts: &InstallCodesphereOpts{GlobalOptions: opts},
+		Opts: opts,
 		Env:  env.NewEnv(),
 	}
-	deps.cmd.Flags().StringVarP(&deps.Opts.Package, "package", "p", "", "Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from")
-	deps.cmd.Flags().BoolVarP(&deps.Opts.Force, "force", "f", false, "Enforce package extraction")
-	deps.cmd.Flags().StringVarP(&deps.Opts.Config, "config", "c", "", "Path to the Codesphere Private Cloud configuration file (yaml)")
-	deps.cmd.Flags().StringVar(&deps.Opts.Vault, "vault", "prod.vault.yaml", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
-	deps.cmd.Flags().StringVarP(&deps.Opts.PrivKey, "priv-key", "k", "", "Path to the private key to encrypt/decrypt secrets")
-	deps.cmd.Flags().StringSliceVarP(&deps.Opts.SkipSteps, "skip-steps", "s", []string{}, "Dependencies steps to skip. E.g. set-up-cluster, ms-backends")
-	deps.cmd.Flags().BoolVar(&deps.Opts.DirectConnection, "direct-connection", false, "Use direct connection for installation, requires having access to the cluster nodes from your machine")
-	deps.cmd.Flags().BoolVar(&deps.Opts.AutoApprove, "auto-approve", true, "Auto approve confirmation prompts with default values")
-
-	util.MarkFlagRequired(deps.cmd, "package")
-	util.MarkFlagRequired(deps.cmd, "config")
-	util.MarkFlagRequired(deps.cmd, "priv-key")
 
 	AddCmd(codesphere, deps.cmd)
 	deps.cmd.RunE = deps.RunE

--- a/cli/cmd/install_codesphere_infra.go
+++ b/cli/cmd/install_codesphere_infra.go
@@ -1,0 +1,84 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/codesphere-cloud/cs-go/pkg/io"
+	"github.com/codesphere-cloud/oms/internal/env"
+	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/system"
+	"github.com/codesphere-cloud/oms/internal/util"
+	"github.com/spf13/cobra"
+)
+
+// InstallCodesphereInfraCmd runs only the infrastructure steps (Phase 1).
+type InstallCodesphereInfraCmd struct {
+	cmd  *cobra.Command
+	Opts *InstallCodesphereOpts
+	Env  env.Env
+}
+
+func (c *InstallCodesphereInfraCmd) RunE(_ *cobra.Command, _ []string) error {
+	workdir := c.Env.GetOmsWorkdir()
+	pm := installer.NewPackage(workdir, c.Opts.Package)
+	cm := installer.NewConfig()
+	im := system.NewImage(context.Background())
+
+	ci := &installer.CodesphereInstaller{
+		ConfigPath:       c.Opts.Config,
+		VaultPath:        c.Opts.Vault,
+		PrivKey:          c.Opts.PrivKey,
+		Force:            c.Opts.Force,
+		SkipSteps:        c.Opts.SkipSteps,
+		AllowedSteps:     installer.InfraSteps,
+		DirectConnection: c.Opts.DirectConnection,
+		AutoApprove:      c.Opts.AutoApprove,
+	}
+	if err := ci.Install(pm, cm, im, runtime.GOOS, runtime.GOARCH); err != nil {
+		return fmt.Errorf("failed to install infra: %w", err)
+	}
+	return nil
+}
+
+func AddInstallCodesphereInfraCmd(codesphere *cobra.Command, opts *GlobalOptions) {
+	infra := InstallCodesphereInfraCmd{
+		cmd: &cobra.Command{
+			Use:   "infra",
+			Short: "Install Codesphere infrastructure (Phase 1)",
+			Long: io.Long(`Install infrastructure dependencies for a Codesphere instance (Phase 1).
+			Runs steps: copy-dependencies, extract-dependencies, load-container-images, sops, docker, postgres, ceph, kubernetes.`),
+			Example: formatExamples("install codesphere infra", []io.Example{
+				{
+					Cmd:  "-p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml",
+					Desc: "Install infrastructure components only",
+				},
+				{
+					Cmd:  "-p codesphere-v1.2.3-installer-lite.tar.gz -k <path-to-private-key> -c config.yaml -s load-container-images",
+					Desc: "Skip loading container images when using a lite package",
+				},
+			}),
+		},
+		Opts: &InstallCodesphereOpts{GlobalOptions: opts},
+		Env:  env.NewEnv(),
+	}
+	infra.cmd.Flags().StringVarP(&infra.Opts.Package, "package", "p", "", "Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from")
+	infra.cmd.Flags().BoolVarP(&infra.Opts.Force, "force", "f", false, "Enforce package extraction")
+	infra.cmd.Flags().StringVarP(&infra.Opts.Config, "config", "c", "", "Path to the Codesphere Private Cloud configuration file (yaml)")
+	infra.cmd.Flags().StringVar(&infra.Opts.Vault, "vault", "prod.vault.yaml", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
+	infra.cmd.Flags().StringVarP(&infra.Opts.PrivKey, "priv-key", "k", "", "Path to the private key to encrypt/decrypt secrets")
+	infra.cmd.Flags().StringSliceVarP(&infra.Opts.SkipSteps, "skip-steps", "s", []string{}, "Infra steps to skip. E.g. copy-dependencies, load-container-images, ceph, kubernetes")
+	infra.cmd.Flags().BoolVar(&infra.Opts.DirectConnection, "direct-connection", false, "Use direct connection for installation, requires having access to the cluster nodes from your machine")
+	infra.cmd.Flags().BoolVar(&infra.Opts.AutoApprove, "auto-approve", true, "Auto approve confirmation prompts with default values")
+
+	util.MarkFlagRequired(infra.cmd, "package")
+	util.MarkFlagRequired(infra.cmd, "config")
+	util.MarkFlagRequired(infra.cmd, "priv-key")
+
+	AddCmd(codesphere, infra.cmd)
+	infra.cmd.RunE = infra.RunE
+}

--- a/cli/cmd/install_codesphere_infra.go
+++ b/cli/cmd/install_codesphere_infra.go
@@ -12,7 +12,6 @@ import (
 	"github.com/codesphere-cloud/oms/internal/env"
 	"github.com/codesphere-cloud/oms/internal/installer"
 	"github.com/codesphere-cloud/oms/internal/system"
-	"github.com/codesphere-cloud/oms/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -24,20 +23,24 @@ type InstallCodesphereInfraCmd struct {
 }
 
 func (c *InstallCodesphereInfraCmd) RunE(_ *cobra.Command, _ []string) error {
-	workdir := c.Env.GetOmsWorkdir()
-	pm := installer.NewPackage(workdir, c.Opts.Package)
+	return installCodesphereInfra(c.Opts, c.Env)
+}
+
+func installCodesphereInfra(opts *InstallCodesphereOpts, env env.Env) error {
+	workdir := env.GetOmsWorkdir()
+	pm := installer.NewPackage(workdir, opts.Package)
 	cm := installer.NewConfig()
 	im := system.NewImage(context.Background())
 
 	ci := &installer.CodesphereInstaller{
-		ConfigPath:       c.Opts.Config,
-		VaultPath:        c.Opts.Vault,
-		PrivKey:          c.Opts.PrivKey,
-		Force:            c.Opts.Force,
-		SkipSteps:        c.Opts.SkipSteps,
+		ConfigPath:       opts.Config,
+		VaultPath:        opts.Vault,
+		PrivKey:          opts.PrivKey,
+		Force:            opts.Force,
+		SkipSteps:        opts.SkipSteps,
 		AllowedSteps:     installer.InfraSteps,
-		DirectConnection: c.Opts.DirectConnection,
-		AutoApprove:      c.Opts.AutoApprove,
+		DirectConnection: opts.DirectConnection,
+		AutoApprove:      opts.AutoApprove,
 	}
 	if err := ci.Install(pm, cm, im, runtime.GOOS, runtime.GOARCH); err != nil {
 		return fmt.Errorf("failed to install infra: %w", err)
@@ -45,7 +48,7 @@ func (c *InstallCodesphereInfraCmd) RunE(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func AddInstallCodesphereInfraCmd(codesphere *cobra.Command, opts *GlobalOptions) {
+func AddInstallCodesphereInfraCmd(codesphere *cobra.Command, opts *InstallCodesphereOpts) {
 	infra := InstallCodesphereInfraCmd{
 		cmd: &cobra.Command{
 			Use:   "infra",
@@ -63,21 +66,9 @@ func AddInstallCodesphereInfraCmd(codesphere *cobra.Command, opts *GlobalOptions
 				},
 			}),
 		},
-		Opts: &InstallCodesphereOpts{GlobalOptions: opts},
+		Opts: opts,
 		Env:  env.NewEnv(),
 	}
-	infra.cmd.Flags().StringVarP(&infra.Opts.Package, "package", "p", "", "Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from")
-	infra.cmd.Flags().BoolVarP(&infra.Opts.Force, "force", "f", false, "Enforce package extraction")
-	infra.cmd.Flags().StringVarP(&infra.Opts.Config, "config", "c", "", "Path to the Codesphere Private Cloud configuration file (yaml)")
-	infra.cmd.Flags().StringVar(&infra.Opts.Vault, "vault", "prod.vault.yaml", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
-	infra.cmd.Flags().StringVarP(&infra.Opts.PrivKey, "priv-key", "k", "", "Path to the private key to encrypt/decrypt secrets")
-	infra.cmd.Flags().StringSliceVarP(&infra.Opts.SkipSteps, "skip-steps", "s", []string{}, "Infra steps to skip. E.g. copy-dependencies, load-container-images, ceph, kubernetes")
-	infra.cmd.Flags().BoolVar(&infra.Opts.DirectConnection, "direct-connection", false, "Use direct connection for installation, requires having access to the cluster nodes from your machine")
-	infra.cmd.Flags().BoolVar(&infra.Opts.AutoApprove, "auto-approve", true, "Auto approve confirmation prompts with default values")
-
-	util.MarkFlagRequired(infra.cmd, "package")
-	util.MarkFlagRequired(infra.cmd, "config")
-	util.MarkFlagRequired(infra.cmd, "priv-key")
 
 	AddCmd(codesphere, infra.cmd)
 	infra.cmd.RunE = infra.RunE

--- a/cli/cmd/install_codesphere_platform.go
+++ b/cli/cmd/install_codesphere_platform.go
@@ -12,7 +12,6 @@ import (
 	"github.com/codesphere-cloud/oms/internal/env"
 	"github.com/codesphere-cloud/oms/internal/installer"
 	"github.com/codesphere-cloud/oms/internal/system"
-	"github.com/codesphere-cloud/oms/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -24,20 +23,24 @@ type InstallCodespherePlatformCmd struct {
 }
 
 func (c *InstallCodespherePlatformCmd) RunE(_ *cobra.Command, _ []string) error {
-	workdir := c.Env.GetOmsWorkdir()
-	pm := installer.NewPackage(workdir, c.Opts.Package)
+	return installCodespherePlatform(c.Opts, c.Env)
+}
+
+func installCodespherePlatform(opts *InstallCodesphereOpts, env env.Env) error {
+	workdir := env.GetOmsWorkdir()
+	pm := installer.NewPackage(workdir, opts.Package)
 	cm := installer.NewConfig()
 	im := system.NewImage(context.Background())
 
 	ci := &installer.CodesphereInstaller{
-		ConfigPath:       c.Opts.Config,
-		VaultPath:        c.Opts.Vault,
-		PrivKey:          c.Opts.PrivKey,
-		Force:            c.Opts.Force,
-		SkipSteps:        c.Opts.SkipSteps,
+		ConfigPath:       opts.Config,
+		VaultPath:        opts.Vault,
+		PrivKey:          opts.PrivKey,
+		Force:            opts.Force,
+		SkipSteps:        opts.SkipSteps,
 		AllowedSteps:     installer.PlatformSteps,
-		DirectConnection: c.Opts.DirectConnection,
-		AutoApprove:      c.Opts.AutoApprove,
+		DirectConnection: opts.DirectConnection,
+		AutoApprove:      opts.AutoApprove,
 	}
 	if err := ci.Install(pm, cm, im, runtime.GOOS, runtime.GOARCH); err != nil {
 		return fmt.Errorf("failed to install platform: %w", err)
@@ -45,7 +48,7 @@ func (c *InstallCodespherePlatformCmd) RunE(_ *cobra.Command, _ []string) error 
 	return nil
 }
 
-func AddInstallCodespherePlatformCmd(codesphere *cobra.Command, opts *GlobalOptions) {
+func AddInstallCodespherePlatformCmd(codesphere *cobra.Command, opts *InstallCodesphereOpts) {
 	platform := InstallCodespherePlatformCmd{
 		cmd: &cobra.Command{
 			Use:   "platform",
@@ -60,21 +63,9 @@ func AddInstallCodespherePlatformCmd(codesphere *cobra.Command, opts *GlobalOpti
 				},
 			}),
 		},
-		Opts: &InstallCodesphereOpts{GlobalOptions: opts},
+		Opts: opts,
 		Env:  env.NewEnv(),
 	}
-	platform.cmd.Flags().StringVarP(&platform.Opts.Package, "package", "p", "", "Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from")
-	platform.cmd.Flags().BoolVarP(&platform.Opts.Force, "force", "f", false, "Enforce package extraction")
-	platform.cmd.Flags().StringVarP(&platform.Opts.Config, "config", "c", "", "Path to the Codesphere Private Cloud configuration file (yaml)")
-	platform.cmd.Flags().StringVar(&platform.Opts.Vault, "vault", "prod.vault.yaml", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
-	platform.cmd.Flags().StringVarP(&platform.Opts.PrivKey, "priv-key", "k", "", "Path to the private key to encrypt/decrypt secrets")
-	platform.cmd.Flags().StringSliceVarP(&platform.Opts.SkipSteps, "skip-steps", "s", []string{}, "Platform steps to skip. E.g. codesphere")
-	platform.cmd.Flags().BoolVar(&platform.Opts.DirectConnection, "direct-connection", false, "Use direct connection for installation, requires having access to the cluster nodes from your machine")
-	platform.cmd.Flags().BoolVar(&platform.Opts.AutoApprove, "auto-approve", true, "Auto approve confirmation prompts with default values")
-
-	util.MarkFlagRequired(platform.cmd, "package")
-	util.MarkFlagRequired(platform.cmd, "config")
-	util.MarkFlagRequired(platform.cmd, "priv-key")
 
 	AddCmd(codesphere, platform.cmd)
 	platform.cmd.RunE = platform.RunE

--- a/cli/cmd/install_codesphere_platform.go
+++ b/cli/cmd/install_codesphere_platform.go
@@ -1,0 +1,81 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/codesphere-cloud/cs-go/pkg/io"
+	"github.com/codesphere-cloud/oms/internal/env"
+	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/system"
+	"github.com/codesphere-cloud/oms/internal/util"
+	"github.com/spf13/cobra"
+)
+
+// InstallCodespherePlatformCmd runs only the Codesphere platform step (Phase 3).
+type InstallCodespherePlatformCmd struct {
+	cmd  *cobra.Command
+	Opts *InstallCodesphereOpts
+	Env  env.Env
+}
+
+func (c *InstallCodespherePlatformCmd) RunE(_ *cobra.Command, _ []string) error {
+	workdir := c.Env.GetOmsWorkdir()
+	pm := installer.NewPackage(workdir, c.Opts.Package)
+	cm := installer.NewConfig()
+	im := system.NewImage(context.Background())
+
+	ci := &installer.CodesphereInstaller{
+		ConfigPath:       c.Opts.Config,
+		VaultPath:        c.Opts.Vault,
+		PrivKey:          c.Opts.PrivKey,
+		Force:            c.Opts.Force,
+		SkipSteps:        c.Opts.SkipSteps,
+		AllowedSteps:     installer.PlatformSteps,
+		DirectConnection: c.Opts.DirectConnection,
+		AutoApprove:      c.Opts.AutoApprove,
+	}
+	if err := ci.Install(pm, cm, im, runtime.GOOS, runtime.GOARCH); err != nil {
+		return fmt.Errorf("failed to install platform: %w", err)
+	}
+	return nil
+}
+
+func AddInstallCodespherePlatformCmd(codesphere *cobra.Command, opts *GlobalOptions) {
+	platform := InstallCodespherePlatformCmd{
+		cmd: &cobra.Command{
+			Use:   "platform",
+			Short: "Install the Codesphere platform (Phase 3)",
+			Long: io.Long(`Install the Codesphere platform (Phase 3).
+			Runs step: codesphere.
+			Requires the infrastructure and dependencies phases to have completed successfully.`),
+			Example: formatExamples("install codesphere platform", []io.Example{
+				{
+					Cmd:  "-p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml",
+					Desc: "Install Codesphere platform only",
+				},
+			}),
+		},
+		Opts: &InstallCodesphereOpts{GlobalOptions: opts},
+		Env:  env.NewEnv(),
+	}
+	platform.cmd.Flags().StringVarP(&platform.Opts.Package, "package", "p", "", "Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from")
+	platform.cmd.Flags().BoolVarP(&platform.Opts.Force, "force", "f", false, "Enforce package extraction")
+	platform.cmd.Flags().StringVarP(&platform.Opts.Config, "config", "c", "", "Path to the Codesphere Private Cloud configuration file (yaml)")
+	platform.cmd.Flags().StringVar(&platform.Opts.Vault, "vault", "prod.vault.yaml", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
+	platform.cmd.Flags().StringVarP(&platform.Opts.PrivKey, "priv-key", "k", "", "Path to the private key to encrypt/decrypt secrets")
+	platform.cmd.Flags().StringSliceVarP(&platform.Opts.SkipSteps, "skip-steps", "s", []string{}, "Platform steps to skip. E.g. codesphere")
+	platform.cmd.Flags().BoolVar(&platform.Opts.DirectConnection, "direct-connection", false, "Use direct connection for installation, requires having access to the cluster nodes from your machine")
+	platform.cmd.Flags().BoolVar(&platform.Opts.AutoApprove, "auto-approve", true, "Auto approve confirmation prompts with default values")
+
+	util.MarkFlagRequired(platform.cmd, "package")
+	util.MarkFlagRequired(platform.cmd, "config")
+	util.MarkFlagRequired(platform.cmd, "priv-key")
+
+	AddCmd(codesphere, platform.cmd)
+	platform.cmd.RunE = platform.RunE
+}

--- a/cli/cmd/install_codesphere_test.go
+++ b/cli/cmd/install_codesphere_test.go
@@ -492,29 +492,29 @@ var _ = Describe("AddInstallCodesphereCmd", func() {
 		Expect(codesphereCmd.Long).To(ContainSubstring("Uses the private-cloud-installer.js script included in the package to perform the installation."))
 		Expect(codesphereCmd.RunE).NotTo(BeNil())
 
-		// Check flags
-		packageFlag := codesphereCmd.Flags().Lookup("package")
+		// Check flags (registered as PersistentFlags so subcommands inherit them)
+		packageFlag := codesphereCmd.PersistentFlags().Lookup("package")
 		Expect(packageFlag).NotTo(BeNil())
 		Expect(packageFlag.Shorthand).To(Equal("p"))
 
-		forceFlag := codesphereCmd.Flags().Lookup("force")
+		forceFlag := codesphereCmd.PersistentFlags().Lookup("force")
 		Expect(forceFlag).NotTo(BeNil())
 		Expect(forceFlag.Shorthand).To(Equal("f"))
 		Expect(forceFlag.DefValue).To(Equal("false"))
 
-		configFlag := codesphereCmd.Flags().Lookup("config")
+		configFlag := codesphereCmd.PersistentFlags().Lookup("config")
 		Expect(configFlag).NotTo(BeNil())
 		Expect(configFlag.Shorthand).To(Equal("c"))
 
-		privKeyFlag := codesphereCmd.Flags().Lookup("priv-key")
+		privKeyFlag := codesphereCmd.PersistentFlags().Lookup("priv-key")
 		Expect(privKeyFlag).NotTo(BeNil())
 		Expect(privKeyFlag.Shorthand).To(Equal("k"))
 
-		vaultFlag := codesphereCmd.Flags().Lookup("vault")
+		vaultFlag := codesphereCmd.PersistentFlags().Lookup("vault")
 		Expect(vaultFlag).NotTo(BeNil())
 		Expect(vaultFlag.DefValue).To(Equal("prod.vault.yaml"))
 
-		skipStepFlag := codesphereCmd.Flags().Lookup("skip-steps")
+		skipStepFlag := codesphereCmd.PersistentFlags().Lookup("skip-steps")
 		Expect(skipStepFlag).NotTo(BeNil())
 		Expect(skipStepFlag.Shorthand).To(Equal("s"))
 	})

--- a/cli/cmd/install_codesphere_test.go
+++ b/cli/cmd/install_codesphere_test.go
@@ -70,7 +70,7 @@ var _ = Describe("InstallCodesphereCmd", func() {
 				Expect(err.Error()).To(ContainSubstring("codesphere installation is only supported on Linux amd64"))
 			} else {
 				// On Linux amd64, it should fail on package extraction since the package doesn't exist
-				Expect(err.Error()).To(ContainSubstring("failed to extract and install package"))
+				Expect(err.Error()).To(ContainSubstring("failed to extract package to workdir"))
 			}
 		})
 	})

--- a/docs/oms_install_codesphere.md
+++ b/docs/oms_install_codesphere.md
@@ -33,7 +33,7 @@ $ oms install codesphere -p codesphere-v1.2.3-installer-lite.tar.gz -k <path-to-
   -h, --help                 help for codesphere
   -p, --package string       Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
   -k, --priv-key string      Path to the private key to encrypt/decrypt secrets
-  -s, --skip-steps strings   Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, kubernetes
+  -s, --skip-steps strings   Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
       --vault string         Path to the SOPS-encrypted prod.vault.yaml file used for config templating (default "prod.vault.yaml")
 ```
 

--- a/docs/oms_install_codesphere.md
+++ b/docs/oms_install_codesphere.md
@@ -40,4 +40,7 @@ $ oms install codesphere -p codesphere-v1.2.3-installer-lite.tar.gz -k <path-to-
 ### SEE ALSO
 
 * [oms install](oms_install.md)	 - Install Codesphere and other components
+* [oms install codesphere dependencies](oms_install_codesphere_dependencies.md)	 - Install Codesphere cluster dependencies (Phase 2)
+* [oms install codesphere infra](oms_install_codesphere_infra.md)	 - Install Codesphere infrastructure (Phase 1)
+* [oms install codesphere platform](oms_install_codesphere_platform.md)	 - Install the Codesphere platform (Phase 3)
 

--- a/docs/oms_install_codesphere_dependencies.md
+++ b/docs/oms_install_codesphere_dependencies.md
@@ -1,0 +1,40 @@
+## oms install codesphere dependencies
+
+Install Codesphere cluster dependencies (Phase 2)
+
+### Synopsis
+
+Install cluster dependencies for a Codesphere instance (Phase 2).
+Runs steps: set-up-cluster, ms-backends.
+Requires the infrastructure phase to have completed successfully.
+
+```
+oms install codesphere dependencies [flags]
+```
+
+### Examples
+
+```
+# Install cluster dependencies only
+$ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml
+
+```
+
+### Options
+
+```
+      --auto-approve         Auto approve confirmation prompts with default values (default true)
+  -c, --config string        Path to the Codesphere Private Cloud configuration file (yaml)
+      --direct-connection    Use direct connection for installation, requires having access to the cluster nodes from your machine
+  -f, --force                Enforce package extraction
+  -h, --help                 help for dependencies
+  -p, --package string       Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
+  -k, --priv-key string      Path to the private key to encrypt/decrypt secrets
+  -s, --skip-steps strings   Dependencies steps to skip. E.g. set-up-cluster, ms-backends
+      --vault string         Path to the SOPS-encrypted prod.vault.yaml file used for config templating (default "prod.vault.yaml")
+```
+
+### SEE ALSO
+
+* [oms install codesphere](oms_install_codesphere.md)	 - Install a Codesphere instance
+

--- a/docs/oms_install_codesphere_dependencies.md
+++ b/docs/oms_install_codesphere_dependencies.md
@@ -23,14 +23,19 @@ $ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <
 ### Options
 
 ```
+  -h, --help   help for dependencies
+```
+
+### Options inherited from parent commands
+
+```
       --auto-approve         Auto approve confirmation prompts with default values (default true)
   -c, --config string        Path to the Codesphere Private Cloud configuration file (yaml)
       --direct-connection    Use direct connection for installation, requires having access to the cluster nodes from your machine
   -f, --force                Enforce package extraction
-  -h, --help                 help for dependencies
   -p, --package string       Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
   -k, --priv-key string      Path to the private key to encrypt/decrypt secrets
-  -s, --skip-steps strings   Dependencies steps to skip. E.g. set-up-cluster, ms-backends
+  -s, --skip-steps strings   Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
       --vault string         Path to the SOPS-encrypted prod.vault.yaml file used for config templating (default "prod.vault.yaml")
 ```
 

--- a/docs/oms_install_codesphere_infra.md
+++ b/docs/oms_install_codesphere_infra.md
@@ -25,14 +25,19 @@ $ oms install codesphere infra -p codesphere-v1.2.3-installer-lite.tar.gz -k <pa
 ### Options
 
 ```
+  -h, --help   help for infra
+```
+
+### Options inherited from parent commands
+
+```
       --auto-approve         Auto approve confirmation prompts with default values (default true)
   -c, --config string        Path to the Codesphere Private Cloud configuration file (yaml)
       --direct-connection    Use direct connection for installation, requires having access to the cluster nodes from your machine
   -f, --force                Enforce package extraction
-  -h, --help                 help for infra
   -p, --package string       Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
   -k, --priv-key string      Path to the private key to encrypt/decrypt secrets
-  -s, --skip-steps strings   Infra steps to skip. E.g. copy-dependencies, load-container-images, ceph, kubernetes
+  -s, --skip-steps strings   Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
       --vault string         Path to the SOPS-encrypted prod.vault.yaml file used for config templating (default "prod.vault.yaml")
 ```
 

--- a/docs/oms_install_codesphere_infra.md
+++ b/docs/oms_install_codesphere_infra.md
@@ -1,0 +1,42 @@
+## oms install codesphere infra
+
+Install Codesphere infrastructure (Phase 1)
+
+### Synopsis
+
+Install infrastructure dependencies for a Codesphere instance (Phase 1).
+Runs steps: copy-dependencies, extract-dependencies, load-container-images, sops, docker, postgres, ceph, kubernetes.
+
+```
+oms install codesphere infra [flags]
+```
+
+### Examples
+
+```
+# Install infrastructure components only
+$ oms install codesphere infra -p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml
+
+# Skip loading container images when using a lite package
+$ oms install codesphere infra -p codesphere-v1.2.3-installer-lite.tar.gz -k <path-to-private-key> -c config.yaml -s load-container-images
+
+```
+
+### Options
+
+```
+      --auto-approve         Auto approve confirmation prompts with default values (default true)
+  -c, --config string        Path to the Codesphere Private Cloud configuration file (yaml)
+      --direct-connection    Use direct connection for installation, requires having access to the cluster nodes from your machine
+  -f, --force                Enforce package extraction
+  -h, --help                 help for infra
+  -p, --package string       Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
+  -k, --priv-key string      Path to the private key to encrypt/decrypt secrets
+  -s, --skip-steps strings   Infra steps to skip. E.g. copy-dependencies, load-container-images, ceph, kubernetes
+      --vault string         Path to the SOPS-encrypted prod.vault.yaml file used for config templating (default "prod.vault.yaml")
+```
+
+### SEE ALSO
+
+* [oms install codesphere](oms_install_codesphere.md)	 - Install a Codesphere instance
+

--- a/docs/oms_install_codesphere_platform.md
+++ b/docs/oms_install_codesphere_platform.md
@@ -1,0 +1,40 @@
+## oms install codesphere platform
+
+Install the Codesphere platform (Phase 3)
+
+### Synopsis
+
+Install the Codesphere platform (Phase 3).
+Runs step: codesphere.
+Requires the infrastructure and dependencies phases to have completed successfully.
+
+```
+oms install codesphere platform [flags]
+```
+
+### Examples
+
+```
+# Install Codesphere platform only
+$ oms install codesphere platform -p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml
+
+```
+
+### Options
+
+```
+      --auto-approve         Auto approve confirmation prompts with default values (default true)
+  -c, --config string        Path to the Codesphere Private Cloud configuration file (yaml)
+      --direct-connection    Use direct connection for installation, requires having access to the cluster nodes from your machine
+  -f, --force                Enforce package extraction
+  -h, --help                 help for platform
+  -p, --package string       Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
+  -k, --priv-key string      Path to the private key to encrypt/decrypt secrets
+  -s, --skip-steps strings   Platform steps to skip. E.g. codesphere
+      --vault string         Path to the SOPS-encrypted prod.vault.yaml file used for config templating (default "prod.vault.yaml")
+```
+
+### SEE ALSO
+
+* [oms install codesphere](oms_install_codesphere.md)	 - Install a Codesphere instance
+

--- a/docs/oms_install_codesphere_platform.md
+++ b/docs/oms_install_codesphere_platform.md
@@ -23,14 +23,19 @@ $ oms install codesphere platform -p codesphere-v1.2.3-installer.tar.gz -k <path
 ### Options
 
 ```
+  -h, --help   help for platform
+```
+
+### Options inherited from parent commands
+
+```
       --auto-approve         Auto approve confirmation prompts with default values (default true)
   -c, --config string        Path to the Codesphere Private Cloud configuration file (yaml)
       --direct-connection    Use direct connection for installation, requires having access to the cluster nodes from your machine
   -f, --force                Enforce package extraction
-  -h, --help                 help for platform
   -p, --package string       Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
   -k, --priv-key string      Path to the private key to encrypt/decrypt secrets
-  -s, --skip-steps strings   Platform steps to skip. E.g. codesphere
+  -s, --skip-steps strings   Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
       --vault string         Path to the SOPS-encrypted prod.vault.yaml file used for config templating (default "prod.vault.yaml")
 ```
 

--- a/internal/installer/codesphere.go
+++ b/internal/installer/codesphere.go
@@ -1,0 +1,341 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package installer
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/codesphere-cloud/oms/internal/configtemplating"
+	"github.com/codesphere-cloud/oms/internal/installer/files"
+	"github.com/codesphere-cloud/oms/internal/system"
+	"github.com/codesphere-cloud/oms/internal/util"
+)
+
+// KnownInstallerSteps mirrors SKIPPABLE_STEPS from private-cloud-installer.ts.
+var KnownInstallerSteps = []string{
+	"copy-dependencies",
+	"extract-dependencies",
+	"load-container-images",
+	"sops",
+	"docker",
+	"postgres",
+	"ceph",
+	"kubernetes",
+	"set-up-cluster",
+	"codesphere",
+	"ms-backends",
+}
+
+// InfraSteps are run in Phase 1 (before ArgoCD) when --argocd is active.
+var InfraSteps = []string{
+	"copy-dependencies",
+	"extract-dependencies",
+	"load-container-images",
+	"sops",
+	"docker",
+	"postgres",
+	"ceph",
+	"kubernetes",
+}
+
+// DependenciesSteps run in Phase 2 after infrastructure is ready.
+var DependenciesSteps = []string{"set-up-cluster", "ms-backends"}
+
+// PlatformSteps run in Phase 3 and install the Codesphere platform only.
+var PlatformSteps = []string{"codesphere"}
+
+// CodesphereInstaller encapsulates the logic for running the private-cloud-installer.js script.
+type CodesphereInstaller struct {
+	// ConfigPath is the path to the Codesphere Private Cloud configuration YAML file.
+	ConfigPath string
+	// VaultPath is the path to the SOPS-encrypted vault file used for config templating.
+	// When non-empty, the config is rendered as a template before use.
+	VaultPath string
+	// PrivKey is the path to the age/GPG private key used to decrypt the vault.
+	PrivKey string
+	// Force re-extracts the package even if the work directory already exists.
+	Force bool
+	// SkipSteps lists installer steps to skip within the active step set.
+	SkipSteps []string
+	// AllowedSteps restricts execution to a subset of KnownInstallerSteps.
+	// When nil, all KnownInstallerSteps are used. Set to InfraSteps, DependenciesSteps,
+	// or PlatformSteps for the split-phase commands.
+	AllowedSteps []string
+	// CodesphereOnly skips all dependency steps and only runs the Codesphere helm charts.
+	CodesphereOnly bool
+	// DirectConnection routes installer traffic directly to cluster nodes instead of
+	// going through a bastion; requires network access to those nodes from the local machine.
+	DirectConnection bool
+	// AutoApprove suppresses the confirmation prompt before executing steps.
+	AutoApprove bool
+	// SkipImageBuilding skips the custom workspace image build-and-push step.
+	// Set when a prior phase already built the images so they are not rebuilt redundantly.
+	SkipImageBuilding bool
+}
+
+// Install validates the platform, extracts the package, builds any custom workspace images,
+// and runs the private-cloud-installer.js script.
+func (ci *CodesphereInstaller) Install(pm PackageManager, cm ConfigManager, im system.ImageManager, goos, goarch string) error {
+	if goos != "linux" || goarch != "amd64" {
+		return fmt.Errorf("codesphere installation is only supported on Linux amd64. Current platform: %s/%s", goos, goarch)
+	}
+
+	originalConfig := ci.ConfigPath
+	cleanup := func() {}
+	if ci.VaultPath != "" {
+		store := NewLazyVaultTemplatingSecretStore(ci.VaultPath, ci.PrivKey)
+		renderedConfig, renderCleanup, err := configtemplating.RenderConfigFileToTemp(ci.ConfigPath, store)
+		if err != nil {
+			return fmt.Errorf("failed to render config template: %w", err)
+		}
+		cleanup = renderCleanup
+		ci.ConfigPath = renderedConfig
+	}
+	defer cleanup()
+	defer func() {
+		ci.ConfigPath = originalConfig
+	}()
+
+	config, err := cm.ParseConfigYaml(ci.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to extract config.yaml: %w", err)
+	}
+	ci.warnIfVaultDirDiffersFromSecretsDir(config)
+
+	err = pm.Extract(ci.Force)
+	if err != nil {
+		return fmt.Errorf("failed to extract package to workdir: %w", err)
+	}
+
+	foundFiles, err := ListPackageContents(pm)
+	if err != nil {
+		return fmt.Errorf("failed to list available files: %w", err)
+	}
+
+	if !slices.Contains(foundFiles, "deps.tar.gz") {
+		return fmt.Errorf("deps.tar.gz not found in package")
+	}
+	if !slices.Contains(foundFiles, "private-cloud-installer.js") {
+		return fmt.Errorf("private-cloud-installer.js not found in package")
+	}
+	if !slices.Contains(foundFiles, "node") {
+		return fmt.Errorf("node executable not found in package")
+	}
+
+	err = pm.ExtractDependency("bom.json", ci.Force)
+	if err != nil {
+		return fmt.Errorf("failed to extract package to workdir: %w", err)
+	}
+
+	// If workspace image is extended extract bom.json and load workspace image
+	if !ci.SkipImageBuilding {
+		for imageKey, imageConfig := range config.Codesphere.DeployConfig.Images {
+			for flavorKey, flavor := range imageConfig.Flavors {
+				if flavor.Image.Dockerfile != "" && config.Registry != nil && config.Registry.Server != "" {
+					bomRef := flavor.Image.BomRef
+					dockerfile := flavor.Image.Dockerfile
+
+					fullImageTag, err := pm.GetFullImageTag(bomRef)
+					if err != nil {
+						return fmt.Errorf("failed to get full image tag for %s: %w", bomRef, err)
+					}
+
+					// Extract root image name from full tag (e.g. repo/image:tag -> image)
+					parts := strings.Split(fullImageTag, ":")
+					if len(parts) < 2 {
+						return fmt.Errorf("invalid image tag format: %s", fullImageTag)
+					}
+					imageNameAndPath := parts[0]
+					version := parts[1]
+					rootImageName := path.Base(imageNameAndPath)
+
+					// Extract and load root image
+					imagePath := filepath.Join("codesphere", "images", fmt.Sprintf("%s.tar", rootImageName))
+					err = pm.ExtractDependency(imagePath, ci.Force)
+					if err != nil {
+						return fmt.Errorf("failed to extract root image %s: %w", imagePath, err)
+					}
+
+					extractedImagePath := pm.GetDependencyPath(imagePath)
+					err = im.LoadImage(extractedImagePath)
+					if err != nil {
+						return fmt.Errorf("failed to load workspace image from Dockerfile %s: %w", dockerfile, err)
+					}
+					log.Printf("Loaded root image '%s'", extractedImagePath)
+
+					// TODO: This is duplicated from update_dockerfile.go, refactor into shared function
+					dockerfileFile, err := pm.FileIO().Open(dockerfile)
+					if err != nil {
+						return fmt.Errorf("failed to open dockerfile %s: %w", dockerfile, err)
+					}
+					defer util.CloseFileIgnoreError(dockerfileFile)
+
+					dockerfileManager := util.NewDockerfileManager()
+					updatedContent, err := dockerfileManager.UpdateFromStatement(dockerfileFile, fullImageTag)
+					if err != nil {
+						return fmt.Errorf("failed to update FROM statement: %w", err)
+					}
+
+					err = pm.FileIO().WriteFile(dockerfile, []byte(updatedContent), 0644)
+					if err != nil {
+						return fmt.Errorf("failed to write updated dockerfile: %w", err)
+					}
+
+					log.Printf("Successfully updated FROM statement in %s to use %s", dockerfile, fullImageTag)
+					// TODO: End duplicated code
+
+					dockerfileName := filepath.Base(dockerfile)
+					dockerfileDir := filepath.Dir(dockerfile)
+
+					// Determine image tag for build and push
+					registryUrl := strings.TrimRight(config.Registry.Server, "/")
+					buildTag := fmt.Sprintf("%s/%s-%s:%s", registryUrl, imageKey, flavorKey, version)
+
+					err = im.BuildImage(dockerfileName, buildTag, dockerfileDir)
+					if err != nil {
+						return fmt.Errorf("failed to build workspace image from Dockerfile %s: %w", dockerfile, err)
+					}
+
+					log.Printf("Pushing image to %s", buildTag)
+					err = im.PushImage(buildTag)
+					if err != nil {
+						return fmt.Errorf("failed to push image %s: %w", buildTag, err)
+					}
+				}
+			}
+		}
+	}
+
+	// Install codesphere with node
+	nodePath := filepath.Join(pm.GetWorkDir(), "node")
+	err = os.Chmod(nodePath, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to make node executable: %w", err)
+	}
+
+	log.Printf("Using Node.js executable: %s", nodePath)
+	log.Println("Starting private cloud installer script...")
+	installerPath := filepath.Join(pm.GetWorkDir(), "private-cloud-installer.js")
+	archivePath := filepath.Join(pm.GetWorkDir(), "deps.tar.gz")
+
+	cmdArgs := []string{installerPath, "--archive", archivePath, "--config", ci.ConfigPath, "--privKey", ci.PrivKey}
+
+	baseSteps := KnownInstallerSteps
+	if len(ci.AllowedSteps) > 0 {
+		baseSteps = ci.AllowedSteps
+	}
+
+	executableSteps := map[string]bool{}
+	for _, step := range baseSteps {
+		executableSteps[step] = true
+	}
+
+	// Steps not in baseSteps are skipped implicitly; add them to cmdArgs
+	for _, step := range KnownInstallerSteps {
+		if _, ok := executableSteps[step]; !ok {
+			cmdArgs = append(cmdArgs, "--skipStep", step)
+		}
+	}
+
+	if config.Operations != nil {
+		for _, step := range config.Operations.Skip {
+			executableSteps[step] = false
+		}
+	}
+
+	for _, step := range ci.SkipSteps {
+		executableSteps[step] = false
+	}
+
+	executedSteps := []string{}
+	for step, executed := range executableSteps {
+		if !executed {
+			cmdArgs = append(cmdArgs, "--skipStep", step)
+		} else {
+			executedSteps = append(executedSteps, step)
+		}
+	}
+
+	sort.Strings(executedSteps)
+
+	prompt := NewPrompter(!ci.AutoApprove)
+	msg := fmt.Sprintf("The following steps will be executed: %s. Type \"yes\" to continue.", strings.Join(executedSteps, ", "))
+	if prompt.String(msg, "yes") != "yes" {
+		return fmt.Errorf("installation aborted")
+	}
+
+	if ci.CodesphereOnly {
+		cmdArgs = append(cmdArgs, "--codesphereOnly")
+	}
+
+	if ci.DirectConnection {
+		cmdArgs = append(cmdArgs, "--directConnection")
+	}
+
+	cmd := exec.Command(nodePath, cmdArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to run installer script: %w", err)
+	}
+	log.Println("Private cloud installer script finished.")
+
+	return nil
+}
+
+func (ci *CodesphereInstaller) warnIfVaultDirDiffersFromSecretsDir(config files.RootConfig) {
+	if ci.VaultPath == "" || config.Secrets.BaseDir == "" {
+		return
+	}
+
+	vaultDir, err := filepath.Abs(filepath.Dir(ci.VaultPath))
+	if err != nil {
+		log.Printf("Warning: failed to resolve vault directory for %s: %v", ci.VaultPath, err)
+		return
+	}
+
+	secretsDir, err := filepath.Abs(config.Secrets.BaseDir)
+	if err != nil {
+		log.Printf("Warning: failed to resolve configured secrets baseDir %s: %v", config.Secrets.BaseDir, err)
+		return
+	}
+
+	if vaultDir != secretsDir {
+		log.Printf("Warning: config secrets.baseDir (%s) does not match the directory of --vault (%s)", secretsDir, vaultDir)
+	}
+}
+
+// ListPackageContents returns the filenames present in the extracted package work directory.
+func ListPackageContents(pm PackageManager) ([]string, error) {
+	packageDir := pm.GetWorkDir()
+	if !pm.FileIO().Exists(packageDir) {
+		return nil, fmt.Errorf("work dir not found: %s", packageDir)
+	}
+
+	entries, err := pm.FileIO().ReadDir(packageDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory contents: %w", err)
+	}
+
+	log.Printf("Listing contents of %s", packageDir)
+	var foundFiles []string
+	for _, entry := range entries {
+		filename := entry.Name()
+		log.Printf("- %s", filename)
+		foundFiles = append(foundFiles, filename)
+	}
+
+	return foundFiles, nil
+}

--- a/internal/util/required_flag.go
+++ b/internal/util/required_flag.go
@@ -15,3 +15,10 @@ func MarkFlagRequired(cmd *cobra.Command, name string) {
 		panic(fmt.Errorf("failed to mark flag as required, please check existence: %w", err))
 	}
 }
+
+func MarkPersistentFlagRequired(cmd *cobra.Command, name string) {
+	err := cmd.MarkPersistentFlagRequired(name)
+	if err != nil {
+		panic(fmt.Errorf("failed to mark persistent flag as required, please check existence: %w", err))
+	}
+}


### PR DESCRIPTION
Add `oms install codesphere infra` (Phase 1: copy-dependencies through kubernetes) and `oms install codesphere cluster` (Phase 2: set-up-cluster, codesphere, ms-backends) as separate commands alongside the existing full `oms install codesphere` command.

Shared execution logic is extracted into `installer.CodesphereInstaller` in the installer package. The `AllowedSteps` field restricts the active step set so each command only runs the steps relevant to its phase. The original command delegates to the same struct with `AllowedSteps: nil`, preserving its existing behaviour exactly. The infra and cluster commands each live in their own file (`install_codesphere_infra.go`, `install_codesphere_cluster.go`).

The previous skipSteps and persistence is still respected, also in both new commands