### PR TITLE
draft: Add Password Policies For Generate Secrets Feature

### DIFF
--- a/internal/installer/manifests/openbao/vault-cr.yaml
+++ b/internal/installer/manifests/openbao/vault-cr.yaml
@@ -118,6 +118,12 @@ spec:
           path "{{ .SecretsEngineName }}/metadata/*" {
             capabilities = ["list", "read", "delete"]
           }
+          # Required by the `generate` secret flow, which manages OpenBao
+          # password policies under sys/policies/password/<name> and reads
+          # generated values from sys/policies/password/<name>/generate.
+          path "sys/policies/password/*" {
+            capabilities = ["create", "read", "update", "delete"]
+          }
     auth:
       - type: userpass
         users:

--- a/internal/installer/openbao_test.go
+++ b/internal/installer/openbao_test.go
@@ -767,6 +767,17 @@ var _ = Describe("OpenBaoInstaller", func() {
 			secretEntry := secrets[0].(map[string]interface{})
 			Expect(secretEntry["path"]).To(Equal("cs-secrets-engine"))
 
+			// Verify the rw policy grants KV access plus the password-policy
+			// management the `generate` secret flow needs.
+			policies := externalConfig["policies"].([]interface{})
+			Expect(policies).To(HaveLen(1))
+			policy := policies[0].(map[string]interface{})
+			Expect(policy["name"]).To(Equal("cs-secrets-engine-rw"))
+			rules := policy["rules"].(string)
+			Expect(rules).To(ContainSubstring(`path "cs-secrets-engine/data/*"`))
+			Expect(rules).To(ContainSubstring(`path "cs-secrets-engine/metadata/*"`))
+			Expect(rules).To(ContainSubstring(`path "sys/policies/password/*"`))
+
 			// Verify auth config
 			auth := externalConfig["auth"].([]interface{})
 			Expect(auth).To(HaveLen(1))


### PR DESCRIPTION
context: The Generate Secrets Feature needs those policies, so that the admin user is able to createsecret policies and generate secrets from those policies. 