### PR TITLE
fix(argocd): Fix oms install deps command and argocd deploy to use environment kubeconfig

### DIFF
--- a/cli/cmd/install_codesphere_dependencies.go
+++ b/cli/cmd/install_codesphere_dependencies.go
@@ -40,21 +40,13 @@ func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error 
 	pm := installer.NewPackage(workdir, opts.Package)
 	stlog := bootstrap.NewStepLogger(false)
 	cm := installer.NewConfig()
+	im := system.NewImage(context.Background())
 
 	cfg, cleanup, err := parseInstallConfig(opts, cm)
 	if err != nil {
 		return fmt.Errorf("failed to extract config.yaml: %w", err)
 	}
 	defer cleanup()
-
-	if !installer.IsStepSkipped(cfg, opts.SkipSteps, installer.ArgoCDStep) {
-		if err := stlog.Step("Install ArgoCD pre-step", func() error {
-			return installArgoCDAndApps(opts, pm, stlog)
-		}); err != nil {
-			return err
-		}
-	}
-	im := system.NewImage(context.Background())
 
 	ci := &installer.CodesphereInstaller{
 		ConfigPath:       opts.Config,
@@ -66,6 +58,18 @@ func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error 
 		DirectConnection: opts.DirectConnection,
 		AutoApprove:      opts.AutoApprove,
 	}
+
+	if !installer.IsStepSkipped(cfg, opts.SkipSteps, installer.ArgoCDStep) {
+		if err := ci.ExtractAndValidatePackage(pm); err != nil {
+			return fmt.Errorf("failed to extract and validate package: %w", err)
+		}
+		if err := stlog.Step("Install ArgoCD pre-step", func() error {
+			return installArgoCDAndApps(opts, pm, stlog)
+		}); err != nil {
+			return err
+		}
+	}
+
 	if err := ci.Install(pm, cm, im, runtime.GOOS, runtime.GOARCH); err != nil {
 		return fmt.Errorf("failed to install dependencies: %w", err)
 	}

--- a/internal/installer/argocd/argocd_resources.go
+++ b/internal/installer/argocd/argocd_resources.go
@@ -13,7 +13,6 @@ import (
 	k8s "github.com/codesphere-cloud/oms/internal/util"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 //mockery:generate: true
@@ -31,12 +30,7 @@ type argoCDResources struct {
 	GitPassword    string
 }
 
-func NewArgoCDResourcesWithRESTConfig(dataCenterId string, ociPassword string, ociRegistryURL string, gitPassword string, restConfig *rest.Config) (ArgoCDResources, error) {
-	clientset, dynClient, err := k8s.NewClientsFromRESTConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("creating kubernetes clients: %w", err)
-	}
-
+func NewArgoCDResources(clientset kubernetes.Interface, dynClient dynamic.Interface, dataCenterId string, ociPassword string, ociRegistryURL string, gitPassword string) (ArgoCDResources, error) {
 	return &argoCDResources{
 		clientset:      clientset,
 		dynClient:      dynClient,

--- a/internal/installer/argocd/installer.go
+++ b/internal/installer/argocd/installer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/codesphere-cloud/oms/internal/installer"
+	k8s "github.com/codesphere-cloud/oms/internal/util"
 	"helm.sh/helm/v4/pkg/chart/common/util"
 	"helm.sh/helm/v4/pkg/cli/values"
 	"helm.sh/helm/v4/pkg/getter"
@@ -45,12 +46,35 @@ type Installer struct {
 }
 
 func NewInstaller(cfg InstallerConfig) (*Installer, error) {
-	helm, err := installer.NewHelmClientWithRESTConfig("argocd", cfg.RESTConfig)
+	if cfg.RESTConfig != nil {
+		helm, err := installer.NewHelmClientWithRESTConfig(DefaultNamespace, cfg.RESTConfig)
+		if err != nil {
+			return nil, fmt.Errorf("init helm client failed: %w", err)
+		}
+
+		clientset, dynClient, err := k8s.NewClientsFromRESTConfig(cfg.RESTConfig)
+		if err != nil {
+			return nil, fmt.Errorf("creating kubernetes clients: %w", err)
+		}
+		resources, err := NewArgoCDResources(clientset, dynClient, cfg.DatacenterId, cfg.OciPassword, cfg.OciRegistryURL, cfg.GitPassword)
+		if err != nil {
+			return nil, fmt.Errorf("init argocd resources client failed: %w", err)
+		}
+		return &Installer{
+			InstallerConfig: cfg,
+			Helm:            helm,
+			Resources:       resources,
+		}, nil
+	}
+	helm, err := installer.NewHelmClient(DefaultNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("init helm client failed: %w", err)
 	}
-
-	resources, err := NewArgoCDResourcesWithRESTConfig(cfg.DatacenterId, cfg.OciPassword, cfg.OciRegistryURL, cfg.GitPassword, cfg.RESTConfig)
+	clientset, dynClient, err := k8s.NewClients()
+	if err != nil {
+		return nil, fmt.Errorf("creating kubernetes clients: %w", err)
+	}
+	resources, err := NewArgoCDResources(clientset, dynClient, cfg.DatacenterId, cfg.OciPassword, cfg.OciRegistryURL, cfg.GitPassword)
 	if err != nil {
 		return nil, fmt.Errorf("init argocd resources client failed: %w", err)
 	}

--- a/internal/installer/codesphere.go
+++ b/internal/installer/codesphere.go
@@ -98,7 +98,7 @@ func (ci *CodesphereInstaller) Install(pm PackageManager, cm ConfigManager, im s
 		return err
 	}
 
-	if err := ci.extractAndValidatePackage(pm); err != nil {
+	if err := ci.ExtractAndValidatePackage(pm); err != nil {
 		return err
 	}
 
@@ -191,7 +191,7 @@ func (ci *CodesphereInstaller) warnIfVaultDirDiffersFromSecretsDir(config files.
 	}
 }
 
-func (ci *CodesphereInstaller) extractAndValidatePackage(pm PackageManager) error {
+func (ci *CodesphereInstaller) ExtractAndValidatePackage(pm PackageManager) error {
 	if err := pm.Extract(ci.Force); err != nil {
 		return fmt.Errorf("failed to extract package to workdir: %w", err)
 	}


### PR DESCRIPTION
With the integration into the dedicated commands, the argo install got broken due to missing kubeconfigs.

When the `oms install codesphere deps` command is run on its own it requires the installer package to be already extracted. This change now extracts it when argo is deployed.