### PR TITLE
fix(install): store CentralOtel credentials in the vault

### DIFF
--- a/internal/bootstrap/gcp/install_config.go
+++ b/internal/bootstrap/gcp/install_config.go
@@ -385,6 +385,7 @@ func (b *GCPBootstrapper) UpdateInstallConfig() error {
 			Username: b.Env.CentralOtelUsername,
 			Password: b.Env.CentralOtelPassword,
 		}
+		b.icg.GetVault().SetSecret(files.SecretEntry{Name: files.SecretCentralOtelCreds, Fields: &files.SecretFields{Username: b.Env.CentralOtelUsername, Password: b.Env.CentralOtelPassword}})
 	}
 
 	if b.Env.OpenBaoURI != "" {

--- a/internal/bootstrap/gcp/install_config_test.go
+++ b/internal/bootstrap/gcp/install_config_test.go
@@ -627,6 +627,21 @@ var _ = Describe("Installconfig & Secrets", func() {
 					Expect(centralOtel.Username).To(Equal("otel-user"))
 					Expect(centralOtel.Password).To(Equal("otel-password"))
 				})
+				It("stores CentralOtel username and password in the vault", func() {
+					icg.EXPECT().GenerateSecrets().Return(nil)
+					icg.EXPECT().WriteInstallConfig("fake-config-file", true).Return(nil)
+					icg.EXPECT().WriteVault("fake-secret", true).Return(nil)
+					nodeClient.EXPECT().CopyFile(mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
+
+					err := bs.UpdateInstallConfig()
+					Expect(err).NotTo(HaveOccurred())
+
+					secret := vault.GetSecret(files.SecretCentralOtelCreds)
+					Expect(secret).NotTo(BeNil())
+					Expect(secret.Fields).NotTo(BeNil())
+					Expect(secret.Fields.Username).To(Equal("otel-user"))
+					Expect(secret.Fields.Password).To(Equal("otel-password"))
+				})
 			})
 
 			Context("When only CentralOtel username is set", func() {

--- a/internal/installer/files/secret_names.go
+++ b/internal/installer/files/secret_names.go
@@ -45,6 +45,7 @@ const (
 
 	// Monitoring
 	SecretLokiGatewayBasicAuthPassword = "lokiGatewayBasicAuthPassword"
+	SecretCentralOtelCreds             = "centralOtelCreds"
 
 	// Postgres
 	SecretPostgresCaKeyPem            = "postgresCaKeyPem"


### PR DESCRIPTION
Sets the centralOtelCreds vault secret with both Username and Password via SecretFields.

Was probably missed when migration secrets in #495