### PR TITLE
fix(openbao): fix raft join address

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -274,7 +274,7 @@ require (
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golangci/asciicheck v0.5.0 // indirect
 	github.com/golangci/dupl v0.0.0-20260401084720-c99c5cf5c202 // indirect

--- a/internal/installer/export_test.go
+++ b/internal/installer/export_test.go
@@ -51,3 +51,7 @@ func (o *OpenBaoInstaller) ReleaseExistsInTargetNamespace(releaseName string) (b
 func (o *OpenBaoInstaller) OperatorInstalledClusterWide() (bool, error) {
 	return o.operatorInstalledClusterWide()
 }
+
+func BuildRetryJoinAddrs(replicas int, namespace string) []string {
+	return buildRetryJoinAddrs(replicas, namespace)
+}

--- a/internal/installer/export_test.go
+++ b/internal/installer/export_test.go
@@ -5,6 +5,7 @@ package installer
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -54,4 +55,12 @@ func (o *OpenBaoInstaller) OperatorInstalledClusterWide() (bool, error) {
 
 func BuildRetryJoinAddrs(replicas int, namespace string) []string {
 	return buildRetryJoinAddrs(replicas, namespace)
+}
+
+func (o *OpenBaoInstaller) ValidateConfig() error {
+	return o.validateConfig()
+}
+
+func (o *OpenBaoInstaller) ReadinessTimeout() time.Duration {
+	return o.readinessTimeout()
 }

--- a/internal/installer/manifests/openbao/vault-cr.yaml
+++ b/internal/installer/manifests/openbao/vault-cr.yaml
@@ -76,12 +76,6 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.name
-      # The bank-vaults operator exposes each pod via a per-pod ClusterIP
-      # service named after the pod ("openbao-<ordinal>"), so the resolvable
-      # address is "$(POD_NAME).<namespace>.svc.cluster.local". There is no
-      # StatefulSet headless service, so an extra ".openbao" label here never
-      # resolves — the Raft leader then can't heartbeat/replicate to peers and
-      # followers never receive the initialized barrier.
       - name: BAO_CLUSTER_ADDR
         value: "http://$(POD_NAME).{{ .Namespace }}.svc.cluster.local:8201"
       - name: BAO_API_ADDR

--- a/internal/installer/manifests/openbao/vault-cr.yaml
+++ b/internal/installer/manifests/openbao/vault-cr.yaml
@@ -76,10 +76,16 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.name
+      # The bank-vaults operator exposes each pod via a per-pod ClusterIP
+      # service named after the pod ("openbao-<ordinal>"), so the resolvable
+      # address is "$(POD_NAME).<namespace>.svc.cluster.local". There is no
+      # StatefulSet headless service, so an extra ".openbao" label here never
+      # resolves — the Raft leader then can't heartbeat/replicate to peers and
+      # followers never receive the initialized barrier.
       - name: BAO_CLUSTER_ADDR
-        value: "http://$(POD_NAME).openbao.{{ .Namespace }}.svc.cluster.local:8201"
+        value: "http://$(POD_NAME).{{ .Namespace }}.svc.cluster.local:8201"
       - name: BAO_API_ADDR
-        value: "http://$(POD_NAME).openbao.{{ .Namespace }}.svc.cluster.local:8200"
+        value: "http://$(POD_NAME).{{ .Namespace }}.svc.cluster.local:8200"
   unsealConfig:
     options:
       preFlightChecks: true

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -33,7 +33,6 @@ var vaultCRTemplate []byte
 
 const (
 	openBaoUnsealSecretName = "openbao-unseal-keys"
-	openBaoHeadlessService  = "openbao"
 	DefaultOpenBaoNamespace = "vault"
 	openBaoImage            = "quay.io/openbao/openbao:2.1.0"
 	bankVaultsImage         = "ghcr.io/bank-vaults/bank-vaults:v1.31.3"
@@ -371,6 +370,24 @@ type vaultCRTemplateData struct {
 	RetryJoinAddrs    []string
 }
 
+// buildRetryJoinAddrs builds the Raft retry_join addresses so each node can
+// autonomously find and join the cluster leader. For a single replica this
+// produces one self-referencing address, which is harmless and means scaling
+// up later only requires changing the replica count.
+//
+// The bank-vaults operator exposes each pod through its own per-pod ClusterIP
+// service named "openbao-<ordinal>" (it does NOT create a StatefulSet headless
+// service), so the resolvable address is "openbao-<i>.<namespace>.svc.cluster.local"
+// — not the "pod.headless-svc.namespace" pattern. Using the latter yields an
+// extra DNS label that never resolves, deadlocking the Raft bootstrap.
+func buildRetryJoinAddrs(replicas int, namespace string) []string {
+	addrs := make([]string, 0, replicas)
+	for i := 0; i < replicas; i++ {
+		addrs = append(addrs, fmt.Sprintf("http://openbao-%d.%s.svc.cluster.local:8200", i, namespace))
+	}
+	return addrs
+}
+
 // ApplyVaultCR renders the Bank-Vaults Vault CR template and applies it to the cluster.
 func (o *OpenBaoInstaller) ApplyVaultCR() error {
 	tmpl, err := template.New("vault-cr").Parse(string(vaultCRTemplate))
@@ -378,15 +395,7 @@ func (o *OpenBaoInstaller) ApplyVaultCR() error {
 		return fmt.Errorf("parsing vault CR template: %w", err)
 	}
 
-	// Build retry_join addresses for Raft so each node can autonomously
-	// find and join the cluster leader. For a single replica this produces
-	// one self-referencing address, which is harmless and means scaling up
-	// later only requires changing the replica count.
-	var retryJoinAddrs []string
-	for i := 0; i < o.Config.Replicas; i++ {
-		addr := fmt.Sprintf("http://openbao-%d.%s.%s.svc.cluster.local:8200", i, openBaoHeadlessService, o.Config.Namespace)
-		retryJoinAddrs = append(retryJoinAddrs, addr)
-	}
+	retryJoinAddrs := buildRetryJoinAddrs(o.Config.Replicas, o.Config.Namespace)
 
 	data := vaultCRTemplateData{
 		Namespace:         o.Config.Namespace,

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -370,16 +370,10 @@ type vaultCRTemplateData struct {
 	RetryJoinAddrs    []string
 }
 
-// buildRetryJoinAddrs builds the Raft retry_join addresses so each node can
-// autonomously find and join the cluster leader. For a single replica this
-// produces one self-referencing address, which is harmless and means scaling
-// up later only requires changing the replica count.
-//
-// The bank-vaults operator exposes each pod through its own per-pod ClusterIP
-// service named "openbao-<ordinal>" (it does NOT create a StatefulSet headless
-// service), so the resolvable address is "openbao-<i>.<namespace>.svc.cluster.local"
-// — not the "pod.headless-svc.namespace" pattern. Using the latter yields an
-// extra DNS label that never resolves, deadlocking the Raft bootstrap.
+// Build retry_join addresses for Raft so each node can autonomously
+// find and join the cluster leader. For a single replica this produces
+// one self-referencing address, which is harmless and means scaling up
+// later only requires changing the replica count.
 func buildRetryJoinAddrs(replicas int, namespace string) []string {
 	addrs := make([]string, 0, replicas)
 	for i := 0; i < replicas; i++ {

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -43,6 +43,12 @@ const (
 	pollInterval            = 5 * time.Second
 	maxPollInterval         = 30 * time.Second
 
+	// defaultReadinessTimeoutPerReplica is added to the base timeout for each
+	// replica when waiting for all OpenBao pods to become ready. Pods come up
+	// sequentially and each must join Raft before the next, so the total wait
+	// scales with the deployment size.
+	defaultReadinessTimeoutPerReplica = 3 * time.Minute
+
 	// vaultCRLabelKey/Value identify resources (pods, PVCs) managed by the
 	// bank-vaults operator for our "openbao" Vault CR.
 	vaultCRLabelKey   = "vault_cr"
@@ -77,8 +83,11 @@ type OpenBaoInstallerConfig struct {
 	Replicas          int
 	StorageSize       string
 	Timeout           time.Duration
-	AgeRecipient      string
-	AgeKeyPath        string
+	// ReadinessTimeoutPerReplica is added to Timeout per replica when waiting
+	// for all pods to become ready. Defaulted in validateConfig when unset.
+	ReadinessTimeoutPerReplica time.Duration
+	AgeRecipient               string
+	AgeKeyPath                 string
 }
 
 // OpenBaoInstaller orchestrates the Day-0 bootstrap, configuration, and DR
@@ -145,6 +154,9 @@ func (o *OpenBaoInstaller) validateConfig() error {
 	}
 	if o.Config.Timeout <= 0 {
 		o.Config.Timeout = defaultTimeout
+	}
+	if o.Config.ReadinessTimeoutPerReplica <= 0 {
+		o.Config.ReadinessTimeoutPerReplica = defaultReadinessTimeoutPerReplica
 	}
 	return nil
 }
@@ -528,6 +540,14 @@ func (o *OpenBaoInstaller) ensureUnsealSecret(secretsClient corev1client.SecretI
 	return nil
 }
 
+// readinessTimeout returns how long to wait for all pods to become ready.
+// StatefulSet pods start sequentially and each Raft member must initialize and
+// join before the next comes up, so the wait grows with replica count: the
+// configured base timeout plus a per-replica allowance.
+func (o *OpenBaoInstaller) readinessTimeout() time.Duration {
+	return o.Config.Timeout + o.Config.ReadinessTimeoutPerReplica*time.Duration(o.Config.Replicas)
+}
+
 // WaitForPodsReady polls until the expected number of vault pods (matching the
 // configured replica count) are in Running phase with all containers Ready.
 // This ensures scaling operations have fully completed before reporting success.
@@ -535,7 +555,7 @@ func (o *OpenBaoInstaller) WaitForPodsReady() error {
 	selector := vaultPodLabelSelector
 	expected := o.Config.Replicas
 
-	return o.pollUntil("waiting for all OpenBao pods to be ready", func() (bool, error) {
+	return o.pollUntilTimeout(o.readinessTimeout(), "waiting for all OpenBao pods to be ready", func() (bool, error) {
 		list, err := o.Clientset.CoreV1().Pods(o.Config.Namespace).List(o.ctx, metav1.ListOptions{
 			LabelSelector: selector,
 		})
@@ -772,12 +792,19 @@ func (o *OpenBaoInstaller) waitForPVCsGone() error {
 // true or the configured timeout expires. timeoutMsg describes the operation
 // for the timeout error message.
 func (o *OpenBaoInstaller) pollUntil(timeoutMsg string, check func() (bool, error)) error {
-	deadline := time.Now().Add(o.Config.Timeout)
+	return o.pollUntilTimeout(o.Config.Timeout, timeoutMsg, check)
+}
+
+// pollUntilTimeout is pollUntil with an explicit timeout, used by steps (e.g.
+// readiness) whose duration scales with the deployment size rather than the
+// fixed per-step timeout.
+func (o *OpenBaoInstaller) pollUntilTimeout(timeout time.Duration, timeoutMsg string, check func() (bool, error)) error {
+	deadline := time.Now().Add(timeout)
 	interval := pollInterval
 
 	for {
 		if time.Now().After(deadline) {
-			return fmt.Errorf("timed out %s (timeout: %s)", timeoutMsg, o.Config.Timeout)
+			return fmt.Errorf("timed out %s (timeout: %s)", timeoutMsg, timeout)
 		}
 
 		done, err := check()

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -47,10 +47,26 @@ const (
 	// bank-vaults operator for our "openbao" Vault CR.
 	vaultCRLabelKey   = "vault_cr"
 	vaultCRLabelValue = "openbao"
+
+	// appNameLabelKey/Value distinguish the OpenBao server pods from the
+	// operator's configurer pod — both carry vault_cr=openbao, but only the
+	// server pods are app.kubernetes.io/name=vault. Pod counting must exclude
+	// the configurer, otherwise readiness never matches the replica count.
+	appNameLabelKey        = "app.kubernetes.io/name"
+	appNameLabelValueVault = "vault"
 )
 
-// vaultCRLabelSelector selects all resources belonging to the "openbao" Vault CR.
+// vaultCRLabelSelector selects all resources belonging to the "openbao" Vault CR
+// (server pods, the configurer pod, and PVCs).
 var vaultCRLabelSelector = labels.SelectorFromSet(labels.Set{vaultCRLabelKey: vaultCRLabelValue}).String()
+
+// vaultPodLabelSelector selects only the OpenBao server pods, excluding the
+// configurer pod (which also carries vault_cr=openbao). Used for readiness and
+// termination checks that must count exactly the StatefulSet replicas.
+var vaultPodLabelSelector = labels.SelectorFromSet(labels.Set{
+	vaultCRLabelKey: vaultCRLabelValue,
+	appNameLabelKey: appNameLabelValueVault,
+}).String()
 
 // OpenBaoInstallerConfig holds all configurable parameters for the OpenBao bootstrap.
 type OpenBaoInstallerConfig struct {
@@ -516,7 +532,7 @@ func (o *OpenBaoInstaller) ensureUnsealSecret(secretsClient corev1client.SecretI
 // configured replica count) are in Running phase with all containers Ready.
 // This ensures scaling operations have fully completed before reporting success.
 func (o *OpenBaoInstaller) WaitForPodsReady() error {
-	selector := vaultCRLabelSelector
+	selector := vaultPodLabelSelector
 	expected := o.Config.Replicas
 
 	return o.pollUntil("waiting for all OpenBao pods to be ready", func() (bool, error) {
@@ -716,7 +732,7 @@ func (o *OpenBaoInstaller) hasExistingDeployment() (bool, error) {
 // waitForVaultPodsGone polls until no pods with label vault_cr=openbao remain
 // in the target namespace, or until the context deadline is exceeded.
 func (o *OpenBaoInstaller) waitForVaultPodsGone() error {
-	selector := vaultCRLabelSelector
+	selector := vaultPodLabelSelector
 
 	return o.pollUntil("waiting for vault pods to terminate", func() (bool, error) {
 		list, err := o.Clientset.CoreV1().Pods(o.Config.Namespace).List(o.ctx, metav1.ListOptions{

--- a/internal/installer/openbao_test.go
+++ b/internal/installer/openbao_test.go
@@ -289,7 +289,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("openbao-%d", i),
 						Namespace: "vault",
-						Labels:    map[string]string{"vault_cr": "openbao"},
+						Labels:    map[string]string{"vault_cr": "openbao", "app.kubernetes.io/name": "vault"},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodRunning,
@@ -317,6 +317,57 @@ var _ = Describe("OpenBaoInstaller", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("does not count the configurer pod toward the replica count", func() {
+			// Pre-create the namespace
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "vault"}}
+			_, err := clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// One ready server pod (expected: 1).
+			serverPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openbao-0",
+					Namespace: "vault",
+					Labels:    map[string]string{"vault_cr": "openbao", "app.kubernetes.io/name": "vault"},
+				},
+				Status: corev1.PodStatus{
+					Phase:      corev1.PodRunning,
+					Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+				},
+			}
+			// The configurer pod also carries vault_cr=openbao — it must be
+			// excluded, otherwise activePods (2) never equals expected (1).
+			configurerPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openbao-configurer-abc123",
+					Namespace: "vault",
+					Labels:    map[string]string{"vault_cr": "openbao", "app.kubernetes.io/name": "vault-configurator"},
+				},
+				Status: corev1.PodStatus{
+					Phase:      corev1.PodRunning,
+					Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+				},
+			}
+			_, err = clientset.CoreV1().Pods("vault").Create(ctx, serverPod, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			_, err = clientset.CoreV1().Pods("vault").Create(ctx, configurerPod, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			inst := &installer.OpenBaoInstaller{
+				Clientset: clientset,
+				Logger:    bootstrap.NewStepLogger(true),
+				Config: installer.OpenBaoInstallerConfig{
+					Namespace: "vault",
+					Replicas:  1,
+					Timeout:   5 * time.Second,
+				},
+			}
+			inst.SetCtx(ctx)
+
+			err = inst.WaitForPodsReady()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("times out when fewer pods than expected exist", func() {
 			// Pre-create the namespace
 			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "vault"}}
@@ -328,7 +379,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "openbao-0",
 					Namespace: "vault",
-					Labels:    map[string]string{"vault_cr": "openbao"},
+					Labels:    map[string]string{"vault_cr": "openbao", "app.kubernetes.io/name": "vault"},
 				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
@@ -369,7 +420,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "openbao-0",
 					Namespace: "vault",
-					Labels:    map[string]string{"vault_cr": "openbao"},
+					Labels:    map[string]string{"vault_cr": "openbao", "app.kubernetes.io/name": "vault"},
 				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
@@ -382,7 +433,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "openbao-1",
 					Namespace:         "vault",
-					Labels:            map[string]string{"vault_cr": "openbao"},
+					Labels:            map[string]string{"vault_cr": "openbao", "app.kubernetes.io/name": "vault"},
 					DeletionTimestamp: &now,
 					Finalizers:        []string{"test-finalizer"}, // Required for DeletionTimestamp in fake
 				},
@@ -426,7 +477,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "openbao-0",
 					Namespace: "vault",
-					Labels:    map[string]string{"vault_cr": "openbao"},
+					Labels:    map[string]string{"vault_cr": "openbao", "app.kubernetes.io/name": "vault"},
 				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
@@ -1001,7 +1052,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "openbao-0",
 					Namespace: "vault",
-					Labels:    map[string]string{"vault_cr": "openbao"},
+					Labels:    map[string]string{"vault_cr": "openbao", "app.kubernetes.io/name": "vault"},
 				},
 				Status: corev1.PodStatus{Phase: corev1.PodRunning},
 			}

--- a/internal/installer/openbao_test.go
+++ b/internal/installer/openbao_test.go
@@ -506,6 +506,30 @@ var _ = Describe("OpenBaoInstaller", func() {
 		})
 	})
 
+	Describe("readiness timeout scaling", func() {
+		It("adds the per-replica allowance to the base timeout (5m + 3m/replica by default)", func() {
+			inst := &installer.OpenBaoInstaller{
+				Config: installer.OpenBaoInstallerConfig{Replicas: 3, Timeout: 5 * time.Minute},
+			}
+			// Defaults (incl. ReadinessTimeoutPerReplica) are applied here.
+			Expect(inst.ValidateConfig()).To(Succeed())
+			// 5m + 3m*3 = 14m
+			Expect(inst.ReadinessTimeout()).To(Equal(14 * time.Minute))
+		})
+
+		It("honors an explicit per-replica allowance", func() {
+			inst := &installer.OpenBaoInstaller{
+				Config: installer.OpenBaoInstallerConfig{
+					Replicas:                   5,
+					Timeout:                    2 * time.Minute,
+					ReadinessTimeoutPerReplica: 1 * time.Minute,
+				},
+			}
+			// 2m + 1m*5 = 7m
+			Expect(inst.ReadinessTimeout()).To(Equal(7 * time.Minute))
+		})
+	})
+
 	Describe("ExtractAndEncrypt", func() {
 		It("creates an encrypted DR backup file with password and unseal keys", func() {
 			if !sopsAndAgeAvailable() {

--- a/internal/installer/openbao_test.go
+++ b/internal/installer/openbao_test.go
@@ -595,7 +595,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 				BaoPassword:       "test-password",
 				Replicas:          1,
 				StorageSize:       "10Gi",
-				RetryJoinAddrs:    []string{"http://openbao-0.openbao.vault.svc.cluster.local:8200"},
+				RetryJoinAddrs:    []string{"http://openbao-0.vault.svc.cluster.local:8200"},
 			}
 
 			docs := renderTemplate(data)
@@ -662,9 +662,9 @@ var _ = Describe("OpenBaoInstaller", func() {
 
 		It("renders valid YAML with raft storage, PVCs, and retry_join for replicas=3", func() {
 			retryJoinAddrs := []string{
-				"http://openbao-0.openbao.vault.svc.cluster.local:8200",
-				"http://openbao-1.openbao.vault.svc.cluster.local:8200",
-				"http://openbao-2.openbao.vault.svc.cluster.local:8200",
+				"http://openbao-0.vault.svc.cluster.local:8200",
+				"http://openbao-1.vault.svc.cluster.local:8200",
+				"http://openbao-2.vault.svc.cluster.local:8200",
 			}
 
 			data := templateData{
@@ -715,10 +715,44 @@ var _ = Describe("OpenBaoInstaller", func() {
 			Expect(containerSpec).To(HaveKey("env"))
 			envVars := containerSpec["env"].([]interface{})
 			envNames := make([]string, 0, len(envVars))
+			envValues := make(map[string]string, len(envVars))
 			for _, e := range envVars {
-				envNames = append(envNames, e.(map[string]interface{})["name"].(string))
+				m := e.(map[string]interface{})
+				name := m["name"].(string)
+				envNames = append(envNames, name)
+				if v, ok := m["value"].(string); ok {
+					envValues[name] = v
+				}
 			}
 			Expect(envNames).To(ContainElements("POD_NAME", "BAO_CLUSTER_ADDR", "BAO_API_ADDR"))
+
+			// The peer/cluster addresses must target the per-pod service
+			// ("$(POD_NAME).<namespace>...") with no extra ".openbao" headless
+			// label, otherwise the Raft leader can't replicate to followers
+			// (regression guard).
+			Expect(envValues["BAO_CLUSTER_ADDR"]).To(Equal("http://$(POD_NAME).vault.svc.cluster.local:8201"))
+			Expect(envValues["BAO_API_ADDR"]).To(Equal("http://$(POD_NAME).vault.svc.cluster.local:8200"))
+		})
+	})
+
+	Describe("BuildRetryJoinAddrs", func() {
+		It("targets the per-pod ClusterIP service, not a headless service", func() {
+			// bank-vaults exposes each pod via a per-pod service "openbao-<i>",
+			// so the resolvable name is "openbao-<i>.<namespace>.svc.cluster.local".
+			// An extra ".openbao" headless-service label never resolves and
+			// deadlocks the Raft bootstrap (regression guard).
+			addrs := installer.BuildRetryJoinAddrs(3, "second")
+			Expect(addrs).To(Equal([]string{
+				"http://openbao-0.second.svc.cluster.local:8200",
+				"http://openbao-1.second.svc.cluster.local:8200",
+				"http://openbao-2.second.svc.cluster.local:8200",
+			}))
+		})
+
+		It("produces a single self-referencing address for one replica", func() {
+			Expect(installer.BuildRetryJoinAddrs(1, "vault")).To(Equal([]string{
+				"http://openbao-0.vault.svc.cluster.local:8200",
+			}))
 		})
 	})
 

--- a/internal/installer/openbao_test.go
+++ b/internal/installer/openbao_test.go
@@ -726,10 +726,6 @@ var _ = Describe("OpenBaoInstaller", func() {
 			}
 			Expect(envNames).To(ContainElements("POD_NAME", "BAO_CLUSTER_ADDR", "BAO_API_ADDR"))
 
-			// The peer/cluster addresses must target the per-pod service
-			// ("$(POD_NAME).<namespace>...") with no extra ".openbao" headless
-			// label, otherwise the Raft leader can't replicate to followers
-			// (regression guard).
 			Expect(envValues["BAO_CLUSTER_ADDR"]).To(Equal("http://$(POD_NAME).vault.svc.cluster.local:8201"))
 			Expect(envValues["BAO_API_ADDR"]).To(Equal("http://$(POD_NAME).vault.svc.cluster.local:8200"))
 		})
@@ -737,10 +733,6 @@ var _ = Describe("OpenBaoInstaller", func() {
 
 	Describe("BuildRetryJoinAddrs", func() {
 		It("targets the per-pod ClusterIP service, not a headless service", func() {
-			// bank-vaults exposes each pod via a per-pod service "openbao-<i>",
-			// so the resolvable name is "openbao-<i>.<namespace>.svc.cluster.local".
-			// An extra ".openbao" headless-service label never resolves and
-			// deadlocks the Raft bootstrap (regression guard).
 			addrs := installer.BuildRetryJoinAddrs(3, "second")
 			Expect(addrs).To(Equal([]string{
 				"http://openbao-0.second.svc.cluster.local:8200",


### PR DESCRIPTION
Fix OpenBao HA (multi-replica Raft) install failing to come up. All peer DNS names used a `pod.openbao.<ns>.svc.cluster.local` form, which assumes a StatefulSet **headless service** named `openbao`. The bank-vaults operator doesn't create one — it exposes each pod via a per-pod ClusterIP service `openbao-<ordinal>`, so the resolvable name is `openbao-<i>.<ns>.svc.cluster.local`. The extra `.openbao` label never resolved (`no such host`).

Two addresses were affected:

- **`retry_join`** (`openbao.go`) — followers couldn't find the leader to join → Raft bootstrap deadlocked, pods crashlooped.
- **`BAO_CLUSTER_ADDR` / `BAO_API_ADDR`** (`vault-cr.yaml`) — even after a follower joined, it advertised an unresolvable peer address, so the leader couldn't heartbeat/replicate and the follower never received the initialized barrier (stuck `security barrier not initialized`, `2/3` Ready).

## Changes

- Drop the `.openbao` segment from `retry_join` addresses; extract construction into `buildRetryJoinAddrs` and remove the now-unused `openBaoHeadlessService` const.
- Drop the `.openbao` segment from `BAO_CLUSTER_ADDR` / `BAO_API_ADDR` in the Vault CR template.
- Tests: regression coverage for `buildRetryJoinAddrs` and assertions on the rendered peer-address env values.

## Testing

`go test ./internal/installer/` passes. Verified against a 3-replica install: all pods reach `3/3` Ready and form a healthy Raft cluster.
