### PR TITLE
fix(bootstrap): fix vault path and add required dependency steps

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1225,25 +1225,25 @@ License URL: https://github.com/protocolbuffers/protobuf-go/blob/f2248ac996af/LI
 Module: gopkg.in/evanphx/json-patch.v4
 Version: v4.13.0
 License: BSD-3-Clause
-License URL: Unknown
+License URL: https://github.com/evanphx/json-patch/blob/v4.13.0/LICENSE
  
 ----------
 Module: gopkg.in/inf.v0
 Version: v0.9.1
 License: BSD-3-Clause
-License URL: Unknown
+License URL: https://github.com/go-inf/inf/blob/v0.9.1/LICENSE
  
 ----------
 Module: gopkg.in/validator.v2
 Version: v2.0.1
 License: Apache-2.0
-License URL: Unknown
+License URL: https://github.com/go-validator/validator/blob/v2.0.1/LICENSE
  
 ----------
 Module: gopkg.in/yaml.v3
 Version: v3.0.1
 License: MIT
-License URL: Unknown
+License URL: https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE
  
 ----------
 Module: helm.sh/helm/v4

--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -50,11 +50,11 @@ func (c *InstallCodesphereCmd) RunE(_ *cobra.Command, _ []string) error {
 		AllowedSteps: installer.InfraSteps,
 	}
 	dependenciesInstaller := &installer.CodesphereInstaller{
-		SkipSteps:    c.Opts.SkipSteps,
+		SkipSteps:    append(sharedInstallCodesphereSteps(), c.Opts.SkipSteps...),
 		AllowedSteps: installer.DependenciesSteps,
 	}
 	platformInstaller := &installer.CodesphereInstaller{
-		SkipSteps:    c.Opts.SkipSteps,
+		SkipSteps:    append(sharedInstallCodesphereSteps(), c.Opts.SkipSteps...),
 		AllowedSteps: installer.PlatformSteps,
 	}
 
@@ -128,4 +128,8 @@ func AddInstallCodesphereCmd(install *cobra.Command, opts *GlobalOptions) {
 	AddInstallCodesphereInfraCmd(codesphere.cmd, codesphere.Opts)
 	AddInstallCodesphereDepenciesCmd(codesphere.cmd, codesphere.Opts)
 	AddInstallCodespherePlatformCmd(codesphere.cmd, codesphere.Opts)
+}
+
+func sharedInstallCodesphereSteps() []string {
+	return []string{"copy-dependencies", "extract-dependencies"}
 }

