### PR TITLE
fix: typo in ceph osd names

### DIFF
--- a/internal/installer/files/config_yaml.go
+++ b/internal/installer/files/config_yaml.go
@@ -143,8 +143,8 @@ type CephHost struct {
 type CephOSD struct {
 	SpecID      string          `yaml:"specId"`
 	Placement   CephPlacement   `yaml:"placement"`
-	DataDevices CephDataDevices `yaml:"data_devices"`
-	DBDevices   CephDBDevices   `yaml:"db_devices"`
+	DataDevices CephDataDevices `yaml:"dataDevices"`
+	DBDevices   CephDBDevices   `yaml:"dbDevices"`
 }
 
 type CephPlacement struct {


### PR DESCRIPTION
reverting a typo in the config yaml