### PR TITLE
feat(installer): add ArgoCD, vault secret sync, and pc-apps as a pre-step in the dependencies phase

### DIFF
--- a/cli/cmd/bootstrap_gcp.go
+++ b/cli/cmd/bootstrap_gcp.go
@@ -200,7 +200,7 @@ func (c *BootstrapGcpCmd) BootstrapGcp() error {
 	}
 
 	packageName := "<package-name>-installer"
-	installCmd := "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt"
+	installCmd := "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt --vault /etc/codesphere/secrets/prod.vault.yaml"
 	if gcp.RegistryType(bs.Env.RegistryType) == gcp.RegistryTypeGitHub {
 		log.Printf("You set a GitHub PAT for direct image access. Make sure to use a lite package, as VM root disk sizes are reduced.")
 		installCmd += " -s load-container-images"

--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -6,6 +6,9 @@ package cmd
 import (
 	"github.com/codesphere-cloud/cs-go/pkg/io"
 	"github.com/codesphere-cloud/oms/internal/env"
+	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/installer/argocd"
+	"github.com/codesphere-cloud/oms/internal/system"
 	"github.com/codesphere-cloud/oms/internal/util"
 	"github.com/spf13/cobra"
 )
@@ -28,6 +31,13 @@ type InstallCodesphereOpts struct {
 	CodesphereOnly   bool
 	DirectConnection bool
 	AutoApprove      bool
+	// ArgoCD deployment (pre-step in Phase 2)
+	SkipArgo             bool
+	ArgoCDVersion        string
+	ArgoCDRegistryURL    string
+	ArgoCDForceConflicts bool
+	ArgoCDRepoURL        string
+	ArgoCDValues         []string
 }
 
 func (c *InstallCodesphereCmd) RunE(_ *cobra.Command, _ []string) error {
@@ -67,12 +77,18 @@ func AddInstallCodesphereCmd(install *cobra.Command, opts *GlobalOptions) {
 	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.Package, "package", "p", "", "Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from")
 	codesphere.cmd.PersistentFlags().BoolVarP(&codesphere.Opts.Force, "force", "f", false, "Enforce package extraction")
 	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.Config, "config", "c", "", "Path to the Codesphere Private Cloud configuration file (yaml)")
-	codesphere.cmd.PersistentFlags().StringVar(&codesphere.Opts.Vault, "vault", "prod.vault.yaml", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
+	codesphere.cmd.PersistentFlags().StringVar(&codesphere.Opts.Vault, "vault", "", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
 	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.PrivKey, "priv-key", "k", "", "Path to the private key to encrypt/decrypt secrets")
 	codesphere.cmd.PersistentFlags().StringSliceVarP(&codesphere.Opts.SkipSteps, "skip-steps", "s", []string{}, "Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker")
 	codesphere.cmd.PersistentFlags().BoolVar(&codesphere.Opts.DirectConnection, "direct-connection", false, "Use direct connection for installation, requires having access to the cluster nodes from your machine")
 	codesphere.cmd.PersistentFlags().BoolVar(&codesphere.Opts.AutoApprove, "auto-approve", true, "Auto approve confirmation prompts with default values")
 	codesphere.cmd.Flags().BoolVar(&codesphere.Opts.CodesphereOnly, "codesphere-only", false, "Install only Codesphere without dependencies")
+	codesphere.cmd.PersistentFlags().BoolVar(&codesphere.Opts.SkipArgo, "skip-argo", false, "Skip ArgoCD, vault secret sync, and pc-apps deployment")
+	codesphere.cmd.PersistentFlags().StringVar(&codesphere.Opts.ArgoCDVersion, "argo-version", "", "ArgoCD Helm chart version to install")
+	codesphere.cmd.PersistentFlags().StringVar(&codesphere.Opts.ArgoCDRegistryURL, "argo-registry-url", "", "OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)")
+	codesphere.cmd.PersistentFlags().BoolVar(&codesphere.Opts.ArgoCDForceConflicts, "argo-force-conflicts", false, "Force SSA ownership conflicts during ArgoCD install")
+	codesphere.cmd.PersistentFlags().StringVar(&codesphere.Opts.ArgoCDRepoURL, "argo-repo", argocd.DefaultRepoURL, "ArgoCD Helm chart repository URL")
+	codesphere.cmd.PersistentFlags().StringArrayVar(&codesphere.Opts.ArgoCDValues, "argo-values", nil, "ArgoCD values YAML file (can be specified multiple times)")
 
 	util.MarkPersistentFlagRequired(codesphere.cmd, "package")
 	util.MarkPersistentFlagRequired(codesphere.cmd, "config")

--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -6,9 +6,7 @@ package cmd
 import (
 	"github.com/codesphere-cloud/cs-go/pkg/io"
 	"github.com/codesphere-cloud/oms/internal/env"
-	"github.com/codesphere-cloud/oms/internal/installer"
 	"github.com/codesphere-cloud/oms/internal/installer/argocd"
-	"github.com/codesphere-cloud/oms/internal/system"
 	"github.com/codesphere-cloud/oms/internal/util"
 	"github.com/spf13/cobra"
 )
@@ -32,7 +30,6 @@ type InstallCodesphereOpts struct {
 	DirectConnection bool
 	AutoApprove      bool
 	// ArgoCD deployment (pre-step in Phase 2)
-	SkipArgo             bool
 	ArgoCDVersion        string
 	ArgoCDRegistryURL    string
 	ArgoCDForceConflicts bool
@@ -79,11 +76,10 @@ func AddInstallCodesphereCmd(install *cobra.Command, opts *GlobalOptions) {
 	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.Config, "config", "c", "", "Path to the Codesphere Private Cloud configuration file (yaml)")
 	codesphere.cmd.PersistentFlags().StringVar(&codesphere.Opts.Vault, "vault", "", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
 	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.PrivKey, "priv-key", "k", "", "Path to the private key to encrypt/decrypt secrets")
-	codesphere.cmd.PersistentFlags().StringSliceVarP(&codesphere.Opts.SkipSteps, "skip-steps", "s", []string{}, "Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker")
+	codesphere.cmd.PersistentFlags().StringSliceVarP(&codesphere.Opts.SkipSteps, "skip-steps", "s", []string{}, "Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd")
 	codesphere.cmd.PersistentFlags().BoolVar(&codesphere.Opts.DirectConnection, "direct-connection", false, "Use direct connection for installation, requires having access to the cluster nodes from your machine")
 	codesphere.cmd.PersistentFlags().BoolVar(&codesphere.Opts.AutoApprove, "auto-approve", true, "Auto approve confirmation prompts with default values")
 	codesphere.cmd.Flags().BoolVar(&codesphere.Opts.CodesphereOnly, "codesphere-only", false, "Install only Codesphere without dependencies")
-	codesphere.cmd.PersistentFlags().BoolVar(&codesphere.Opts.SkipArgo, "skip-argo", false, "Skip ArgoCD, vault secret sync, and pc-apps deployment")
 	codesphere.cmd.PersistentFlags().StringVar(&codesphere.Opts.ArgoCDVersion, "argo-version", "", "ArgoCD Helm chart version to install")
 	codesphere.cmd.PersistentFlags().StringVar(&codesphere.Opts.ArgoCDRegistryURL, "argo-registry-url", "", "OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)")
 	codesphere.cmd.PersistentFlags().BoolVar(&codesphere.Opts.ArgoCDForceConflicts, "argo-force-conflicts", false, "Force SSA ownership conflicts during ArgoCD install")

--- a/cli/cmd/install_codesphere_dependencies.go
+++ b/cli/cmd/install_codesphere_dependencies.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/codesphere-cloud/cs-go/pkg/io"
 	"github.com/codesphere-cloud/oms/internal/bootstrap"
+	"github.com/codesphere-cloud/oms/internal/configtemplating"
 	"github.com/codesphere-cloud/oms/internal/env"
 	"github.com/codesphere-cloud/oms/internal/installer"
 	argocdinstaller "github.com/codesphere-cloud/oms/internal/installer/argocd"
@@ -38,15 +39,21 @@ func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error 
 	workdir := env.GetOmsWorkdir()
 	pm := installer.NewPackage(workdir, opts.Package)
 	stlog := bootstrap.NewStepLogger(false)
+	cm := installer.NewConfig()
 
-	if !opts.SkipArgo {
+	cfg, cleanup, err := parseInstallConfig(opts, cm)
+	if err != nil {
+		return fmt.Errorf("failed to extract config.yaml: %w", err)
+	}
+	defer cleanup()
+
+	if !installer.IsStepSkipped(cfg, opts.SkipSteps, installer.ArgoCDStep) {
 		if err := stlog.Step("Install ArgoCD pre-step", func() error {
 			return installArgoCDAndApps(opts, pm, stlog)
 		}); err != nil {
 			return err
 		}
 	}
-	cm := installer.NewConfig()
 	im := system.NewImage(context.Background())
 
 	ci := &installer.CodesphereInstaller{
@@ -63,6 +70,23 @@ func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error 
 		return fmt.Errorf("failed to install dependencies: %w", err)
 	}
 	return nil
+}
+
+func parseInstallConfig(opts *InstallCodesphereOpts, cm installer.ConfigManager) (files.RootConfig, func(), error) {
+	configPath := opts.Config
+	cleanup := func() {}
+	if opts.Vault != "" {
+		store := installer.NewLazyVaultTemplatingSecretStore(opts.Vault, opts.PrivKey)
+		renderedConfig, renderCleanup, err := configtemplating.RenderConfigFileToTemp(opts.Config, store)
+		if err != nil {
+			return files.RootConfig{}, cleanup, err
+		}
+		configPath = renderedConfig
+		cleanup = renderCleanup
+	}
+
+	cfg, err := cm.ParseConfigYaml(configPath)
+	return cfg, cleanup, err
 }
 
 // installArgoCDAndApps runs ArgoCD install, vault secret sync, and pc-apps install
@@ -200,14 +224,14 @@ func AddInstallCodesphereDepenciesCmd(codesphere *cobra.Command, opts *InstallCo
 			Long: io.Long(`Install cluster dependencies for a Codesphere instance (Phase 2).
 			Runs ArgoCD install, vault secret sync, and pc-apps deployment first, then steps: set-up-cluster, ms-backends.
 			Requires the infrastructure phase to have completed successfully.
-			Pass --skip-argo to skip the ArgoCD pre-step.`),
+			Pass --skip-steps argocd or add argocd to operations.skip to skip the ArgoCD pre-step.`),
 			Example: formatExamples("install codesphere dependencies", []io.Example{
 				{
 					Cmd:  "-p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml",
 					Desc: "Install cluster dependencies (including ArgoCD)",
 				},
 				{
-					Cmd:  "-p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml --skip-argo",
+					Cmd:  "-p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml -s argocd",
 					Desc: "Install cluster dependencies without the ArgoCD pre-step",
 				},
 			}),

--- a/cli/cmd/install_codesphere_dependencies.go
+++ b/cli/cmd/install_codesphere_dependencies.go
@@ -6,13 +6,21 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
+	"strings"
 
 	"github.com/codesphere-cloud/cs-go/pkg/io"
+	"github.com/codesphere-cloud/oms/internal/bootstrap"
 	"github.com/codesphere-cloud/oms/internal/env"
 	"github.com/codesphere-cloud/oms/internal/installer"
+	argocdinstaller "github.com/codesphere-cloud/oms/internal/installer/argocd"
+	"github.com/codesphere-cloud/oms/internal/installer/files"
 	"github.com/codesphere-cloud/oms/internal/system"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // InstallCodesphereDepenciesCmd runs the cluster dependency steps (Phase 2).
@@ -29,6 +37,15 @@ func (c *InstallCodesphereDepenciesCmd) RunE(_ *cobra.Command, _ []string) error
 func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error {
 	workdir := env.GetOmsWorkdir()
 	pm := installer.NewPackage(workdir, opts.Package)
+	stlog := bootstrap.NewStepLogger(false)
+
+	if !opts.SkipArgo {
+		if err := stlog.Step("Install ArgoCD pre-step", func() error {
+			return installArgoCDAndApps(opts, pm, stlog)
+		}); err != nil {
+			return err
+		}
+	}
 	cm := installer.NewConfig()
 	im := system.NewImage(context.Background())
 
@@ -48,18 +65,136 @@ func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error 
 	return nil
 }
 
+// installArgoCDAndApps runs ArgoCD install, vault secret sync, and pc-apps install
+// before the main dependency steps.
+func installArgoCDAndApps(opts *InstallCodesphereOpts, pm installer.PackageManager, stlog *bootstrap.StepLogger) error {
+	ctx := context.Background()
+
+	var (
+		ociPassword    string
+		ociRegistryURL string
+		argoInstall    *argocdinstaller.Installer
+		kubeClient     ctrlclient.Client
+		vault          *files.InstallVault
+		kubeConfig     *rest.Config
+	)
+
+	if err := stlog.Substep("Load vault data", func() error {
+		var err error
+		vault, err = installer.LoadVaultData(opts.Vault, opts.PrivKey)
+		if err != nil {
+			return fmt.Errorf("failed to load vault: %w", err)
+		}
+		if s := vault.GetSecret(files.SecretRegistryPassword); s != nil && s.Fields != nil {
+			ociPassword = s.Fields.Password
+		}
+		if ociPassword == "" {
+			return fmt.Errorf("registry password not found in vault (secret %q)", files.SecretRegistryPassword)
+		}
+		kubeConfigContent, err := kubeConfigContentFromVault(vault)
+		if err != nil {
+			return err
+		}
+
+		kubeConfig, err = clientcmd.RESTConfigFromKubeConfig([]byte(kubeConfigContent))
+		if err != nil {
+			return fmt.Errorf("failed to load kubernetes config from vault: %w", err)
+		}
+		kubeClient, err = ctrlclient.New(kubeConfig, ctrlclient.Options{})
+		if err != nil {
+			return fmt.Errorf("failed to create kubernetes client: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := stlog.Substep("Install ArgoCD", func() error {
+		cfg, err := installer.NewConfig().ParseConfigYaml(opts.Config)
+		if err != nil {
+			return fmt.Errorf("failed to parse config.yaml: %w", err)
+		}
+		ociRegistryURL = opts.ArgoCDRegistryURL
+		if ociRegistryURL == "" && cfg.Registry != nil {
+			ociRegistryURL = cfg.Registry.Server
+		}
+		argoInstall, err = argocdinstaller.NewInstaller(argocdinstaller.InstallerConfig{
+			Version:        opts.ArgoCDVersion,
+			DatacenterId:   fmt.Sprintf("%d", cfg.Datacenter.ID),
+			OciPassword:    ociPassword,
+			OciRegistryURL: ociRegistryURL,
+			GitPassword:    os.Getenv("OMS_GIT_PASSWORD"),
+			FullInstall:    true,
+			ForceConflicts: opts.ArgoCDForceConflicts,
+			RepoURL:        opts.ArgoCDRepoURL,
+			ValueFiles:     opts.ArgoCDValues,
+			RESTConfig:     kubeConfig,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to initialize ArgoCD installer: %w", err)
+		}
+		if err := argoInstall.Install(); err != nil {
+			return fmt.Errorf("failed to install ArgoCD: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := stlog.Substep("Sync vault secret", func() error {
+		creator := installer.NewVaultSecretCreator(kubeClient)
+		if err := creator.CreateSecretFromVault(ctx, vault, installer.VaultSecretNamespace, installer.VaultSecretName); err != nil {
+			return fmt.Errorf("failed to sync vault secret: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := stlog.Substep("Install pc-apps", func() error {
+		pcApps, err := installer.NewPcAppsFromBom(kubeClient, pm.GetDependencyPath("bom.json"), argocdinstaller.DefaultNamespace)
+		if err != nil {
+			return fmt.Errorf("failed to initialize pc-apps installer: %w", err)
+		}
+		if err := pcApps.Install(ctx); err != nil {
+			return fmt.Errorf("failed to install pc-apps: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func kubeConfigContentFromVault(vault *files.InstallVault) (string, error) {
+	if vault == nil {
+		return "", fmt.Errorf("vault is not loaded")
+	}
+	kubeConfig := vault.GetSecret(files.SecretKubeConfig)
+	if kubeConfig == nil || kubeConfig.File == nil || strings.TrimSpace(kubeConfig.File.Content) == "" {
+		return "", fmt.Errorf("kubeconfig not found in vault (secret %q)", files.SecretKubeConfig)
+	}
+	return kubeConfig.File.Content, nil
+}
+
 func AddInstallCodesphereDepenciesCmd(codesphere *cobra.Command, opts *InstallCodesphereOpts) {
 	deps := InstallCodesphereDepenciesCmd{
 		cmd: &cobra.Command{
 			Use:   "dependencies",
 			Short: "Install Codesphere cluster dependencies (Phase 2)",
 			Long: io.Long(`Install cluster dependencies for a Codesphere instance (Phase 2).
-			Runs steps: set-up-cluster, ms-backends.
-			Requires the infrastructure phase to have completed successfully.`),
+			Runs ArgoCD install, vault secret sync, and pc-apps deployment first, then steps: set-up-cluster, ms-backends.
+			Requires the infrastructure phase to have completed successfully.
+			Pass --skip-argo to skip the ArgoCD pre-step.`),
 			Example: formatExamples("install codesphere dependencies", []io.Example{
 				{
 					Cmd:  "-p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml",
-					Desc: "Install cluster dependencies only",
+					Desc: "Install cluster dependencies (including ArgoCD)",
+				},
+				{
+					Cmd:  "-p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml --skip-argo",
+					Desc: "Install cluster dependencies without the ArgoCD pre-step",
 				},
 			}),
 		},

--- a/cli/cmd/install_codesphere_dependencies.go
+++ b/cli/cmd/install_codesphere_dependencies.go
@@ -68,102 +68,116 @@ func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error 
 // installArgoCDAndApps runs ArgoCD install, vault secret sync, and pc-apps install
 // before the main dependency steps.
 func installArgoCDAndApps(opts *InstallCodesphereOpts, pm installer.PackageManager, stlog *bootstrap.StepLogger) error {
-	ctx := context.Background()
+	install := &argoCDAndAppsInstall{
+		ctx:  context.Background(),
+		opts: opts,
+		pm:   pm,
+	}
 
-	var (
-		ociPassword    string
-		ociRegistryURL string
-		argoInstall    *argocdinstaller.Installer
-		kubeClient     ctrlclient.Client
-		vault          *files.InstallVault
-		kubeConfig     *rest.Config
-	)
-
-	if err := stlog.Substep("Load vault data", func() error {
-		var err error
-		vault, err = installer.LoadVaultData(opts.Vault, opts.PrivKey)
-		if err != nil {
-			return fmt.Errorf("failed to load vault: %w", err)
-		}
-		if s := vault.GetSecret(files.SecretRegistryPassword); s != nil && s.Fields != nil {
-			ociPassword = s.Fields.Password
-		}
-		if ociPassword == "" {
-			return fmt.Errorf("registry password not found in vault (secret %q)", files.SecretRegistryPassword)
-		}
-		kubeConfigContent, err := kubeConfigContentFromVault(vault)
-		if err != nil {
-			return err
-		}
-
-		kubeConfig, err = clientcmd.RESTConfigFromKubeConfig([]byte(kubeConfigContent))
-		if err != nil {
-			return fmt.Errorf("failed to load kubernetes config from vault: %w", err)
-		}
-		kubeClient, err = ctrlclient.New(kubeConfig, ctrlclient.Options{})
-		if err != nil {
-			return fmt.Errorf("failed to create kubernetes client: %w", err)
-		}
-		return nil
-	}); err != nil {
+	if err := stlog.Substep("Load vault data", install.loadVaultData); err != nil {
+		return err
+	}
+	if err := stlog.Substep("Install ArgoCD", install.installArgoCD); err != nil {
+		return err
+	}
+	if err := stlog.Substep("Sync vault secret", install.syncVaultSecret); err != nil {
+		return err
+	}
+	if err := stlog.Substep("Install pc-apps", install.installPcApps); err != nil {
 		return err
 	}
 
-	if err := stlog.Substep("Install ArgoCD", func() error {
-		cfg, err := installer.NewConfig().ParseConfigYaml(opts.Config)
-		if err != nil {
-			return fmt.Errorf("failed to parse config.yaml: %w", err)
-		}
-		ociRegistryURL = opts.ArgoCDRegistryURL
-		if ociRegistryURL == "" && cfg.Registry != nil {
-			ociRegistryURL = cfg.Registry.Server
-		}
-		argoInstall, err = argocdinstaller.NewInstaller(argocdinstaller.InstallerConfig{
-			Version:        opts.ArgoCDVersion,
-			DatacenterId:   fmt.Sprintf("%d", cfg.Datacenter.ID),
-			OciPassword:    ociPassword,
-			OciRegistryURL: ociRegistryURL,
-			GitPassword:    os.Getenv("OMS_GIT_PASSWORD"),
-			FullInstall:    true,
-			ForceConflicts: opts.ArgoCDForceConflicts,
-			RepoURL:        opts.ArgoCDRepoURL,
-			ValueFiles:     opts.ArgoCDValues,
-			RESTConfig:     kubeConfig,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to initialize ArgoCD installer: %w", err)
-		}
-		if err := argoInstall.Install(); err != nil {
-			return fmt.Errorf("failed to install ArgoCD: %w", err)
-		}
-		return nil
-	}); err != nil {
+	return nil
+}
+
+type argoCDAndAppsInstall struct {
+	ctx context.Context
+
+	opts *InstallCodesphereOpts
+	pm   installer.PackageManager
+
+	ociPassword    string
+	ociRegistryURL string
+	argoInstall    *argocdinstaller.Installer
+	kubeClient     ctrlclient.Client
+	vault          *files.InstallVault
+	kubeConfig     *rest.Config
+}
+
+func (i *argoCDAndAppsInstall) loadVaultData() error {
+	var err error
+	i.vault, err = installer.LoadVaultData(i.opts.Vault, i.opts.PrivKey)
+	if err != nil {
+		return fmt.Errorf("failed to load vault: %w", err)
+	}
+	if s := i.vault.GetSecret(files.SecretRegistryPassword); s != nil && s.Fields != nil {
+		i.ociPassword = s.Fields.Password
+	}
+	if i.ociPassword == "" {
+		return fmt.Errorf("registry password not found in vault (secret %q)", files.SecretRegistryPassword)
+	}
+	kubeConfigContent, err := kubeConfigContentFromVault(i.vault)
+	if err != nil {
 		return err
 	}
 
-	if err := stlog.Substep("Sync vault secret", func() error {
-		creator := installer.NewVaultSecretCreator(kubeClient)
-		if err := creator.CreateSecretFromVault(ctx, vault, installer.VaultSecretNamespace, installer.VaultSecretName); err != nil {
-			return fmt.Errorf("failed to sync vault secret: %w", err)
-		}
-		return nil
-	}); err != nil {
-		return err
+	i.kubeConfig, err = clientcmd.RESTConfigFromKubeConfig([]byte(kubeConfigContent))
+	if err != nil {
+		return fmt.Errorf("failed to load kubernetes config from vault: %w", err)
 	}
-
-	if err := stlog.Substep("Install pc-apps", func() error {
-		pcApps, err := installer.NewPcAppsFromBom(kubeClient, pm.GetDependencyPath("bom.json"), argocdinstaller.DefaultNamespace)
-		if err != nil {
-			return fmt.Errorf("failed to initialize pc-apps installer: %w", err)
-		}
-		if err := pcApps.Install(ctx); err != nil {
-			return fmt.Errorf("failed to install pc-apps: %w", err)
-		}
-		return nil
-	}); err != nil {
-		return err
+	i.kubeClient, err = ctrlclient.New(i.kubeConfig, ctrlclient.Options{})
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
+	return nil
+}
 
+func (i *argoCDAndAppsInstall) installArgoCD() error {
+	cfg, err := installer.NewConfig().ParseConfigYaml(i.opts.Config)
+	if err != nil {
+		return fmt.Errorf("failed to parse config.yaml: %w", err)
+	}
+	i.ociRegistryURL = i.opts.ArgoCDRegistryURL
+	if i.ociRegistryURL == "" && cfg.Registry != nil {
+		i.ociRegistryURL = cfg.Registry.Server
+	}
+	i.argoInstall, err = argocdinstaller.NewInstaller(argocdinstaller.InstallerConfig{
+		Version:        i.opts.ArgoCDVersion,
+		DatacenterId:   fmt.Sprintf("%d", cfg.Datacenter.ID),
+		OciPassword:    i.ociPassword,
+		OciRegistryURL: i.ociRegistryURL,
+		GitPassword:    os.Getenv("OMS_GIT_PASSWORD"),
+		FullInstall:    true,
+		ForceConflicts: i.opts.ArgoCDForceConflicts,
+		RepoURL:        i.opts.ArgoCDRepoURL,
+		ValueFiles:     i.opts.ArgoCDValues,
+		RESTConfig:     i.kubeConfig,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize ArgoCD installer: %w", err)
+	}
+	if err := i.argoInstall.Install(); err != nil {
+		return fmt.Errorf("failed to install ArgoCD: %w", err)
+	}
+	return nil
+}
+
+func (i *argoCDAndAppsInstall) syncVaultSecret() error {
+	creator := installer.NewVaultSecretCreator(i.kubeClient)
+	if err := creator.CreateSecretFromVault(i.ctx, i.vault, installer.VaultSecretNamespace, installer.VaultSecretName); err != nil {
+		return fmt.Errorf("failed to sync vault secret: %w", err)
+	}
+	return nil
+}
+
+func (i *argoCDAndAppsInstall) installPcApps() error {
+	pcApps, err := installer.NewPcAppsFromBom(i.kubeClient, i.pm.GetDependencyPath("bom.json"), argocdinstaller.DefaultNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to initialize pc-apps installer: %w", err)
+	}
+	if err := pcApps.Install(i.ctx); err != nil {
+		return fmt.Errorf("failed to install pc-apps: %w", err)
+	}
 	return nil
 }
 

--- a/cli/cmd/install_codesphere_test.go
+++ b/cli/cmd/install_codesphere_test.go
@@ -119,7 +119,7 @@ var _ = Describe("AddInstallCodesphereCmd", func() {
 
 		vaultFlag := codesphereCmd.PersistentFlags().Lookup("vault")
 		Expect(vaultFlag).NotTo(BeNil())
-		Expect(vaultFlag.DefValue).To(Equal("prod.vault.yaml"))
+		Expect(vaultFlag.DefValue).To(Equal(""))
 
 		skipStepFlag := codesphereCmd.PersistentFlags().Lookup("skip-steps")
 		Expect(skipStepFlag).NotTo(BeNil())

--- a/docs/oms_install_codesphere.md
+++ b/docs/oms_install_codesphere.md
@@ -38,8 +38,7 @@ $ oms install codesphere -p codesphere-v1.2.3-installer-lite.tar.gz -k <path-to-
   -h, --help                       help for codesphere
   -p, --package string             Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
   -k, --priv-key string            Path to the private key to encrypt/decrypt secrets
-      --skip-argo                  Skip ArgoCD, vault secret sync, and pc-apps deployment
-  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
+  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd
       --vault string               Path to the SOPS-encrypted prod.vault.yaml file used for config templating
 ```
 
@@ -49,4 +48,3 @@ $ oms install codesphere -p codesphere-v1.2.3-installer-lite.tar.gz -k <path-to-
 * [oms install codesphere dependencies](oms_install_codesphere_dependencies.md)	 - Install Codesphere cluster dependencies (Phase 2)
 * [oms install codesphere infra](oms_install_codesphere_infra.md)	 - Install Codesphere infrastructure (Phase 1)
 * [oms install codesphere platform](oms_install_codesphere_platform.md)	 - Install the Codesphere platform (Phase 3)
-

--- a/docs/oms_install_codesphere.md
+++ b/docs/oms_install_codesphere.md
@@ -25,16 +25,22 @@ $ oms install codesphere -p codesphere-v1.2.3-installer-lite.tar.gz -k <path-to-
 ### Options
 
 ```
-      --auto-approve         Auto approve confirmation prompts with default values (default true)
-      --codesphere-only      Install only Codesphere without dependencies
-  -c, --config string        Path to the Codesphere Private Cloud configuration file (yaml)
-      --direct-connection    Use direct connection for installation, requires having access to the cluster nodes from your machine
-  -f, --force                Enforce package extraction
-  -h, --help                 help for codesphere
-  -p, --package string       Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
-  -k, --priv-key string      Path to the private key to encrypt/decrypt secrets
-  -s, --skip-steps strings   Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
-      --vault string         Path to the SOPS-encrypted prod.vault.yaml file used for config templating (default "prod.vault.yaml")
+      --argo-force-conflicts       Force SSA ownership conflicts during ArgoCD install
+      --argo-registry-url string   OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)
+      --argo-repo string           ArgoCD Helm chart repository URL (default "https://argoproj.github.io/argo-helm")
+      --argo-values stringArray    ArgoCD values YAML file (can be specified multiple times)
+      --argo-version string        ArgoCD Helm chart version to install
+      --auto-approve               Auto approve confirmation prompts with default values (default true)
+      --codesphere-only            Install only Codesphere without dependencies
+  -c, --config string              Path to the Codesphere Private Cloud configuration file (yaml)
+      --direct-connection          Use direct connection for installation, requires having access to the cluster nodes from your machine
+  -f, --force                      Enforce package extraction
+  -h, --help                       help for codesphere
+  -p, --package string             Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
+  -k, --priv-key string            Path to the private key to encrypt/decrypt secrets
+      --skip-argo                  Skip ArgoCD, vault secret sync, and pc-apps deployment
+  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
+      --vault string               Path to the SOPS-encrypted prod.vault.yaml file used for config templating
 ```
 
 ### SEE ALSO

--- a/docs/oms_install_codesphere.md
+++ b/docs/oms_install_codesphere.md
@@ -48,3 +48,4 @@ $ oms install codesphere -p codesphere-v1.2.3-installer-lite.tar.gz -k <path-to-
 * [oms install codesphere dependencies](oms_install_codesphere_dependencies.md)	 - Install Codesphere cluster dependencies (Phase 2)
 * [oms install codesphere infra](oms_install_codesphere_infra.md)	 - Install Codesphere infrastructure (Phase 1)
 * [oms install codesphere platform](oms_install_codesphere_platform.md)	 - Install the Codesphere platform (Phase 3)
+

--- a/docs/oms_install_codesphere_dependencies.md
+++ b/docs/oms_install_codesphere_dependencies.md
@@ -5,8 +5,9 @@ Install Codesphere cluster dependencies (Phase 2)
 ### Synopsis
 
 Install cluster dependencies for a Codesphere instance (Phase 2).
-Runs steps: set-up-cluster, ms-backends.
+Runs ArgoCD install, vault secret sync, and pc-apps deployment first, then steps: set-up-cluster, ms-backends.
 Requires the infrastructure phase to have completed successfully.
+Pass --skip-argo to skip the ArgoCD pre-step.
 
 ```
 oms install codesphere dependencies [flags]
@@ -15,8 +16,11 @@ oms install codesphere dependencies [flags]
 ### Examples
 
 ```
-# Install cluster dependencies only
+# Install cluster dependencies (including ArgoCD)
 $ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml
+
+# Install cluster dependencies without the ArgoCD pre-step
+$ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml --skip-argo
 
 ```
 
@@ -29,14 +33,20 @@ $ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <
 ### Options inherited from parent commands
 
 ```
-      --auto-approve         Auto approve confirmation prompts with default values (default true)
-  -c, --config string        Path to the Codesphere Private Cloud configuration file (yaml)
-      --direct-connection    Use direct connection for installation, requires having access to the cluster nodes from your machine
-  -f, --force                Enforce package extraction
-  -p, --package string       Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
-  -k, --priv-key string      Path to the private key to encrypt/decrypt secrets
-  -s, --skip-steps strings   Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
-      --vault string         Path to the SOPS-encrypted prod.vault.yaml file used for config templating (default "prod.vault.yaml")
+      --argo-force-conflicts       Force SSA ownership conflicts during ArgoCD install
+      --argo-registry-url string   OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)
+      --argo-repo string           ArgoCD Helm chart repository URL (default "https://argoproj.github.io/argo-helm")
+      --argo-values stringArray    ArgoCD values YAML file (can be specified multiple times)
+      --argo-version string        ArgoCD Helm chart version to install
+      --auto-approve               Auto approve confirmation prompts with default values (default true)
+  -c, --config string              Path to the Codesphere Private Cloud configuration file (yaml)
+      --direct-connection          Use direct connection for installation, requires having access to the cluster nodes from your machine
+  -f, --force                      Enforce package extraction
+  -p, --package string             Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
+  -k, --priv-key string            Path to the private key to encrypt/decrypt secrets
+      --skip-argo                  Skip ArgoCD, vault secret sync, and pc-apps deployment
+  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
+      --vault string               Path to the SOPS-encrypted prod.vault.yaml file used for config templating
 ```
 
 ### SEE ALSO

--- a/docs/oms_install_codesphere_dependencies.md
+++ b/docs/oms_install_codesphere_dependencies.md
@@ -51,3 +51,4 @@ $ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <
 ### SEE ALSO
 
 * [oms install codesphere](oms_install_codesphere.md)	 - Install a Codesphere instance
+

--- a/docs/oms_install_codesphere_dependencies.md
+++ b/docs/oms_install_codesphere_dependencies.md
@@ -7,7 +7,7 @@ Install Codesphere cluster dependencies (Phase 2)
 Install cluster dependencies for a Codesphere instance (Phase 2).
 Runs ArgoCD install, vault secret sync, and pc-apps deployment first, then steps: set-up-cluster, ms-backends.
 Requires the infrastructure phase to have completed successfully.
-Pass --skip-argo to skip the ArgoCD pre-step.
+Pass --skip-steps argocd or add argocd to operations.skip to skip the ArgoCD pre-step.
 
 ```
 oms install codesphere dependencies [flags]
@@ -20,7 +20,7 @@ oms install codesphere dependencies [flags]
 $ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml
 
 # Install cluster dependencies without the ArgoCD pre-step
-$ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml --skip-argo
+$ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml -s argocd
 
 ```
 
@@ -44,12 +44,10 @@ $ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <
   -f, --force                      Enforce package extraction
   -p, --package string             Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
   -k, --priv-key string            Path to the private key to encrypt/decrypt secrets
-      --skip-argo                  Skip ArgoCD, vault secret sync, and pc-apps deployment
-  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
+  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd
       --vault string               Path to the SOPS-encrypted prod.vault.yaml file used for config templating
 ```
 
 ### SEE ALSO
 
 * [oms install codesphere](oms_install_codesphere.md)	 - Install a Codesphere instance
-

--- a/docs/oms_install_codesphere_infra.md
+++ b/docs/oms_install_codesphere_infra.md
@@ -31,14 +31,20 @@ $ oms install codesphere infra -p codesphere-v1.2.3-installer-lite.tar.gz -k <pa
 ### Options inherited from parent commands
 
 ```
-      --auto-approve         Auto approve confirmation prompts with default values (default true)
-  -c, --config string        Path to the Codesphere Private Cloud configuration file (yaml)
-      --direct-connection    Use direct connection for installation, requires having access to the cluster nodes from your machine
-  -f, --force                Enforce package extraction
-  -p, --package string       Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
-  -k, --priv-key string      Path to the private key to encrypt/decrypt secrets
-  -s, --skip-steps strings   Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
-      --vault string         Path to the SOPS-encrypted prod.vault.yaml file used for config templating (default "prod.vault.yaml")
+      --argo-force-conflicts       Force SSA ownership conflicts during ArgoCD install
+      --argo-registry-url string   OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)
+      --argo-repo string           ArgoCD Helm chart repository URL (default "https://argoproj.github.io/argo-helm")
+      --argo-values stringArray    ArgoCD values YAML file (can be specified multiple times)
+      --argo-version string        ArgoCD Helm chart version to install
+      --auto-approve               Auto approve confirmation prompts with default values (default true)
+  -c, --config string              Path to the Codesphere Private Cloud configuration file (yaml)
+      --direct-connection          Use direct connection for installation, requires having access to the cluster nodes from your machine
+  -f, --force                      Enforce package extraction
+  -p, --package string             Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
+  -k, --priv-key string            Path to the private key to encrypt/decrypt secrets
+      --skip-argo                  Skip ArgoCD, vault secret sync, and pc-apps deployment
+  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
+      --vault string               Path to the SOPS-encrypted prod.vault.yaml file used for config templating
 ```
 
 ### SEE ALSO

--- a/docs/oms_install_codesphere_infra.md
+++ b/docs/oms_install_codesphere_infra.md
@@ -42,12 +42,10 @@ $ oms install codesphere infra -p codesphere-v1.2.3-installer-lite.tar.gz -k <pa
   -f, --force                      Enforce package extraction
   -p, --package string             Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
   -k, --priv-key string            Path to the private key to encrypt/decrypt secrets
-      --skip-argo                  Skip ArgoCD, vault secret sync, and pc-apps deployment
-  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
+  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd
       --vault string               Path to the SOPS-encrypted prod.vault.yaml file used for config templating
 ```
 
 ### SEE ALSO
 
 * [oms install codesphere](oms_install_codesphere.md)	 - Install a Codesphere instance
-

--- a/docs/oms_install_codesphere_infra.md
+++ b/docs/oms_install_codesphere_infra.md
@@ -49,3 +49,4 @@ $ oms install codesphere infra -p codesphere-v1.2.3-installer-lite.tar.gz -k <pa
 ### SEE ALSO
 
 * [oms install codesphere](oms_install_codesphere.md)	 - Install a Codesphere instance
+

--- a/docs/oms_install_codesphere_platform.md
+++ b/docs/oms_install_codesphere_platform.md
@@ -47,3 +47,4 @@ $ oms install codesphere platform -p codesphere-v1.2.3-installer.tar.gz -k <path
 ### SEE ALSO
 
 * [oms install codesphere](oms_install_codesphere.md)	 - Install a Codesphere instance
+

--- a/docs/oms_install_codesphere_platform.md
+++ b/docs/oms_install_codesphere_platform.md
@@ -40,12 +40,10 @@ $ oms install codesphere platform -p codesphere-v1.2.3-installer.tar.gz -k <path
   -f, --force                      Enforce package extraction
   -p, --package string             Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
   -k, --priv-key string            Path to the private key to encrypt/decrypt secrets
-      --skip-argo                  Skip ArgoCD, vault secret sync, and pc-apps deployment
-  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
+  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd
       --vault string               Path to the SOPS-encrypted prod.vault.yaml file used for config templating
 ```
 
 ### SEE ALSO
 
 * [oms install codesphere](oms_install_codesphere.md)	 - Install a Codesphere instance
-

--- a/docs/oms_install_codesphere_platform.md
+++ b/docs/oms_install_codesphere_platform.md
@@ -29,14 +29,20 @@ $ oms install codesphere platform -p codesphere-v1.2.3-installer.tar.gz -k <path
 ### Options inherited from parent commands
 
 ```
-      --auto-approve         Auto approve confirmation prompts with default values (default true)
-  -c, --config string        Path to the Codesphere Private Cloud configuration file (yaml)
-      --direct-connection    Use direct connection for installation, requires having access to the cluster nodes from your machine
-  -f, --force                Enforce package extraction
-  -p, --package string       Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
-  -k, --priv-key string      Path to the private key to encrypt/decrypt secrets
-  -s, --skip-steps strings   Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
-      --vault string         Path to the SOPS-encrypted prod.vault.yaml file used for config templating (default "prod.vault.yaml")
+      --argo-force-conflicts       Force SSA ownership conflicts during ArgoCD install
+      --argo-registry-url string   OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)
+      --argo-repo string           ArgoCD Helm chart repository URL (default "https://argoproj.github.io/argo-helm")
+      --argo-values stringArray    ArgoCD values YAML file (can be specified multiple times)
+      --argo-version string        ArgoCD Helm chart version to install
+      --auto-approve               Auto approve confirmation prompts with default values (default true)
+  -c, --config string              Path to the Codesphere Private Cloud configuration file (yaml)
+      --direct-connection          Use direct connection for installation, requires having access to the cluster nodes from your machine
+  -f, --force                      Enforce package extraction
+  -p, --package string             Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
+  -k, --priv-key string            Path to the private key to encrypt/decrypt secrets
+      --skip-argo                  Skip ArgoCD, vault secret sync, and pc-apps deployment
+  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker
+      --vault string               Path to the SOPS-encrypted prod.vault.yaml file used for config templating
 ```
 
 ### SEE ALSO

--- a/internal/bootstrap/gcp/gcp.go
+++ b/internal/bootstrap/gcp/gcp.go
@@ -1020,8 +1020,8 @@ func (b *GCPBootstrapper) ensureCodespherePackageOnJumpbox() (string, error) {
 
 func (b *GCPBootstrapper) runInstallCommand(packageFilename string) error {
 	b.stlog.Logf("Installing Codesphere...")
-	installCmd := fmt.Sprintf("oms install codesphere -c /etc/codesphere/config.yaml -k %s/age_key.txt -p %s%s",
-		b.Env.SecretsDir, packageFilename, b.generateSkipStepsArg())
+	installCmd := fmt.Sprintf("oms install codesphere -c /etc/codesphere/config.yaml -k %s/age_key.txt --vault %s -p %s%s",
+		b.Env.SecretsDir, b.icg.GetSecretFilePath(), packageFilename, b.generateSkipStepsArg())
 	return b.Env.Jumpbox.RunSSHCommand("root", installCmd)
 }
 

--- a/internal/bootstrap/gcp/gcp_test.go
+++ b/internal/bootstrap/gcp/gcp_test.go
@@ -1279,6 +1279,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 		BeforeEach(func() {
 			csEnv.InstallVersion = "v1.2.3"
 			csEnv.InstallHash = "abc1234567890"
+			icg.EXPECT().GetSecretFilePath().Return("/etc/codesphere/secrets/prod.vault.yaml").Maybe()
 		})
 		Describe("Valid InstallCodesphere", func() {
 			Context("Direct GitHub access", func() {
@@ -1293,7 +1294,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 
 					// Expect install codesphere
 					nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root",
-						"oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p v1.2.3-abc1234567890-installer-lite.tar.gz -s load-container-images").Return(nil)
+						"oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt --vault /etc/codesphere/secrets/prod.vault.yaml -p v1.2.3-abc1234567890-installer-lite.tar.gz -s load-container-images").Return(nil)
 
 					err := bs.InstallCodesphere()
 					Expect(err).NotTo(HaveOccurred())
@@ -1310,7 +1311,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 					nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms download package -f installer.tar.gz -H def9876543210 v1.2.3").Return(nil)
 
 					// Expect install codesphere
-					nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p v1.2.3-def9876543210-installer.tar.gz").Return(nil)
+					nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt --vault /etc/codesphere/secrets/prod.vault.yaml -p v1.2.3-def9876543210-installer.tar.gz").Return(nil)
 
 					err := bs.InstallCodesphere()
 					Expect(err).NotTo(HaveOccurred())
@@ -1319,7 +1320,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 
 			It("downloads and installs codesphere with hash", func() {
 				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms download package -f installer.tar.gz -H abc1234567890 v1.2.3").Return(nil)
-				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p v1.2.3-abc1234567890-installer.tar.gz").Return(nil)
+				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt --vault /etc/codesphere/secrets/prod.vault.yaml -p v1.2.3-abc1234567890-installer.tar.gz").Return(nil)
 
 				err := bs.InstallCodesphere()
 				Expect(err).NotTo(HaveOccurred())
@@ -1338,7 +1339,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 					It("installs codesphere from local package", func() {
 						nodeClient.EXPECT().CopyFile(mock.Anything, csEnv.InstallLocal, "/root/local-installer-lite.tar.gz").Return(nil)
 						nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root",
-							"oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p local-installer-lite.tar.gz -s load-container-images").Return(nil)
+							"oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt --vault /etc/codesphere/secrets/prod.vault.yaml -p local-installer-lite.tar.gz -s load-container-images").Return(nil)
 
 						err := bs.InstallCodesphere()
 						Expect(err).NotTo(HaveOccurred())
@@ -1352,7 +1353,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 					It("installs codesphere from local package", func() {
 						nodeClient.EXPECT().CopyFile(mock.Anything, csEnv.InstallLocal, "/root/local-installer.tar.gz").Return(nil)
 						nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root",
-							"oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p local-installer.tar.gz").Return(nil)
+							"oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt --vault /etc/codesphere/secrets/prod.vault.yaml -p local-installer.tar.gz").Return(nil)
 
 						err := bs.InstallCodesphere()
 						Expect(err).NotTo(HaveOccurred())
@@ -1396,7 +1397,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 
 			It("fails when install codesphere fails", func() {
 				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms download package -f installer.tar.gz -H abc1234567890 v1.2.3").Return(nil).Once()
-				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt -p v1.2.3-abc1234567890-installer.tar.gz").Return(fmt.Errorf("install error")).Once()
+				nodeClient.EXPECT().RunCommand(mock.MatchedBy(jumpboxMatcher), "root", "oms install codesphere -c /etc/codesphere/config.yaml -k /etc/codesphere/secrets/age_key.txt --vault /etc/codesphere/secrets/prod.vault.yaml -p v1.2.3-abc1234567890-installer.tar.gz").Return(fmt.Errorf("install error")).Once()
 
 				err := bs.InstallCodesphere()
 				Expect(err).To(HaveOccurred())

--- a/internal/installer/argocd/argocd_resources.go
+++ b/internal/installer/argocd/argocd_resources.go
@@ -13,6 +13,7 @@ import (
 	k8s "github.com/codesphere-cloud/oms/internal/util"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 //mockery:generate: true
@@ -30,8 +31,8 @@ type argoCDResources struct {
 	GitPassword    string
 }
 
-func NewArgoCDResources(dataCenterId string, ociPassword string, ociRegistryURL string, gitPassword string) (ArgoCDResources, error) {
-	clientset, dynClient, err := k8s.NewClients()
+func NewArgoCDResourcesWithRESTConfig(dataCenterId string, ociPassword string, ociRegistryURL string, gitPassword string, restConfig *rest.Config) (ArgoCDResources, error) {
+	clientset, dynClient, err := k8s.NewClientsFromRESTConfig(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("creating kubernetes clients: %w", err)
 	}

--- a/internal/installer/argocd/installer.go
+++ b/internal/installer/argocd/installer.go
@@ -15,13 +15,12 @@ import (
 	"helm.sh/helm/v4/pkg/cli/values"
 	"helm.sh/helm/v4/pkg/getter"
 	"helm.sh/helm/v4/pkg/kube"
+	"k8s.io/client-go/rest"
 )
 
 const (
-	defaultRepoURL         = "https://argoproj.github.io/argo-helm"
-	DefaultNamespace       = "argocd"
-	DefaultVaultNamespace  = "codesphere-system"
-	DefaultVaultSecretName = "vault"
+	DefaultRepoURL   = "https://argoproj.github.io/argo-helm"
+	DefaultNamespace = "argocd"
 )
 
 // InstallerConfig holds all user-facing parameters for an ArgoCD install/upgrade.
@@ -35,6 +34,7 @@ type InstallerConfig struct {
 	ForceConflicts bool
 	RepoURL        string
 	ValueFiles     []string
+	RESTConfig     *rest.Config
 }
 
 // Installer holds the resolved configuration and initialized clients.
@@ -45,12 +45,12 @@ type Installer struct {
 }
 
 func NewInstaller(cfg InstallerConfig) (*Installer, error) {
-	helm, err := installer.NewHelmClient("argocd")
+	helm, err := installer.NewHelmClientWithRESTConfig("argocd", cfg.RESTConfig)
 	if err != nil {
 		return nil, fmt.Errorf("init helm client failed: %w", err)
 	}
 
-	resources, err := NewArgoCDResources(cfg.DatacenterId, cfg.OciPassword, cfg.OciRegistryURL, cfg.GitPassword)
+	resources, err := NewArgoCDResourcesWithRESTConfig(cfg.DatacenterId, cfg.OciPassword, cfg.OciRegistryURL, cfg.GitPassword, cfg.RESTConfig)
 	if err != nil {
 		return nil, fmt.Errorf("init argocd resources client failed: %w", err)
 	}
@@ -195,7 +195,7 @@ func (a *Installer) validateRepoURL() error {
 func (a *Installer) resolveChartRef(chartName string) (string, string) {
 	repoURL := a.RepoURL
 	if repoURL == "" {
-		repoURL = defaultRepoURL
+		repoURL = DefaultRepoURL
 	}
 	if strings.HasPrefix(repoURL, "oci://") {
 		return strings.TrimRight(repoURL, "/") + "/" + chartName, ""

--- a/internal/installer/codesphere.go
+++ b/internal/installer/codesphere.go
@@ -35,6 +35,9 @@ var KnownInstallerSteps = []string{
 	"ms-backends",
 }
 
+// ArgoCDStep is the skip-step name for the dependency-phase ArgoCD pre-step.
+const ArgoCDStep = "argocd"
+
 // InfraSteps are run in Phase 1 (before ArgoCD) when --argocd is active.
 var InfraSteps = []string{
 	"copy-dependencies",
@@ -133,6 +136,37 @@ func (ci *CodesphereInstaller) prepareConfig(cm ConfigManager) (files.RootConfig
 
 	ci.warnIfVaultDirDiffersFromSecretsDir(config)
 	return config, cleanup, nil
+}
+
+// IsStepSkipped reports whether step is present in persisted or CLI skip steps.
+func IsStepSkipped(config files.RootConfig, skipSteps []string, step string) bool {
+	skippedSteps := map[string]bool{}
+	if config.Operations != nil {
+		for _, skippedStep := range config.Operations.Skip {
+			skippedSteps[skippedStep] = true
+		}
+	}
+	for _, skippedStep := range skipSteps {
+		skippedSteps[skippedStep] = true
+	}
+	return skippedSteps[step]
+}
+
+// ApplySkippedSteps marks known executable steps as skipped from persisted or CLI skip steps.
+func ApplySkippedSteps(executableSteps map[string]bool, config files.RootConfig, skipSteps []string) {
+	if config.Operations != nil {
+		for _, step := range config.Operations.Skip {
+			if _, ok := executableSteps[step]; ok {
+				executableSteps[step] = false
+			}
+		}
+	}
+
+	for _, step := range skipSteps {
+		if _, ok := executableSteps[step]; ok {
+			executableSteps[step] = false
+		}
+	}
 }
 
 func (ci *CodesphereInstaller) warnIfVaultDirDiffersFromSecretsDir(config files.RootConfig) {
@@ -406,15 +440,7 @@ func (ci *CodesphereInstaller) executableInstallerSteps(config files.RootConfig)
 		executableSteps[step] = true
 	}
 
-	if config.Operations != nil {
-		for _, step := range config.Operations.Skip {
-			executableSteps[step] = false
-		}
-	}
-
-	for _, step := range ci.SkipSteps {
-		executableSteps[step] = false
-	}
+	ApplySkippedSteps(executableSteps, config, ci.SkipSteps)
 
 	return executableSteps
 }

--- a/internal/installer/codesphere_skip_test.go
+++ b/internal/installer/codesphere_skip_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package installer_test
+
+import (
+	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/installer/files"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Codesphere skip steps", func() {
+	It("detects persisted and CLI skip steps", func() {
+		config := files.RootConfig{
+			Operations: &files.OperationsConfig{
+				Skip: []string{installer.ArgoCDStep},
+			},
+		}
+
+		Expect(installer.IsStepSkipped(config, nil, installer.ArgoCDStep)).To(BeTrue())
+		Expect(installer.IsStepSkipped(files.RootConfig{}, []string{"ms-backends"}, "ms-backends")).To(BeTrue())
+		Expect(installer.IsStepSkipped(config, nil, "set-up-cluster")).To(BeFalse())
+	})
+
+	It("only applies skips to executable private-cloud installer steps", func() {
+		executableSteps := map[string]bool{
+			"set-up-cluster": true,
+			"ms-backends":    true,
+		}
+		config := files.RootConfig{
+			Operations: &files.OperationsConfig{
+				Skip: []string{installer.ArgoCDStep, "set-up-cluster"},
+			},
+		}
+
+		installer.ApplySkippedSteps(executableSteps, config, []string{"unknown-step", "ms-backends"})
+
+		Expect(executableSteps).To(Equal(map[string]bool{
+			"set-up-cluster": false,
+			"ms-backends":    false,
+		}))
+		Expect(executableSteps).NotTo(HaveKey(installer.ArgoCDStep))
+		Expect(executableSteps).NotTo(HaveKey("unknown-step"))
+	})
+})

--- a/internal/installer/config_manager.go
+++ b/internal/installer/config_manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"path/filepath"
 
 	"github.com/codesphere-cloud/oms/internal/configtemplating"
 	"github.com/codesphere-cloud/oms/internal/installer/files"
@@ -32,6 +33,7 @@ type InstallConfigManager interface {
 	ValidateVault() []string
 	GetInstallConfig() *files.RootConfig
 	GetVault() *files.InstallVault
+	GetSecretFilePath() string
 	CollectInteractively() error
 
 	// Output
@@ -207,6 +209,10 @@ func (g *InstallConfig) GetInstallConfig() *files.RootConfig {
 
 func (g *InstallConfig) GetVault() *files.InstallVault {
 	return g.Vault
+}
+
+func (g *InstallConfig) GetSecretFilePath() string {
+	return filepath.Join(g.Config.Secrets.BaseDir, "prod.vault.yaml")
 }
 
 func (g *InstallConfig) WriteInstallConfig(configPath string, withComments bool) error {

--- a/internal/installer/helm_client.go
+++ b/internal/installer/helm_client.go
@@ -18,6 +18,14 @@ import (
 	"helm.sh/helm/v4/pkg/registry"
 	"helm.sh/helm/v4/pkg/release"
 	"helm.sh/helm/v4/pkg/storage/driver"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // ReleaseInfo holds the details of an existing Helm release that the rest of
@@ -75,6 +83,7 @@ type HelmClient interface {
 type helmClient struct {
 	defaultNamespace string
 	driver           string
+	restConfig       *rest.Config
 	registryClient   *registry.Client
 }
 
@@ -82,6 +91,18 @@ func NewHelmClient(namespace string) (HelmClient, error) {
 	return &helmClient{
 		defaultNamespace: namespace,
 		driver:           os.Getenv("HELM_DRIVER"),
+	}, nil
+}
+
+func NewHelmClientWithRESTConfig(namespace string, restConfig *rest.Config) (HelmClient, error) {
+	if restConfig == nil {
+		return nil, fmt.Errorf("rest config is required")
+	}
+
+	return &helmClient{
+		defaultNamespace: namespace,
+		driver:           os.Getenv("HELM_DRIVER"),
+		restConfig:       rest.CopyConfig(restConfig),
 	}, nil
 }
 
@@ -125,9 +146,14 @@ func (h *helmClient) newHelmEnv(namespace string) (*helmEnv, error) {
 	settings := cli.New()
 	settings.SetNamespace(namespace)
 
+	restClientGetter := settings.RESTClientGetter()
+	if h.restConfig != nil {
+		restClientGetter = newRESTConfigGetter(h.restConfig, namespace)
+	}
+
 	actionConfig := new(action.Configuration)
 	if err := actionConfig.Init(
-		settings.RESTClientGetter(),
+		restClientGetter,
 		namespace,
 		h.driver,
 	); err != nil {
@@ -146,6 +172,57 @@ func (h *helmClient) newHelmEnv(namespace string) (*helmEnv, error) {
 	}
 
 	return &helmEnv{actionConfig: actionConfig, settings: settings}, nil
+}
+
+type restConfigGetter struct {
+	config    *rest.Config
+	namespace string
+}
+
+// restConfigGetter adapts an in-memory rest.Config to Helm's expected
+// RESTClientGetter interface. Helm cannot use rest.Config directly because the
+// SDK also asks the getter for discovery, REST mapping, and namespace
+// resolution while installing/upgrading resources. Providing those wrappers
+// lets callers reuse a parsed kubeconfig without writing it to disk just so
+// Helm's default EnvSettings can read it back.
+func newRESTConfigGetter(config *rest.Config, namespace string) *restConfigGetter {
+	return &restConfigGetter{
+		config:    rest.CopyConfig(config),
+		namespace: namespace,
+	}
+}
+
+func (g *restConfigGetter) ToRESTConfig() (*rest.Config, error) {
+	return rest.CopyConfig(g.config), nil
+}
+
+func (g *restConfigGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	clientset, err := kubernetes.NewForConfig(rest.CopyConfig(g.config))
+	if err != nil {
+		return nil, err
+	}
+	return memory.NewMemCacheClient(clientset.Discovery()), nil
+}
+
+func (g *restConfigGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	discoveryClient, err := g.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+	return restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient), nil
+}
+
+func (g *restConfigGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	config := clientcmdapi.NewConfig()
+	config.CurrentContext = "in-memory"
+	config.Contexts[config.CurrentContext] = &clientcmdapi.Context{
+		Cluster:   "in-memory",
+		AuthInfo:  "in-memory",
+		Namespace: g.namespace,
+	}
+	config.Clusters["in-memory"] = &clientcmdapi.Cluster{Server: g.config.Host}
+	config.AuthInfos["in-memory"] = &clientcmdapi.AuthInfo{}
+	return clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{})
 }
 
 func waitStrategy(s kube.WaitStrategy) kube.WaitStrategy {

--- a/internal/installer/mocks.go
+++ b/internal/installer/mocks.go
@@ -361,6 +361,50 @@ func (_c *MockInstallConfigManager_GetInstallConfig_Call) RunAndReturn(run func(
 	return _c
 }
 
+// GetSecretFilePath provides a mock function for the type MockInstallConfigManager
+func (_mock *MockInstallConfigManager) GetSecretFilePath() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSecretFilePath")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockInstallConfigManager_GetSecretFilePath_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSecretFilePath'
+type MockInstallConfigManager_GetSecretFilePath_Call struct {
+	*mock.Call
+}
+
+// GetSecretFilePath is a helper method to define mock.On call
+func (_e *MockInstallConfigManager_Expecter) GetSecretFilePath() *MockInstallConfigManager_GetSecretFilePath_Call {
+	return &MockInstallConfigManager_GetSecretFilePath_Call{Call: _e.mock.On("GetSecretFilePath")}
+}
+
+func (_c *MockInstallConfigManager_GetSecretFilePath_Call) Run(run func()) *MockInstallConfigManager_GetSecretFilePath_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockInstallConfigManager_GetSecretFilePath_Call) Return(s string) *MockInstallConfigManager_GetSecretFilePath_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockInstallConfigManager_GetSecretFilePath_Call) RunAndReturn(run func() string) *MockInstallConfigManager_GetSecretFilePath_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetVault provides a mock function for the type MockInstallConfigManager
 func (_mock *MockInstallConfigManager) GetVault() *files.InstallVault {
 	ret := _mock.Called()

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	sigyaml "sigs.k8s.io/yaml"
 )
@@ -141,9 +142,8 @@ func ApplySecretFromYAML(ctx context.Context, clientset kubernetes.Interface, da
 	return nil
 }
 
-// NewClients creates both a typed and dynamic Kubernetes client
-// using the current kubeconfig context (respects KUBECONFIG env var
-// and defaults to ~/.kube/config).
+// NewClients creates both a typed and dynamic Kubernetes client using the
+// current kubeconfig context.
 func NewClients() (kubernetes.Interface, dynamic.Interface, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
@@ -154,12 +154,20 @@ func NewClients() (kubernetes.Interface, dynamic.Interface, error) {
 		return nil, nil, fmt.Errorf("loading kubeconfig: %w", err)
 	}
 
-	clientset, err := kubernetes.NewForConfig(cfg)
+	return NewClientsFromRESTConfig(cfg)
+}
+
+func NewClientsFromRESTConfig(cfg *rest.Config) (kubernetes.Interface, dynamic.Interface, error) {
+	if cfg == nil {
+		return nil, nil, fmt.Errorf("rest config is required")
+	}
+
+	clientset, err := kubernetes.NewForConfig(rest.CopyConfig(cfg))
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating kubernetes clientset: %w", err)
 	}
 
-	dynClient, err := dynamic.NewForConfig(cfg)
+	dynClient, err := dynamic.NewForConfig(rest.CopyConfig(cfg))
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating dynamic client: %w", err)
 	}


### PR DESCRIPTION
Before running the existing dependency steps (set-up-cluster, ms-backends), the dependencies phase now deploys ArgoCD with full DC config, syncs the vault to a Kubernetes secret, and installs pc-applications from the BOM.

- Registry credentials (password) are read from the vault using the existing priv-key; the OCI registry URL is sourced from config.yaml registry.server
- The datacenter ID is read from config.yaml instead of being a CLI flag
- The pc-apps version is derived from bom.json via NewPcAppsFromBom; namespace is hardcoded to argocd.DefaultNamespace
- Vault secret namespace/name are hardcoded to installer constants
- Pass --skip-argo to bypass the entire pre-step (ArgoCD enabled by default)