### PR TITLE
fix(openbao): fix operator cleanup

### DIFF
--- a/cli/cmd/install_openbao.go
+++ b/cli/cmd/install_openbao.go
@@ -141,7 +141,7 @@ func AddInstallOpenBaoCmd(install *cobra.Command, opts *GlobalOptions) {
 	openbao.cmd.Flags().StringVar(&openbao.Opts.SecretsEngineName, "secrets-engine", "cs-secrets-engine", "Name of the KV-v2 secrets engine to provision")
 	openbao.cmd.Flags().StringVar(&openbao.Opts.BaoUsername, "bao-user", "admin", "Username for the userpass auth method (ignored on restore, uses DR backup value)")
 	openbao.cmd.Flags().StringVar(&openbao.Opts.DRBackupPath, "dr-backup-path", "", "Path for SOPS-encrypted DR backup file (required)")
-	openbao.cmd.Flags().IntVar(&openbao.Opts.Replicas, "replicas", 1, "Number of OpenBao replicas (1 for single-node, odd number >= 3 for HA)")
+	openbao.cmd.Flags().IntVar(&openbao.Opts.Replicas, "replicas", 3, "Number of OpenBao replicas (1 for single-node, odd number >= 3 for HA)")
 	openbao.cmd.Flags().StringVar(&openbao.Opts.StorageSize, "storage-size", "10Gi", "PVC storage size for each OpenBao replica")
 	openbao.cmd.Flags().DurationVar(&openbao.Opts.Timeout, "timeout", 5*time.Minute, "Timeout for waiting on initialization")
 	openbao.cmd.Flags().StringVarP(&openbao.Opts.AgeKeyFile, "age-key-file", "k", "", "Path to age private key file for SOPS encryption/decryption (auto-detected if not set)")

--- a/docs/oms_install_openbao.md
+++ b/docs/oms_install_openbao.md
@@ -42,7 +42,7 @@ $ oms install openbao --dr-backup-path ./backups/cluster-1.enc.json --timeout 10
       --dr-backup-path string   Path for SOPS-encrypted DR backup file (required)
   -h, --help                    help for openbao
   -n, --namespace string        Kubernetes namespace for OpenBao deployment (default "vault")
-      --replicas int            Number of OpenBao replicas (1 for single-node, odd number >= 3 for HA) (default 1)
+      --replicas int            Number of OpenBao replicas (1 for single-node, odd number >= 3 for HA) (default 3)
       --secrets-engine string   Name of the KV-v2 secrets engine to provision (default "cs-secrets-engine")
       --storage-size string     PVC storage size for each OpenBao replica (default "10Gi")
       --timeout duration        Timeout for waiting on initialization (default 5m0s)

--- a/internal/installer/export_test.go
+++ b/internal/installer/export_test.go
@@ -49,8 +49,8 @@ func (o *OpenBaoInstaller) ReleaseExistsInTargetNamespace(releaseName string) (b
 	return o.releaseExistsInTargetNamespace(releaseName)
 }
 
-func (o *OpenBaoInstaller) OperatorInstalledClusterWide() (bool, error) {
-	return o.operatorInstalledClusterWide()
+func (o *OpenBaoInstaller) OperatorRunningClusterWide() (bool, error) {
+	return o.operatorRunningClusterWide()
 }
 
 func BuildRetryJoinAddrs(replicas int, namespace string) []string {

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -60,6 +60,10 @@ const (
 	// the configurer, otherwise readiness never matches the replica count.
 	appNameLabelKey        = "app.kubernetes.io/name"
 	appNameLabelValueVault = "vault"
+
+	// operatorName is the bank-vaults operator's Helm release name and the name
+	// of its cluster-scoped RBAC resources (ClusterRole/ClusterRoleBinding).
+	operatorName = "vault-operator"
 )
 
 // vaultCRLabelSelector selects all resources belonging to the "openbao" Vault CR
@@ -73,6 +77,10 @@ var vaultPodLabelSelector = labels.SelectorFromSet(labels.Set{
 	vaultCRLabelKey: vaultCRLabelValue,
 	appNameLabelKey: appNameLabelValueVault,
 }).String()
+
+// operatorLabelSelector selects the bank-vaults operator's Deployment/pods,
+// used to detect whether an operator is actually running anywhere in the cluster.
+var operatorLabelSelector = labels.SelectorFromSet(labels.Set{appNameLabelKey: operatorName}).String()
 
 // OpenBaoInstallerConfig holds all configurable parameters for the OpenBao bootstrap.
 type OpenBaoInstallerConfig struct {
@@ -317,7 +325,7 @@ func (o *OpenBaoInstaller) GeneratePassword() error {
 // is sufficient for the entire cluster.
 func (o *OpenBaoInstaller) DeployBankVaultsOperator() error {
 	cfg := ChartConfig{
-		ReleaseName: "vault-operator",
+		ReleaseName: operatorName,
 		ChartName:   bankVaultsChartRepo + "/" + bankVaultsChartName,
 		Version:     bankVaultsChartVersion,
 		Namespace:   o.Config.Namespace,
@@ -336,19 +344,48 @@ func (o *OpenBaoInstaller) DeployBankVaultsOperator() error {
 		return o.Helm.UpgradeChart(o.ctx, cfg, UpgradeChartOptions{})
 	}
 
-	// Release not found in target namespace. Skip when the operator is already
-	// deployed cluster-wide (in another namespace) — one instance suffices.
-	clusterWide, err := o.operatorInstalledClusterWide()
+	// Release not found in target namespace. Skip when an operator Deployment is
+	// already running cluster-wide (e.g. in another namespace) — one instance
+	// suffices for the entire cluster.
+	running, err := o.operatorRunningClusterWide()
 	if err != nil {
 		return err
 	}
-	if clusterWide {
-		o.Logger.Logf("Bank-Vaults Operator already installed in the cluster, skipping deployment")
+	if running {
+		o.Logger.Logf("Bank-Vaults Operator already running in the cluster, skipping deployment")
 		return nil
+	}
+
+	// No operator is running. A prior incomplete teardown (e.g. deleting the
+	// operator's namespace) may have left orphaned cluster-scoped RBAC, which
+	// would make the fresh Helm install conflict on the pre-existing, unowned
+	// ClusterRole/ClusterRoleBinding. Remove it before installing.
+	if err := o.cleanOrphanedOperatorRBAC(); err != nil {
+		return err
 	}
 
 	// Operator does not exist — perform fresh install.
 	return o.Helm.InstallChart(o.ctx, cfg, InstallChartOptions{})
+}
+
+// cleanOrphanedOperatorRBAC best-effort deletes the operator's cluster-scoped
+// ClusterRole and ClusterRoleBinding. These are not garbage-collected when the
+// operator's namespace is deleted, so they can linger after a teardown and make
+// a subsequent Helm install fail. NotFound is tolerated — there may be nothing
+// to clean on a genuinely fresh cluster.
+func (o *OpenBaoInstaller) cleanOrphanedOperatorRBAC() error {
+	crErr := o.Clientset.RbacV1().ClusterRoles().Delete(o.ctx, operatorName, metav1.DeleteOptions{})
+	if crErr != nil && !k8serrors.IsNotFound(crErr) {
+		return fmt.Errorf("deleting orphaned %s ClusterRole: %w", operatorName, crErr)
+	}
+	crbErr := o.Clientset.RbacV1().ClusterRoleBindings().Delete(o.ctx, operatorName, metav1.DeleteOptions{})
+	if crbErr != nil && !k8serrors.IsNotFound(crbErr) {
+		return fmt.Errorf("deleting orphaned %s ClusterRoleBinding: %w", operatorName, crbErr)
+	}
+	if crErr == nil || crbErr == nil {
+		o.Logger.Logf("Removed orphaned %s cluster-scoped RBAC left by a prior install", operatorName)
+	}
+	return nil
 }
 
 // releaseExistsInTargetNamespace reports whether the named Helm release exists
@@ -371,18 +408,21 @@ func (o *OpenBaoInstaller) releaseExistsInTargetNamespace(releaseName string) (b
 	return rel != nil, nil
 }
 
-// operatorInstalledClusterWide reports whether the bank-vaults operator is
-// already installed anywhere in the cluster, detected via its cluster-scoped
-// "vault-operator" ClusterRole.
-func (o *OpenBaoInstaller) operatorInstalledClusterWide() (bool, error) {
-	_, err := o.Clientset.RbacV1().ClusterRoles().Get(o.ctx, "vault-operator", metav1.GetOptions{})
-	if err == nil {
-		return true, nil
+// operatorRunningClusterWide reports whether a bank-vaults operator Deployment
+// is actually running anywhere in the cluster. Detection is by the operator's
+// Deployment (app.kubernetes.io/name=vault-operator), not its cluster-scoped
+// ClusterRole: a ClusterRole can be left orphaned after an incomplete teardown
+// (deleting a namespace does not remove cluster-scoped resources), and keying
+// the skip decision off it would wrongly suppress deploying an operator that no
+// longer exists — leaving the Vault CR unreconciled.
+func (o *OpenBaoInstaller) operatorRunningClusterWide() (bool, error) {
+	deps, err := o.Clientset.AppsV1().Deployments(metav1.NamespaceAll).List(o.ctx, metav1.ListOptions{
+		LabelSelector: operatorLabelSelector,
+	})
+	if err != nil {
+		return false, fmt.Errorf("listing %s deployments: %w", operatorName, err)
 	}
-	if !k8serrors.IsNotFound(err) {
-		return false, fmt.Errorf("checking for existing vault-operator ClusterRole: %w", err)
-	}
-	return false, nil
+	return len(deps.Items) > 0, nil
 }
 
 // vaultCRTemplateData holds the values injected into the Vault CR template.

--- a/internal/installer/openbao.go
+++ b/internal/installer/openbao.go
@@ -409,12 +409,17 @@ func (o *OpenBaoInstaller) releaseExistsInTargetNamespace(releaseName string) (b
 }
 
 // operatorRunningClusterWide reports whether a bank-vaults operator Deployment
-// is actually running anywhere in the cluster. Detection is by the operator's
-// Deployment (app.kubernetes.io/name=vault-operator), not its cluster-scoped
-// ClusterRole: a ClusterRole can be left orphaned after an incomplete teardown
-// (deleting a namespace does not remove cluster-scoped resources), and keying
-// the skip decision off it would wrongly suppress deploying an operator that no
-// longer exists — leaving the Vault CR unreconciled.
+// is actually running (has at least one available replica) anywhere in the
+// cluster. Detection is by the operator's Deployment
+// (app.kubernetes.io/name=vault-operator), not its cluster-scoped ClusterRole: a
+// ClusterRole can be left orphaned after an incomplete teardown (deleting a
+// namespace does not remove cluster-scoped resources), and keying the skip
+// decision off it would wrongly suppress deploying an operator that no longer
+// exists — leaving the Vault CR unreconciled.
+//
+// Availability (not mere existence) is required: a Deployment scaled to zero or
+// stuck with no ready pods cannot reconcile the Vault CR, so it must not
+// suppress a (re)deploy.
 func (o *OpenBaoInstaller) operatorRunningClusterWide() (bool, error) {
 	deps, err := o.Clientset.AppsV1().Deployments(metav1.NamespaceAll).List(o.ctx, metav1.ListOptions{
 		LabelSelector: operatorLabelSelector,
@@ -422,7 +427,12 @@ func (o *OpenBaoInstaller) operatorRunningClusterWide() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("listing %s deployments: %w", operatorName, err)
 	}
-	return len(deps.Items) > 0, nil
+	for i := range deps.Items {
+		if deps.Items[i].Status.AvailableReplicas > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // vaultCRTemplateData holds the values injected into the Vault CR template.

--- a/internal/installer/openbao_test.go
+++ b/internal/installer/openbao_test.go
@@ -152,6 +152,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 					Namespace: "other-ns",
 					Labels:    map[string]string{"app.kubernetes.io/name": "vault-operator"},
 				},
+				Status: appsv1.DeploymentStatus{AvailableReplicas: 1},
 			}
 			_, err = clientset.AppsV1().Deployments("other-ns").Create(ctx, dep, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -1006,13 +1007,14 @@ var _ = Describe("OpenBaoInstaller", func() {
 	})
 
 	Describe("operatorRunningClusterWide", func() {
-		It("returns true when an operator Deployment runs in any namespace", func() {
+		It("returns true when an available operator Deployment runs in any namespace", func() {
 			dep := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "vault-operator",
 					Namespace: "other-ns",
 					Labels:    map[string]string{"app.kubernetes.io/name": "vault-operator"},
 				},
+				Status: appsv1.DeploymentStatus{AvailableReplicas: 1},
 			}
 			_, err := clientset.AppsV1().Deployments("other-ns").Create(ctx, dep, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -1027,6 +1029,32 @@ var _ = Describe("OpenBaoInstaller", func() {
 			running, err := inst.OperatorRunningClusterWide()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(running).To(BeTrue())
+		})
+
+		It("returns false when the operator Deployment has no available replicas", func() {
+			// A Deployment that exists but is scaled to zero / has no ready pods
+			// cannot reconcile the Vault CR, so it must not suppress a (re)deploy.
+			dep := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vault-operator",
+					Namespace: "other-ns",
+					Labels:    map[string]string{"app.kubernetes.io/name": "vault-operator"},
+				},
+				Status: appsv1.DeploymentStatus{AvailableReplicas: 0},
+			}
+			_, err := clientset.AppsV1().Deployments("other-ns").Create(ctx, dep, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			inst := &installer.OpenBaoInstaller{
+				Clientset: clientset,
+				Logger:    bootstrap.NewStepLogger(true),
+				Config:    installer.OpenBaoInstallerConfig{Namespace: "vault"},
+			}
+			inst.SetCtx(ctx)
+
+			running, err := inst.OperatorRunningClusterWide()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(running).To(BeFalse())
 		})
 
 		It("returns false when only an orphaned ClusterRole exists (no Deployment)", func() {

--- a/internal/installer/openbao_test.go
+++ b/internal/installer/openbao_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,7 +64,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 			// FindRelease returns nil (no existing release in target namespace)
 			helmMock.EXPECT().FindRelease("vault", "vault-operator").Return(nil, nil)
 
-			// No ClusterRole exists (fake clientset has nothing), so InstallChart is called
+			// No operator Deployment exists (fake clientset has nothing), so InstallChart is called
 			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
 				return cfg.ReleaseName == "vault-operator" &&
 					cfg.ChartName == "oci://ghcr.io/bank-vaults/helm-charts/vault-operator" &&
@@ -86,7 +87,7 @@ var _ = Describe("OpenBaoInstaller", func() {
 
 		It("performs fresh install when target namespace does not exist", func() {
 			// Namespace "new-ns" is NOT created — FindRelease must be skipped.
-			// No ClusterRole exists, so InstallChart is called directly.
+			// No operator Deployment exists, so InstallChart is called directly.
 			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
 				return cfg.ReleaseName == "vault-operator" &&
 					cfg.Namespace == "new-ns" &&
@@ -143,11 +144,16 @@ var _ = Describe("OpenBaoInstaller", func() {
 			// FindRelease returns nil (not in target namespace)
 			helmMock.EXPECT().FindRelease("second", "vault-operator").Return(nil, nil)
 
-			// Pre-create the ClusterRole to simulate operator installed elsewhere
-			cr := &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: "vault-operator"},
+			// A running operator Deployment in another namespace simulates the
+			// operator being installed elsewhere.
+			dep := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vault-operator",
+					Namespace: "other-ns",
+					Labels:    map[string]string{"app.kubernetes.io/name": "vault-operator"},
+				},
 			}
-			_, err = clientset.RbacV1().ClusterRoles().Create(ctx, cr, metav1.CreateOptions{})
+			_, err = clientset.AppsV1().Deployments("other-ns").Create(ctx, dep, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			inst := &installer.OpenBaoInstaller{
@@ -161,6 +167,46 @@ var _ = Describe("OpenBaoInstaller", func() {
 			// Should not call InstallChart or UpgradeChart
 			err = inst.DeployBankVaultsOperator()
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("installs and cleans orphaned RBAC when the ClusterRole lingers but no operator runs", func() {
+			// Pre-create the namespace so FindRelease is reachable.
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "vault"}}
+			_, err := clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			helmMock.EXPECT().FindRelease("vault", "vault-operator").Return(nil, nil)
+
+			// Orphaned cluster-scoped RBAC from a torn-down install, but NO
+			// operator Deployment anywhere — the regression scenario.
+			cr := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "vault-operator"}}
+			_, err = clientset.RbacV1().ClusterRoles().Create(ctx, cr, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			crb := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "vault-operator"}}
+			_, err = clientset.RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Must perform a fresh install rather than skip.
+			helmMock.EXPECT().InstallChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				return cfg.ReleaseName == "vault-operator" && cfg.Namespace == "vault"
+			}), mock.Anything).Return(nil)
+
+			inst := &installer.OpenBaoInstaller{
+				Helm:      helmMock,
+				Clientset: clientset,
+				Logger:    bootstrap.NewStepLogger(true),
+				Config:    installer.OpenBaoInstallerConfig{Namespace: "vault"},
+			}
+			inst.SetCtx(ctx)
+
+			err = inst.DeployBankVaultsOperator()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Orphaned RBAC must have been removed before install.
+			_, err = clientset.RbacV1().ClusterRoles().Get(ctx, "vault-operator", metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
+			_, err = clientset.RbacV1().ClusterRoleBindings().Get(ctx, "vault-operator", metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("returns an error when Helm InstallChart fails", func() {
@@ -959,8 +1005,32 @@ var _ = Describe("OpenBaoInstaller", func() {
 		})
 	})
 
-	Describe("operatorInstalledClusterWide", func() {
-		It("returns true when the vault-operator ClusterRole exists", func() {
+	Describe("operatorRunningClusterWide", func() {
+		It("returns true when an operator Deployment runs in any namespace", func() {
+			dep := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vault-operator",
+					Namespace: "other-ns",
+					Labels:    map[string]string{"app.kubernetes.io/name": "vault-operator"},
+				},
+			}
+			_, err := clientset.AppsV1().Deployments("other-ns").Create(ctx, dep, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			inst := &installer.OpenBaoInstaller{
+				Clientset: clientset,
+				Logger:    bootstrap.NewStepLogger(true),
+				Config:    installer.OpenBaoInstallerConfig{Namespace: "vault"},
+			}
+			inst.SetCtx(ctx)
+
+			running, err := inst.OperatorRunningClusterWide()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(running).To(BeTrue())
+		})
+
+		It("returns false when only an orphaned ClusterRole exists (no Deployment)", func() {
+			// A lingering ClusterRole must NOT be mistaken for a running operator.
 			cr := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "vault-operator"}}
 			_, err := clientset.RbacV1().ClusterRoles().Create(ctx, cr, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -972,22 +1042,9 @@ var _ = Describe("OpenBaoInstaller", func() {
 			}
 			inst.SetCtx(ctx)
 
-			clusterWide, err := inst.OperatorInstalledClusterWide()
+			running, err := inst.OperatorRunningClusterWide()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(clusterWide).To(BeTrue())
-		})
-
-		It("returns false when the ClusterRole does not exist", func() {
-			inst := &installer.OpenBaoInstaller{
-				Clientset: clientset,
-				Logger:    bootstrap.NewStepLogger(true),
-				Config:    installer.OpenBaoInstallerConfig{Namespace: "vault"},
-			}
-			inst.SetCtx(ctx)
-
-			clusterWide, err := inst.OperatorInstalledClusterWide()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(clusterWide).To(BeFalse())
+			Expect(running).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
## What

A default `oms install openbao` could silently do nothing: every step reported success, but the `vault` namespace stayed empty and the command hung at "Waiting for initialization".

Root cause: `DeployBankVaultsOperator` decided the operator was "already installed cluster-wide" based **solely on the cluster-scoped `vault-operator` ClusterRole**. Cluster-scoped resources are not garbage-collected when a namespace is deleted, so after any incomplete teardown (e.g. `kubectl delete ns`) the ClusterRole lingers with no operator behind it. The installer then skipped deploying the operator, leaving the Vault CR unreconciled — no StatefulSet, no pods, no unseal secret — so the install waited forever.

## Changes

- **Detect the operator by its Deployment, not its ClusterRole.** `operatorInstalledClusterWide` → `operatorRunningClusterWide`, which lists Deployments labeled `app.kubernetes.io/name=vault-operator` across all namespaces. A lingering ClusterRole no longer masquerades as a running operator.
- **Auto-clean orphaned RBAC before a fresh install.** New `cleanOrphanedOperatorRBAC` best-effort deletes the `vault-operator` ClusterRole/ClusterRoleBinding (tolerating NotFound), so the subsequent Helm install doesn't conflict on pre-existing, unowned cluster-scoped resources.
- Added an `operatorName` constant and `operatorLabelSelector`.
- **Default `--replicas` 1 → 3** so the out-of-the-box install is an HA Raft cluster. (Note: a default install now requires a cluster that can schedule 3 replicas and provisions 3× storage.)

## Tests

- Operator-presence detection now simulated via a Deployment instead of a ClusterRole.
- New regression test: orphaned ClusterRole/ClusterRoleBinding + no operator Deployment → still performs a fresh install **and** removes the orphaned RBAC.
- Detection test asserts a lone ClusterRole is not treated as a running operator.

## Testing

`go test ./internal/installer/` passes; linter clean. Verified end-to-end: with the orphaned RBAC present, the rebuilt binary now deploys the operator and the install completes.