--- a/cli/cmd/install_codesphere_dependencies.go
+++ b/cli/cmd/install_codesphere_dependencies.go
@@ -17,6 +17,7 @@ import (
 	"github.com/codesphere-cloud/oms/internal/installer"
 	argocdinstaller "github.com/codesphere-cloud/oms/internal/installer/argocd"
 	"github.com/codesphere-cloud/oms/internal/installer/files"
+	"github.com/codesphere-cloud/oms/internal/installer/secrets"
 	"github.com/codesphere-cloud/oms/internal/system"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
@@ -191,6 +192,10 @@ func (i *argoCDAndAppsInstall) installArgoCD() error {
 }
 
 func (i *argoCDAndAppsInstall) syncVaultSecret() error {
+	// Always create new service accounts tokens during creation to ensure they are always valid and updated.
+	if err := secrets.EnsureServiceAccountTokens(i.vault); err != nil {
+		return fmt.Errorf("failed to ensure service account tokens: %w", err)
+	}
 	creator := installer.NewVaultSecretCreator(i.kubeClient)
 	if err := creator.CreateSecretFromVault(i.ctx, i.vault, installer.VaultSecretNamespace, installer.VaultSecretName); err != nil {
 		return fmt.Errorf("failed to sync vault secret: %w", err)

--- a/internal/bootstrap/gcp/gcp.go
+++ b/internal/bootstrap/gcp/gcp.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -1021,7 +1022,7 @@ func (b *GCPBootstrapper) ensureCodespherePackageOnJumpbox() (string, error) {
 func (b *GCPBootstrapper) runInstallCommand(packageFilename string) error {
 	b.stlog.Logf("Installing Codesphere...")
 	installCmd := fmt.Sprintf("oms install codesphere -c /etc/codesphere/config.yaml -k %s/age_key.txt --vault %s -p %s%s",
-		b.Env.SecretsDir, b.icg.GetSecretFilePath(), packageFilename, b.generateSkipStepsArg())
+		b.Env.SecretsDir, filepath.Join(b.Env.SecretsDir, "prod.vault.yaml"), packageFilename, b.generateSkipStepsArg())
 	return b.Env.Jumpbox.RunSSHCommand("root", installCmd)
 }
 

--- a/internal/codesphere/secrets.go
+++ b/internal/codesphere/secrets.go
@@ -1,4 +1,0 @@
-// Copyright (c) Codesphere Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-package codesphere

--- a/internal/installer/codesphere.go
+++ b/internal/installer/codesphere.go
@@ -52,10 +52,10 @@ var InfraSteps = []string{
 }
 
 // DependenciesSteps run in Phase 2 after infrastructure is ready.
-var DependenciesSteps = []string{"set-up-cluster", "ms-backends"}
+var DependenciesSteps = []string{"copy-dependencies", "extract-dependencies", "set-up-cluster", "ms-backends"}
 
 // PlatformSteps run in Phase 3 and install the Codesphere platform only.
-var PlatformSteps = []string{"codesphere"}
+var PlatformSteps = []string{"copy-dependencies", "extract-dependencies", "codesphere"}
 
 // CodesphereInstaller encapsulates the logic for running the private-cloud-installer.js script.
 type CodesphereInstaller struct {

--- a/internal/installer/codesphere_skip_test.go
+++ b/internal/installer/codesphere_skip_test.go
@@ -47,13 +47,13 @@ var _ = Describe("Codesphere skip steps", func() {
 	It("detects when an allowed step set has no executable steps left", func() {
 		config := files.RootConfig{
 			Operations: &files.OperationsConfig{
-				Skip: []string{"set-up-cluster"},
+				Skip: []string{"copy-dependencies", "set-up-cluster"},
 			},
 		}
 
 		ci := &installer.CodesphereInstaller{
 			AllowedSteps: installer.DependenciesSteps,
-			SkipSteps:    []string{"ms-backends"},
+			SkipSteps:    []string{"extract-dependencies", "ms-backends"},
 		}
 
 		Expect(ci.HasExecutableSteps(config)).To(BeFalse())
@@ -84,13 +84,13 @@ var _ = Describe("Codesphere skip steps", func() {
 	It("returns no executable steps when all known allowed steps are skipped", func() {
 		config := files.RootConfig{
 			Operations: &files.OperationsConfig{
-				Skip: []string{"set-up-cluster"},
+				Skip: []string{"copy-dependencies", "set-up-cluster"},
 			},
 		}
 
 		ci := &installer.CodesphereInstaller{
 			AllowedSteps: installer.DependenciesSteps,
-			SkipSteps:    []string{"ms-backends", installer.ArgoCDStep},
+			SkipSteps:    []string{"extract-dependencies", "ms-backends", installer.ArgoCDStep},
 		}
 
 		Expect(ci.ExecutableSteps(config)).To(BeEmpty())

--- a/internal/tmpl/NOTICE
+++ b/internal/tmpl/NOTICE
@@ -1225,25 +1225,25 @@ License URL: https://github.com/protocolbuffers/protobuf-go/blob/f2248ac996af/LI
 Module: gopkg.in/evanphx/json-patch.v4
 Version: v4.13.0
 License: BSD-3-Clause
-License URL: Unknown
+License URL: https://github.com/evanphx/json-patch/blob/v4.13.0/LICENSE
  
 ----------
 Module: gopkg.in/inf.v0
 Version: v0.9.1
 License: BSD-3-Clause
-License URL: Unknown
+License URL: https://github.com/go-inf/inf/blob/v0.9.1/LICENSE
  
 ----------
 Module: gopkg.in/validator.v2
 Version: v2.0.1
 License: Apache-2.0
-License URL: Unknown
+License URL: https://github.com/go-validator/validator/blob/v2.0.1/LICENSE
  
 ----------
 Module: gopkg.in/yaml.v3
 Version: v3.0.1
 License: MIT
-License URL: Unknown
+License URL: https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE
  
 ----------
 Module: helm.sh/helm/v4


### PR DESCRIPTION
- Fix the vault path in runInstallCommand to use filepath.Join(SecretsDir, "prod.vault.yaml") instead of icg.GetSecretFilePath(), ensuring the correct vault path is passed to the install command
- Add "copy-dependencies" and "extract-dependencies" steps to DependenciesSteps and PlatformSteps so that required artifacts are always staged before cluster setup and platform installation