### PR TITLE
fix(cs install): respect the --codesphereOnly flag

### DIFF
--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -33,6 +33,9 @@ type InstallCodesphereOpts struct {
 }
 
 func (c *InstallCodesphereCmd) RunE(_ *cobra.Command, _ []string) error {
+	if c.Opts.CodesphereOnly {
+		return installCodespherePlatform(c.Opts, c.Env)
+	}
 	if err := installCodesphereInfra(c.Opts, c.Env); err != nil {
 		return err
 	}
@@ -96,6 +99,11 @@ func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm
 		{steps: installer.DependenciesSteps, skipImageBuilding: true},
 		{steps: installer.PlatformSteps, skipImageBuilding: true},
 	}
+	if c.Opts.CodesphereOnly {
+		phases = []phaseConfig{
+			{steps: installer.PlatformSteps, skipImageBuilding: true},
+		}
+	}
 	for _, phase := range phases {
 		ci := &installer.CodesphereInstaller{
 			ConfigPath:        c.Opts.Config,
@@ -105,6 +113,7 @@ func (c *InstallCodesphereCmd) ExtractAndInstall(pm installer.PackageManager, cm
 			SkipSteps:         c.Opts.SkipSteps,
 			AllowedSteps:      phase.steps,
 			SkipImageBuilding: phase.skipImageBuilding,
+			CodesphereOnly:    c.Opts.CodesphereOnly,
 			DirectConnection:  c.Opts.DirectConnection,
 			AutoApprove:       c.Opts.AutoApprove,
 		}

--- a/cli/cmd/install_codesphere_platform.go
+++ b/cli/cmd/install_codesphere_platform.go
@@ -39,6 +39,7 @@ func installCodespherePlatform(opts *InstallCodesphereOpts, env env.Env) error {
 		Force:            opts.Force,
 		SkipSteps:        opts.SkipSteps,
 		AllowedSteps:     installer.PlatformSteps,
+		CodesphereOnly:   opts.CodesphereOnly,
 		DirectConnection: opts.DirectConnection,
 		AutoApprove:      opts.AutoApprove,
 	}

--- a/cli/cmd/install_codesphere_test.go
+++ b/cli/cmd/install_codesphere_test.go
@@ -339,6 +339,73 @@ var _ = Describe("InstallCodesphereCmd", func() {
 				Expect(err).To(BeNil())
 			})
 
+			It("runs only the codesphere step when CodesphereOnly is set", func() {
+				mockPackageManager := installer.NewMockPackageManager(GinkgoT())
+				mockConfigManager := installer.NewMockConfigManager(GinkgoT())
+				mockImageManager := system.NewMockImageManager(GinkgoT())
+				mockFileIO := util.NewMockFileIO(GinkgoT())
+
+				c.Opts.Config = "valid-config.yaml"
+				c.Opts.PrivKey = "test-key.pem"
+				c.Opts.CodesphereOnly = true
+
+				config := files.RootConfig{
+					Registry: &files.RegistryConfig{
+						Server: "https://my-registry.com",
+					},
+					Codesphere: files.CodesphereConfig{
+						DeployConfig: files.DeployConfig{
+							Images: map[string]files.ImageConfig{
+								"ubuntu-24.04": {
+									Flavors: map[string]files.FlavorConfig{
+										"default": {
+											Image: files.ImageRef{
+												BomRef:     "docker.io/library/ubuntu:24.04",
+												Dockerfile: "workspace.Dockerfile",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				mockConfigManager.EXPECT().ParseConfigYaml("valid-config.yaml").Return(config, nil)
+
+				tempDir, err := os.MkdirTemp("", "test-install")
+				Expect(err).To(BeNil())
+				defer func() {
+					_ = os.RemoveAll(tempDir)
+				}()
+
+				argsFile := filepath.Join(tempDir, "installer-args.txt")
+				nodeFile := filepath.Join(tempDir, "node")
+				err = os.WriteFile(nodeFile, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > "+argsFile+"\n"), 0755)
+				Expect(err).To(BeNil())
+
+				mockPackageManager.EXPECT().Extract(false).Return(nil)
+				mockPackageManager.EXPECT().GetWorkDir().Return(tempDir).Maybe()
+				mockPackageManager.EXPECT().FileIO().Return(mockFileIO)
+				mockFileIO.EXPECT().Exists(tempDir).Return(true)
+				mockFileIO.EXPECT().ReadDir(tempDir).Return([]os.DirEntry{
+					&MockDirEntry{name: "deps.tar.gz", isDir: false},
+					&MockDirEntry{name: "node", isDir: false},
+					&MockDirEntry{name: "private-cloud-installer.js", isDir: false},
+					&MockDirEntry{name: "kubectl", isDir: false},
+				}, nil)
+				mockPackageManager.EXPECT().ExtractDependency("bom.json", false).Return(nil)
+
+				err = c.ExtractAndInstall(mockPackageManager, mockConfigManager, mockImageManager, "linux", "amd64")
+				Expect(err).To(BeNil())
+
+				args, err := os.ReadFile(argsFile)
+				Expect(err).To(BeNil())
+				Expect(string(args)).To(ContainSubstring("--codesphereOnly\n"))
+				Expect(string(args)).To(ContainSubstring("--skipStep\ncopy-dependencies\n"))
+				Expect(string(args)).To(ContainSubstring("--skipStep\nms-backends\n"))
+				Expect(string(args)).NotTo(ContainSubstring("--skipStep\ncodesphere\n"))
+			})
+
 			It("fails when image tag in bom.json is missing version", func() {
 				mockPackageManager := installer.NewMockPackageManager(GinkgoT())
 				mockConfigManager := installer.NewMockConfigManager(GinkgoT())


### PR DESCRIPTION
With the split of the codepshere install steps, the `codepshereOnly` flag did not get respected anymore.
This PR adds back the flag and only runs the platform install if specified