### PR TITLE
fix(installer): reuse kube rest config for pc-apps helm

### DIFF
--- a/cli/cmd/install_codesphere_dependencies.go
+++ b/cli/cmd/install_codesphere_dependencies.go
@@ -199,7 +199,7 @@ func (i *argoCDAndAppsInstall) syncVaultSecret() error {
 }
 
 func (i *argoCDAndAppsInstall) installPcApps() error {
-	pcApps, err := installer.NewPcAppsFromBom(i.kubeClient, i.pm.GetDependencyPath("bom.json"), argocdinstaller.DefaultNamespace)
+	pcApps, err := installer.NewPcAppsFromBom(i.kubeClient, i.kubeConfig, i.pm.GetDependencyPath("bom.json"), argocdinstaller.DefaultNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to initialize pc-apps installer: %w", err)
 	}

--- a/internal/bootstrap/local/installer.go
+++ b/internal/bootstrap/local/installer.go
@@ -431,7 +431,7 @@ func (b *LocalBootstrapper) RunInstaller() (err error) {
 	}
 
 	if b.Env.UseArgoCD {
-		pcApps, err := installer.NewPcAppsFromBom(b.kubeClient, filepath.Join(depsDir, "bom.json"), argocd.DefaultNamespace)
+		pcApps, err := installer.NewPcAppsFromBom(b.kubeClient, b.restConfig, filepath.Join(depsDir, "bom.json"), argocd.DefaultNamespace)
 		if err != nil {
 			return fmt.Errorf("failed to initialize pc-apps installer from BOM: %w", err)
 		}

--- a/internal/installer/pc_apps.go
+++ b/internal/installer/pc_apps.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/codesphere-cloud/oms/internal/installer/bom"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"helm.sh/helm/v4/pkg/cli"
@@ -68,7 +69,7 @@ func NewPCApps(c client.Client, version, namespace string, valuesFiles []string,
 	}, nil
 }
 
-func NewPcAppsFromBom(c client.Client, bomPath string, namespace string) (*PCApps, error) {
+func NewPcAppsFromBom(c client.Client, restConfig *rest.Config, bomPath string, namespace string) (*PCApps, error) {
 	bomCfg, err := bom.Parse(bomPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse bom.json: %w", err)
@@ -79,7 +80,7 @@ func NewPcAppsFromBom(c client.Client, bomPath string, namespace string) (*PCApp
 		return nil, fmt.Errorf("pc-applications component not found in BOM")
 	}
 
-	helm, err := NewHelmClient(namespace)
+	helm, err := NewHelmClientWithRESTConfig(namespace, restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("creating helm client: %w", err)
 	}


### PR DESCRIPTION
Thread the existing Kubernetes REST config into NewPcAppsFromBom so its Helm client uses the same cluster configuration as the caller.

This avoids falling back to ambient kubeconfig state when installing pc-applications from the BOM and keeps the dependency and local bootstrap flows aligned with the provided controller-runtime client.