### PR TITLE
feat(install): support merged config overlays and pc-apps values

### DIFF
--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/codesphere-cloud/cs-go/pkg/io"
 	"github.com/codesphere-cloud/oms/internal/configtemplating"
@@ -16,6 +17,11 @@ import (
 	"github.com/codesphere-cloud/oms/internal/util"
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v3"
+)
+
+const (
+	mergedInstallConfigDirPattern = "oms-install-config-*"
+	mergedInstallConfigFileName   = "config.yaml"
 )
 
 // InstallCodesphereCmd represents the codesphere command
@@ -29,8 +35,8 @@ type InstallCodesphereOpts struct {
 	*GlobalOptions
 	Package          string
 	Force            bool
-	Config           string
-	ConfigFiles      []string
+	Configs          []string
+	ConfigPath       string
 	Vault            string
 	PrivKey          string
 	SkipSteps        []string
@@ -77,7 +83,7 @@ func (c *InstallCodesphereCmd) RunE(_ *cobra.Command, _ []string) error {
 	}
 
 	if dependenciesInstaller.HasExecutableSteps(cfg) || !installer.IsStepSkipped(cfg, c.Opts.SkipSteps, installer.ArgoCDStep) {
-		if err := installCodesphereDepencies(effectiveOpts, c.Env); err != nil {
+		if err := installCodesphereDepencies(effectiveOpts, cfg, c.Env); err != nil {
 			return err
 		}
 	}
@@ -112,7 +118,7 @@ func AddInstallCodesphereCmd(install *cobra.Command, opts *GlobalOptions) {
 	}
 	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.Package, "package", "p", "", "Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from")
 	codesphere.cmd.PersistentFlags().BoolVarP(&codesphere.Opts.Force, "force", "f", false, "Enforce package extraction")
-	codesphere.cmd.PersistentFlags().StringArrayVarP(&codesphere.Opts.ConfigFiles, "config", "c", nil, "Path to a Codesphere Private Cloud configuration file (yaml). Can be specified multiple times and merged in order")
+	codesphere.cmd.PersistentFlags().StringArrayVarP(&codesphere.Opts.Configs, "config", "c", nil, "Path to a Codesphere Private Cloud configuration file (yaml). Can be specified multiple times and merged in order")
 	codesphere.cmd.PersistentFlags().StringVar(&codesphere.Opts.Vault, "vault", "", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
 	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.PrivKey, "priv-key", "k", "", "Path to the private key to encrypt/decrypt secrets")
 	codesphere.cmd.PersistentFlags().StringSliceVarP(&codesphere.Opts.SkipSteps, "skip-steps", "s", []string{}, "Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd")
@@ -143,10 +149,20 @@ func sharedInstallCodesphereSteps() []string {
 	return []string{"copy-dependencies", "extract-dependencies"}
 }
 
+// prepareInstallConfig resolves the install command's repeated --config inputs
+// into a single config file for downstream installer steps.
+//
+// For each input config it optionally renders vault-backed template expressions,
+// parses the YAML into a generic map, and deep-merges the maps in flag order so
+// later --config values override earlier ones. The merged YAML is then written
+// to a dedicated temporary directory at a stable file name,
+// "<tmp>/config.yaml", parsed once through the config manager, and returned via
+// effectiveOpts.ConfigPath. The returned cleanup function removes any rendered
+// per-file temps as well as the merged config directory.
 func prepareInstallConfig(opts *InstallCodesphereOpts, cm installer.ConfigManager) (*InstallCodesphereOpts, files.RootConfig, func(), error) {
-	configFiles := opts.configInputs()
+	configFiles := append([]string(nil), opts.Configs...)
 	if len(configFiles) == 0 {
-		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: at least one config file is required")
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("no config.yaml input provided: at least one config file is required")
 	}
 
 	store := installer.NewLazyVaultTemplatingSecretStore(opts.Vault, opts.PrivKey)
@@ -164,7 +180,7 @@ func prepareInstallConfig(opts *InstallCodesphereOpts, cm installer.ConfigManage
 			tmpPath, renderCleanup, err := configtemplating.RenderConfigFileToTemp(configPath, store)
 			if err != nil {
 				cleanup()
-				return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: %w", err)
+				return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to render config template %s: %w", configPath, err)
 			}
 			cleanupFns = append(cleanupFns, renderCleanup)
 			renderedPath = tmpPath
@@ -173,13 +189,13 @@ func prepareInstallConfig(opts *InstallCodesphereOpts, cm installer.ConfigManage
 		data, err := os.ReadFile(renderedPath)
 		if err != nil {
 			cleanup()
-			return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to read config file %s: %w", renderedPath, err)
+			return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to read config file %s: %w", renderedPath, err)
 		}
 
 		var partial map[string]any
 		if err := yaml.Unmarshal(data, &partial); err != nil {
 			cleanup()
-			return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to parse config.yaml: %w", err)
+			return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to parse config file %s: %w", renderedPath, err)
 		}
 		if partial == nil {
 			partial = map[string]any{}
@@ -190,56 +206,45 @@ func prepareInstallConfig(opts *InstallCodesphereOpts, cm installer.ConfigManage
 	mergedBytes, err := yaml.Marshal(merged)
 	if err != nil {
 		cleanup()
-		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to marshal merged config.yaml: %w", err)
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to marshal merged config.yaml: %w", err)
 	}
 
-	tmp, err := os.CreateTemp("", "oms-merged-config-*.yaml")
+	mergedDir, err := os.MkdirTemp("", mergedInstallConfigDirPattern)
 	if err != nil {
 		cleanup()
-		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to create merged config file: %w", err)
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to create merged config directory: %w", err)
 	}
-	mergedPath := tmp.Name()
-	if err := tmp.Chmod(0600); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(mergedPath)
+	mergedPath := filepath.Join(mergedDir, mergedInstallConfigFileName)
+	tmp, err := os.OpenFile(mergedPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
 		cleanup()
-		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to set merged config permissions: %w", err)
+		_ = os.RemoveAll(mergedDir)
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to create merged config file %s: %w", mergedPath, err)
 	}
 	if _, err := tmp.Write(mergedBytes); err != nil {
 		_ = tmp.Close()
-		_ = os.Remove(mergedPath)
+		_ = os.RemoveAll(mergedDir)
 		cleanup()
-		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to write merged config file: %w", err)
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to write merged config file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		_ = os.Remove(mergedPath)
+		_ = os.RemoveAll(mergedDir)
 		cleanup()
-		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to close merged config file: %w", err)
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to close merged config file: %w", err)
 	}
 	cleanupFns = append(cleanupFns, func() {
-		_ = os.Remove(mergedPath)
+		_ = os.RemoveAll(mergedDir)
 	})
 
 	cfg, err := cm.ParseConfigYaml(mergedPath)
 	if err != nil {
 		cleanup()
-		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: %w", err)
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to parse merged config.yaml: %w", err)
 	}
 
 	effectiveOpts := *opts
-	effectiveOpts.Config = mergedPath
-	effectiveOpts.ConfigFiles = append([]string(nil), configFiles...)
-	effectiveOpts.Vault = ""
+	effectiveOpts.ConfigPath = mergedPath
+	effectiveOpts.Configs = append([]string(nil), configFiles...)
 
 	return &effectiveOpts, cfg, cleanup, nil
-}
-
-func (o *InstallCodesphereOpts) configInputs() []string {
-	if len(o.ConfigFiles) > 0 {
-		return append([]string(nil), o.ConfigFiles...)
-	}
-	if o.Config != "" {
-		return []string{o.Config}
-	}
-	return nil
 }

--- a/cli/cmd/install_codesphere.go
+++ b/cli/cmd/install_codesphere.go
@@ -4,12 +4,18 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/codesphere-cloud/cs-go/pkg/io"
+	"github.com/codesphere-cloud/oms/internal/configtemplating"
 	"github.com/codesphere-cloud/oms/internal/env"
 	"github.com/codesphere-cloud/oms/internal/installer"
 	"github.com/codesphere-cloud/oms/internal/installer/argocd"
+	"github.com/codesphere-cloud/oms/internal/installer/files"
 	"github.com/codesphere-cloud/oms/internal/util"
 	"github.com/spf13/cobra"
+	"go.yaml.in/yaml/v3"
 )
 
 // InstallCodesphereCmd represents the codesphere command
@@ -24,6 +30,7 @@ type InstallCodesphereOpts struct {
 	Package          string
 	Force            bool
 	Config           string
+	ConfigFiles      []string
 	Vault            string
 	PrivKey          string
 	SkipSteps        []string
@@ -36,10 +43,11 @@ type InstallCodesphereOpts struct {
 	ArgoCDForceConflicts bool
 	ArgoCDRepoURL        string
 	ArgoCDValues         []string
+	PCAppsValues         []string
 }
 
 func (c *InstallCodesphereCmd) RunE(_ *cobra.Command, _ []string) error {
-	cfg, cleanup, err := parseInstallConfig(c.Opts, installer.NewConfig())
+	effectiveOpts, cfg, cleanup, err := prepareInstallConfig(c.Opts, installer.NewConfig())
 	if err != nil {
 		return err
 	}
@@ -59,17 +67,17 @@ func (c *InstallCodesphereCmd) RunE(_ *cobra.Command, _ []string) error {
 	}
 
 	if c.Opts.CodesphereOnly {
-		return installCodespherePlatform(c.Opts, c.Env)
+		return installCodespherePlatform(effectiveOpts, c.Env)
 	}
 
 	if infraInstaller.HasExecutableSteps(cfg) {
-		if err := installCodesphereInfra(c.Opts, c.Env); err != nil {
+		if err := installCodesphereInfra(effectiveOpts, c.Env); err != nil {
 			return err
 		}
 	}
 
 	if dependenciesInstaller.HasExecutableSteps(cfg) || !installer.IsStepSkipped(cfg, c.Opts.SkipSteps, installer.ArgoCDStep) {
-		if err := installCodesphereDepencies(c.Opts, c.Env); err != nil {
+		if err := installCodesphereDepencies(effectiveOpts, c.Env); err != nil {
 			return err
 		}
 	}
@@ -78,7 +86,7 @@ func (c *InstallCodesphereCmd) RunE(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	return installCodespherePlatform(c.Opts, c.Env)
+	return installCodespherePlatform(effectiveOpts, c.Env)
 }
 
 func AddInstallCodesphereCmd(install *cobra.Command, opts *GlobalOptions) {
@@ -104,7 +112,7 @@ func AddInstallCodesphereCmd(install *cobra.Command, opts *GlobalOptions) {
 	}
 	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.Package, "package", "p", "", "Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from")
 	codesphere.cmd.PersistentFlags().BoolVarP(&codesphere.Opts.Force, "force", "f", false, "Enforce package extraction")
-	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.Config, "config", "c", "", "Path to the Codesphere Private Cloud configuration file (yaml)")
+	codesphere.cmd.PersistentFlags().StringArrayVarP(&codesphere.Opts.ConfigFiles, "config", "c", nil, "Path to a Codesphere Private Cloud configuration file (yaml). Can be specified multiple times and merged in order")
 	codesphere.cmd.PersistentFlags().StringVar(&codesphere.Opts.Vault, "vault", "", "Path to the SOPS-encrypted prod.vault.yaml file used for config templating")
 	codesphere.cmd.PersistentFlags().StringVarP(&codesphere.Opts.PrivKey, "priv-key", "k", "", "Path to the private key to encrypt/decrypt secrets")
 	codesphere.cmd.PersistentFlags().StringSliceVarP(&codesphere.Opts.SkipSteps, "skip-steps", "s", []string{}, "Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd")
@@ -116,6 +124,7 @@ func AddInstallCodesphereCmd(install *cobra.Command, opts *GlobalOptions) {
 	codesphere.cmd.PersistentFlags().BoolVar(&codesphere.Opts.ArgoCDForceConflicts, "argo-force-conflicts", false, "Force SSA ownership conflicts during ArgoCD install")
 	codesphere.cmd.PersistentFlags().StringVar(&codesphere.Opts.ArgoCDRepoURL, "argo-repo", argocd.DefaultRepoURL, "ArgoCD Helm chart repository URL")
 	codesphere.cmd.PersistentFlags().StringArrayVar(&codesphere.Opts.ArgoCDValues, "argo-values", nil, "ArgoCD values YAML file (can be specified multiple times)")
+	codesphere.cmd.PersistentFlags().StringArrayVar(&codesphere.Opts.PCAppsValues, "pc-apps-values", nil, "pc-apps values YAML file (can be specified multiple times)")
 
 	util.MarkPersistentFlagRequired(codesphere.cmd, "package")
 	util.MarkPersistentFlagRequired(codesphere.cmd, "config")
@@ -132,4 +141,105 @@ func AddInstallCodesphereCmd(install *cobra.Command, opts *GlobalOptions) {
 
 func sharedInstallCodesphereSteps() []string {
 	return []string{"copy-dependencies", "extract-dependencies"}
+}
+
+func prepareInstallConfig(opts *InstallCodesphereOpts, cm installer.ConfigManager) (*InstallCodesphereOpts, files.RootConfig, func(), error) {
+	configFiles := opts.configInputs()
+	if len(configFiles) == 0 {
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: at least one config file is required")
+	}
+
+	store := installer.NewLazyVaultTemplatingSecretStore(opts.Vault, opts.PrivKey)
+	cleanupFns := []func(){}
+	cleanup := func() {
+		for i := len(cleanupFns) - 1; i >= 0; i-- {
+			cleanupFns[i]()
+		}
+	}
+
+	merged := map[string]any{}
+	for _, configPath := range configFiles {
+		renderedPath := configPath
+		if opts.Vault != "" {
+			tmpPath, renderCleanup, err := configtemplating.RenderConfigFileToTemp(configPath, store)
+			if err != nil {
+				cleanup()
+				return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: %w", err)
+			}
+			cleanupFns = append(cleanupFns, renderCleanup)
+			renderedPath = tmpPath
+		}
+
+		data, err := os.ReadFile(renderedPath)
+		if err != nil {
+			cleanup()
+			return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to read config file %s: %w", renderedPath, err)
+		}
+
+		var partial map[string]any
+		if err := yaml.Unmarshal(data, &partial); err != nil {
+			cleanup()
+			return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to parse config.yaml: %w", err)
+		}
+		if partial == nil {
+			partial = map[string]any{}
+		}
+		merged = util.DeepMergeMaps(merged, partial)
+	}
+
+	mergedBytes, err := yaml.Marshal(merged)
+	if err != nil {
+		cleanup()
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to marshal merged config.yaml: %w", err)
+	}
+
+	tmp, err := os.CreateTemp("", "oms-merged-config-*.yaml")
+	if err != nil {
+		cleanup()
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to create merged config file: %w", err)
+	}
+	mergedPath := tmp.Name()
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(mergedPath)
+		cleanup()
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to set merged config permissions: %w", err)
+	}
+	if _, err := tmp.Write(mergedBytes); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(mergedPath)
+		cleanup()
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to write merged config file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(mergedPath)
+		cleanup()
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: failed to close merged config file: %w", err)
+	}
+	cleanupFns = append(cleanupFns, func() {
+		_ = os.Remove(mergedPath)
+	})
+
+	cfg, err := cm.ParseConfigYaml(mergedPath)
+	if err != nil {
+		cleanup()
+		return nil, files.RootConfig{}, func() {}, fmt.Errorf("failed to extract config.yaml: %w", err)
+	}
+
+	effectiveOpts := *opts
+	effectiveOpts.Config = mergedPath
+	effectiveOpts.ConfigFiles = append([]string(nil), configFiles...)
+	effectiveOpts.Vault = ""
+
+	return &effectiveOpts, cfg, cleanup, nil
+}
+
+func (o *InstallCodesphereOpts) configInputs() []string {
+	if len(o.ConfigFiles) > 0 {
+		return append([]string(nil), o.ConfigFiles...)
+	}
+	if o.Config != "" {
+		return []string{o.Config}
+	}
+	return nil
 }

--- a/cli/cmd/install_codesphere_config_test.go
+++ b/cli/cmd/install_codesphere_config_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/codesphere-cloud/oms/internal/installer"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("prepareInstallConfig", func() {
+	It("merges multiple config files in order and returns a single parsed config path", func() {
+		tmpDir, err := os.MkdirTemp("", "install-config-merge-*")
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		}()
+
+		basePath := filepath.Join(tmpDir, "base.yaml")
+		Expect(os.WriteFile(basePath, []byte(`
+dataCenter:
+  id: 1
+  name: dc-base
+  city: Base City
+  countryCode: DE
+secrets:
+  baseDir: /base/secrets
+registry:
+  server: registry.base.example.com
+cluster:
+  gateway:
+    serviceType: LoadBalancer
+  publicGateway:
+    serviceType: LoadBalancer
+codesphere:
+  domain: base.example.com
+  workspaceHostingBaseDomain: ws.base.example.com
+  customDomains:
+    cNameBaseDomain: cname.base.example.com
+  deployConfig:
+    images: {}
+pcApps:
+  spec:
+    source:
+      targetRevision: from-base
+`), 0644)).To(Succeed())
+
+		overlayPath := filepath.Join(tmpDir, "overlay.yaml")
+		Expect(os.WriteFile(overlayPath, []byte(`
+dataCenter:
+  name: dc-overlay
+registry:
+  server: registry.overlay.example.com
+codesphere:
+  domain: overlay.example.com
+pcApps:
+  spec:
+    source:
+      helm:
+        valuesObject:
+          featureFlags:
+            enabled: true
+`), 0644)).To(Succeed())
+
+		opts := &InstallCodesphereOpts{
+			ConfigFiles: []string{basePath, overlayPath},
+		}
+
+		effectiveOpts, cfg, cleanup, err := prepareInstallConfig(opts, installer.NewConfig())
+		Expect(err).ToNot(HaveOccurred())
+		defer cleanup()
+
+		Expect(effectiveOpts.Config).ToNot(BeEmpty())
+		Expect(effectiveOpts.Config).ToNot(Equal(basePath))
+		Expect(effectiveOpts.Config).ToNot(Equal(overlayPath))
+		Expect(effectiveOpts.Vault).To(Equal(""))
+		Expect(cfg.Datacenter.ID).To(Equal(1))
+		Expect(cfg.Datacenter.Name).To(Equal("dc-overlay"))
+		Expect(cfg.Datacenter.City).To(Equal("Base City"))
+		Expect(cfg.Registry).ToNot(BeNil())
+		Expect(cfg.Registry.Server).To(Equal("registry.overlay.example.com"))
+		Expect(cfg.Codesphere.Domain).To(Equal("overlay.example.com"))
+		Expect(cfg.Codesphere.WorkspaceHostingBaseDomain).To(Equal("ws.base.example.com"))
+		Expect(cfg.PcApps).To(HaveKey("spec"))
+		spec := cfg.PcApps["spec"].(map[string]interface{})
+		source := spec["source"].(map[string]interface{})
+		Expect(source["targetRevision"]).To(Equal("from-base"))
+		helm := source["helm"].(map[string]interface{})
+		valuesObject := helm["valuesObject"].(map[string]interface{})
+		featureFlags := valuesObject["featureFlags"].(map[string]interface{})
+		Expect(featureFlags["enabled"]).To(BeTrue())
+
+		_, statErr := os.Stat(effectiveOpts.Config)
+		Expect(statErr).ToNot(HaveOccurred())
+
+		cleanup()
+		_, statErr = os.Stat(effectiveOpts.Config)
+		Expect(os.IsNotExist(statErr)).To(BeTrue())
+	})
+})

--- a/cli/cmd/install_codesphere_config_test.go
+++ b/cli/cmd/install_codesphere_config_test.go
@@ -4,10 +4,14 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/installer/files"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -67,16 +71,17 @@ pcApps:
 `), 0644)).To(Succeed())
 
 		opts := &InstallCodesphereOpts{
-			ConfigFiles: []string{basePath, overlayPath},
+			Configs: []string{basePath, overlayPath},
 		}
 
 		effectiveOpts, cfg, cleanup, err := prepareInstallConfig(opts, installer.NewConfig())
 		Expect(err).ToNot(HaveOccurred())
 		defer cleanup()
 
-		Expect(effectiveOpts.Config).ToNot(BeEmpty())
-		Expect(effectiveOpts.Config).ToNot(Equal(basePath))
-		Expect(effectiveOpts.Config).ToNot(Equal(overlayPath))
+		Expect(effectiveOpts.ConfigPath).ToNot(BeEmpty())
+		Expect(effectiveOpts.ConfigPath).ToNot(Equal(basePath))
+		Expect(effectiveOpts.ConfigPath).ToNot(Equal(overlayPath))
+		Expect(filepath.Base(effectiveOpts.ConfigPath)).To(Equal("config.yaml"))
 		Expect(effectiveOpts.Vault).To(Equal(""))
 		Expect(cfg.Datacenter.ID).To(Equal(1))
 		Expect(cfg.Datacenter.Name).To(Equal("dc-overlay"))
@@ -94,11 +99,135 @@ pcApps:
 		featureFlags := valuesObject["featureFlags"].(map[string]interface{})
 		Expect(featureFlags["enabled"]).To(BeTrue())
 
-		_, statErr := os.Stat(effectiveOpts.Config)
+		_, statErr := os.Stat(effectiveOpts.ConfigPath)
 		Expect(statErr).ToNot(HaveOccurred())
 
 		cleanup()
-		_, statErr = os.Stat(effectiveOpts.Config)
+		_, statErr = os.Stat(effectiveOpts.ConfigPath)
 		Expect(os.IsNotExist(statErr)).To(BeTrue())
 	})
+
+	It("renders each config file with vault templating before merging", func() {
+		if !installCodesphereSopsAndAgeAvailable() {
+			Skip("sops and age-keygen not available")
+		}
+
+		tmpDir := GinkgoT().TempDir()
+		basePath := filepath.Join(tmpDir, "base.yaml")
+		overlayPath := filepath.Join(tmpDir, "overlay.yaml")
+		vaultPath := filepath.Join(tmpDir, "prod.vault.yaml")
+		plaintextVaultPath := filepath.Join(tmpDir, "prod.vault.plain.yaml")
+		ageKeyPath := filepath.Join(tmpDir, "age_key.txt")
+
+		Expect(os.WriteFile(basePath, []byte(`
+dataCenter:
+  id: 1
+  name: dc-base
+  city: '{{ secret "dcCity" }}'
+  countryCode: DE
+secrets:
+  baseDir: /base/secrets
+cluster:
+  gateway:
+    serviceType: LoadBalancer
+  publicGateway:
+    serviceType: LoadBalancer
+codesphere:
+  domain: '{{ secret "baseDomain" }}'
+  workspaceHostingBaseDomain: ws.base.example.com
+  customDomains:
+    cNameBaseDomain: cname.base.example.com
+  deployConfig:
+    images: {}
+`), 0644)).To(Succeed())
+		Expect(os.WriteFile(overlayPath, []byte(`
+dataCenter:
+  name: '{{ secret "dcName" }}'
+pcApps:
+  spec:
+    source:
+      targetRevision: '{{ secret "pcAppsRevision" }}'
+`), 0644)).To(Succeed())
+
+		vault := &files.InstallVault{
+			Secrets: []files.SecretEntry{
+				{Name: "dcCity", File: &files.SecretFile{Content: "Templated City"}},
+				{Name: "baseDomain", File: &files.SecretFile{Content: "templated.example.com"}},
+				{Name: "dcName", File: &files.SecretFile{Content: "dc-from-vault"}},
+				{Name: "pcAppsRevision", File: &files.SecretFile{Content: "from-vault"}},
+			},
+		}
+		vaultYAML, err := vault.Marshal()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.WriteFile(plaintextVaultPath, vaultYAML, 0600)).To(Succeed())
+		Expect(exec.Command("age-keygen", "-o", ageKeyPath).Run()).To(Succeed())
+		recipient, err := exec.Command("age-keygen", "-y", ageKeyPath).Output()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(installer.EncryptFileWithSOPS(plaintextVaultPath, vaultPath, strings.TrimSpace(string(recipient)))).To(Succeed())
+
+		opts := &InstallCodesphereOpts{
+			Configs: []string{basePath, overlayPath},
+			Vault:   vaultPath,
+			PrivKey: ageKeyPath,
+		}
+
+		effectiveOpts, cfg, cleanup, err := prepareInstallConfig(opts, installer.NewConfig())
+		Expect(err).ToNot(HaveOccurred())
+		defer cleanup()
+
+		Expect(effectiveOpts.Vault).To(Equal(vaultPath))
+		Expect(cfg.Datacenter.City).To(Equal("Templated City"))
+		Expect(cfg.Datacenter.Name).To(Equal("dc-from-vault"))
+		Expect(cfg.Codesphere.Domain).To(Equal("templated.example.com"))
+		Expect(cfg.PcApps).To(HaveKey("spec"))
+		spec := cfg.PcApps["spec"].(map[string]interface{})
+		source := spec["source"].(map[string]interface{})
+		Expect(source["targetRevision"]).To(Equal("from-vault"))
+	})
+
+	It("supports a single config path", func() {
+		tmpDir := GinkgoT().TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		Expect(os.WriteFile(configPath, []byte(fmt.Sprintf(`
+dataCenter:
+  id: 7
+  name: dc-legacy
+  city: Legacy City
+  countryCode: DE
+secrets:
+  baseDir: %s
+cluster:
+  gateway:
+    serviceType: LoadBalancer
+  publicGateway:
+    serviceType: LoadBalancer
+codesphere:
+  domain: legacy.example.com
+  workspaceHostingBaseDomain: ws.legacy.example.com
+  customDomains:
+    cNameBaseDomain: cname.legacy.example.com
+  deployConfig:
+    images: {}
+`, filepath.ToSlash(tmpDir))), 0644)).To(Succeed())
+
+		opts := &InstallCodesphereOpts{Configs: []string{configPath}}
+
+		effectiveOpts, cfg, cleanup, err := prepareInstallConfig(opts, installer.NewConfig())
+		Expect(err).ToNot(HaveOccurred())
+		defer cleanup()
+
+		Expect(effectiveOpts.Configs).To(Equal([]string{configPath}))
+		Expect(cfg.Datacenter.ID).To(Equal(7))
+		Expect(cfg.Datacenter.Name).To(Equal("dc-legacy"))
+	})
 })
+
+func installCodesphereSopsAndAgeAvailable() bool {
+	if _, err := exec.LookPath("sops"); err != nil {
+		return false
+	}
+	if _, err := exec.LookPath("age-keygen"); err != nil {
+		return false
+	}
+	return true
+}

--- a/cli/cmd/install_codesphere_dependencies.go
+++ b/cli/cmd/install_codesphere_dependencies.go
@@ -32,29 +32,24 @@ type InstallCodesphereDepenciesCmd struct {
 }
 
 func (c *InstallCodesphereDepenciesCmd) RunE(_ *cobra.Command, _ []string) error {
-	effectiveOpts, _, cleanup, err := prepareInstallConfig(c.Opts, installer.NewConfig())
+	effectiveOpts, cfg, cleanup, err := prepareInstallConfig(c.Opts, installer.NewConfig())
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	return installCodesphereDepencies(effectiveOpts, c.Env)
+	return installCodesphereDepencies(effectiveOpts, cfg, c.Env)
 }
 
-func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error {
+func installCodesphereDepencies(opts *InstallCodesphereOpts, cfg files.RootConfig, env env.Env) error {
 	workdir := env.GetOmsWorkdir()
 	pm := installer.NewPackage(workdir, opts.Package)
 	stlog := bootstrap.NewStepLogger(false)
 	cm := installer.NewConfig()
 	im := system.NewImage(context.Background())
 
-	cfg, err := cm.ParseConfigYaml(opts.Config)
-	if err != nil {
-		return fmt.Errorf("failed to extract config.yaml: %w", err)
-	}
-
 	ci := &installer.CodesphereInstaller{
-		ConfigPath:       opts.Config,
+		ConfigPath:       opts.ConfigPath,
 		VaultPath:        opts.Vault,
 		PrivKey:          opts.PrivKey,
 		Force:            opts.Force,
@@ -69,7 +64,7 @@ func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error 
 			return fmt.Errorf("failed to extract and validate package: %w", err)
 		}
 		if err := stlog.Step("Install ArgoCD pre-step", func() error {
-			return installArgoCDAndApps(opts, pm, stlog)
+			return installArgoCDAndApps(opts, cfg, pm, stlog)
 		}); err != nil {
 			return err
 		}
@@ -83,11 +78,12 @@ func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error 
 
 // installArgoCDAndApps runs ArgoCD install, vault secret sync, and pc-apps install
 // before the main dependency steps.
-func installArgoCDAndApps(opts *InstallCodesphereOpts, pm installer.PackageManager, stlog *bootstrap.StepLogger) error {
+func installArgoCDAndApps(opts *InstallCodesphereOpts, cfg files.RootConfig, pm installer.PackageManager, stlog *bootstrap.StepLogger) error {
 	install := &argoCDAndAppsInstall{
-		ctx:  context.Background(),
-		opts: opts,
-		pm:   pm,
+		ctx:    context.Background(),
+		opts:   opts,
+		pm:     pm,
+		config: cfg,
 	}
 
 	if err := stlog.Substep("Load vault data", install.loadVaultData); err != nil {
@@ -150,18 +146,14 @@ func (i *argoCDAndAppsInstall) loadVaultData() error {
 }
 
 func (i *argoCDAndAppsInstall) installArgoCD() error {
-	cfg, err := installer.NewConfig().ParseConfigYaml(i.opts.Config)
-	if err != nil {
-		return fmt.Errorf("failed to parse config.yaml: %w", err)
-	}
-	i.config = cfg
 	i.ociRegistryURL = i.opts.ArgoCDRegistryURL
-	if i.ociRegistryURL == "" && cfg.Registry != nil {
-		i.ociRegistryURL = cfg.Registry.Server + "/codesphere-cloud/charts"
+	if i.ociRegistryURL == "" && i.config.Registry != nil {
+		i.ociRegistryURL = i.config.Registry.Server + "/codesphere-cloud/charts"
 	}
+	var err error
 	i.argoInstall, err = argocdinstaller.NewInstaller(argocdinstaller.InstallerConfig{
 		Version:        i.opts.ArgoCDVersion,
-		DatacenterId:   fmt.Sprintf("%d", cfg.Datacenter.ID),
+		DatacenterId:   fmt.Sprintf("%d", i.config.Datacenter.ID),
 		OciPassword:    i.ociPassword,
 		OciRegistryURL: i.ociRegistryURL,
 		GitPassword:    os.Getenv("OMS_GIT_PASSWORD"),

--- a/cli/cmd/install_codesphere_dependencies.go
+++ b/cli/cmd/install_codesphere_dependencies.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/codesphere-cloud/cs-go/pkg/io"
 	"github.com/codesphere-cloud/oms/internal/bootstrap"
-	"github.com/codesphere-cloud/oms/internal/configtemplating"
 	"github.com/codesphere-cloud/oms/internal/env"
 	"github.com/codesphere-cloud/oms/internal/installer"
 	argocdinstaller "github.com/codesphere-cloud/oms/internal/installer/argocd"
@@ -33,7 +32,13 @@ type InstallCodesphereDepenciesCmd struct {
 }
 
 func (c *InstallCodesphereDepenciesCmd) RunE(_ *cobra.Command, _ []string) error {
-	return installCodesphereDepencies(c.Opts, c.Env)
+	effectiveOpts, _, cleanup, err := prepareInstallConfig(c.Opts, installer.NewConfig())
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return installCodesphereDepencies(effectiveOpts, c.Env)
 }
 
 func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error {
@@ -43,11 +48,10 @@ func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error 
 	cm := installer.NewConfig()
 	im := system.NewImage(context.Background())
 
-	cfg, cleanup, err := parseInstallConfig(opts, cm)
+	cfg, err := cm.ParseConfigYaml(opts.Config)
 	if err != nil {
 		return fmt.Errorf("failed to extract config.yaml: %w", err)
 	}
-	defer cleanup()
 
 	ci := &installer.CodesphereInstaller{
 		ConfigPath:       opts.Config,
@@ -75,23 +79,6 @@ func installCodesphereDepencies(opts *InstallCodesphereOpts, env env.Env) error 
 		return fmt.Errorf("failed to install dependencies: %w", err)
 	}
 	return nil
-}
-
-func parseInstallConfig(opts *InstallCodesphereOpts, cm installer.ConfigManager) (files.RootConfig, func(), error) {
-	configPath := opts.Config
-	cleanup := func() {}
-	if opts.Vault != "" {
-		store := installer.NewLazyVaultTemplatingSecretStore(opts.Vault, opts.PrivKey)
-		renderedConfig, renderCleanup, err := configtemplating.RenderConfigFileToTemp(opts.Config, store)
-		if err != nil {
-			return files.RootConfig{}, cleanup, err
-		}
-		configPath = renderedConfig
-		cleanup = renderCleanup
-	}
-
-	cfg, err := cm.ParseConfigYaml(configPath)
-	return cfg, cleanup, err
 }
 
 // installArgoCDAndApps runs ArgoCD install, vault secret sync, and pc-apps install
@@ -131,6 +118,7 @@ type argoCDAndAppsInstall struct {
 	kubeClient     ctrlclient.Client
 	vault          *files.InstallVault
 	kubeConfig     *rest.Config
+	config         files.RootConfig
 }
 
 func (i *argoCDAndAppsInstall) loadVaultData() error {
@@ -166,6 +154,7 @@ func (i *argoCDAndAppsInstall) installArgoCD() error {
 	if err != nil {
 		return fmt.Errorf("failed to parse config.yaml: %w", err)
 	}
+	i.config = cfg
 	i.ociRegistryURL = i.opts.ArgoCDRegistryURL
 	if i.ociRegistryURL == "" && cfg.Registry != nil {
 		i.ociRegistryURL = cfg.Registry.Server + "/codesphere-cloud/charts"
@@ -204,7 +193,14 @@ func (i *argoCDAndAppsInstall) syncVaultSecret() error {
 }
 
 func (i *argoCDAndAppsInstall) installPcApps() error {
-	pcApps, err := installer.NewPcAppsFromBom(i.kubeClient, i.kubeConfig, i.pm.GetDependencyPath("bom.json"), argocdinstaller.DefaultNamespace)
+	pcApps, err := installer.NewPcAppsFromBom(
+		i.kubeClient,
+		i.kubeConfig,
+		i.pm.GetDependencyPath("bom.json"),
+		argocdinstaller.DefaultNamespace,
+		i.opts.PCAppsValues,
+		i.config.PcApps,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize pc-apps installer: %w", err)
 	}
@@ -242,6 +238,10 @@ func AddInstallCodesphereDepenciesCmd(codesphere *cobra.Command, opts *InstallCo
 				{
 					Cmd:  "-p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml -s argocd",
 					Desc: "Install cluster dependencies without the ArgoCD pre-step",
+				},
+				{
+					Cmd:  "-p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml --pc-apps-values base.yaml --pc-apps-values dc-overlay.yaml",
+					Desc: "Install cluster dependencies with custom pc-apps values files",
 				},
 			}),
 		},

--- a/cli/cmd/install_codesphere_infra.go
+++ b/cli/cmd/install_codesphere_infra.go
@@ -23,7 +23,13 @@ type InstallCodesphereInfraCmd struct {
 }
 
 func (c *InstallCodesphereInfraCmd) RunE(_ *cobra.Command, _ []string) error {
-	return installCodesphereInfra(c.Opts, c.Env)
+	effectiveOpts, _, cleanup, err := prepareInstallConfig(c.Opts, installer.NewConfig())
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return installCodesphereInfra(effectiveOpts, c.Env)
 }
 
 func installCodesphereInfra(opts *InstallCodesphereOpts, env env.Env) error {

--- a/cli/cmd/install_codesphere_infra.go
+++ b/cli/cmd/install_codesphere_infra.go
@@ -39,7 +39,7 @@ func installCodesphereInfra(opts *InstallCodesphereOpts, env env.Env) error {
 	im := system.NewImage(context.Background())
 
 	ci := &installer.CodesphereInstaller{
-		ConfigPath:       opts.Config,
+		ConfigPath:       opts.ConfigPath,
 		VaultPath:        opts.Vault,
 		PrivKey:          opts.PrivKey,
 		Force:            opts.Force,

--- a/cli/cmd/install_codesphere_platform.go
+++ b/cli/cmd/install_codesphere_platform.go
@@ -39,7 +39,7 @@ func installCodespherePlatform(opts *InstallCodesphereOpts, env env.Env) error {
 	im := system.NewImage(context.Background())
 
 	ci := &installer.CodesphereInstaller{
-		ConfigPath:       opts.Config,
+		ConfigPath:       opts.ConfigPath,
 		VaultPath:        opts.Vault,
 		PrivKey:          opts.PrivKey,
 		Force:            opts.Force,

--- a/cli/cmd/install_codesphere_platform.go
+++ b/cli/cmd/install_codesphere_platform.go
@@ -23,7 +23,13 @@ type InstallCodespherePlatformCmd struct {
 }
 
 func (c *InstallCodespherePlatformCmd) RunE(_ *cobra.Command, _ []string) error {
-	return installCodespherePlatform(c.Opts, c.Env)
+	effectiveOpts, _, cleanup, err := prepareInstallConfig(c.Opts, installer.NewConfig())
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return installCodespherePlatform(effectiveOpts, c.Env)
 }
 
 func installCodespherePlatform(opts *InstallCodesphereOpts, env env.Env) error {

--- a/cli/cmd/install_codesphere_test.go
+++ b/cli/cmd/install_codesphere_test.go
@@ -53,7 +53,7 @@ var _ = Describe("InstallCodesphereCmd", func() {
 			Expect(err).To(BeNil())
 			_ = tempConfigFile.Close()
 
-			c.Opts.Config = tempConfigFile.Name()
+			c.Opts.Configs = []string{tempConfigFile.Name()}
 			mockEnv.EXPECT().GetOmsWorkdir().Return("/test/workdir")
 
 			err = c.RunE(nil, []string{})

--- a/cli/cmd/pc_apps.go
+++ b/cli/cmd/pc_apps.go
@@ -44,6 +44,7 @@ func (c *InstallPCAppsCmd) RunE(cmd *cobra.Command, args []string) error {
 		c.Opts.Version,
 		c.Opts.Namespace,
 		c.Opts.ValuesFiles,
+		nil,
 		c.Opts.ForceConflicts,
 	)
 	if err != nil {

--- a/docs/oms_install_codesphere.md
+++ b/docs/oms_install_codesphere.md
@@ -25,21 +25,22 @@ $ oms install codesphere -p codesphere-v1.2.3-installer-lite.tar.gz -k <path-to-
 ### Options
 
 ```
-      --argo-force-conflicts       Force SSA ownership conflicts during ArgoCD install
-      --argo-registry-url string   OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)
-      --argo-repo string           ArgoCD Helm chart repository URL (default "https://argoproj.github.io/argo-helm")
-      --argo-values stringArray    ArgoCD values YAML file (can be specified multiple times)
-      --argo-version string        ArgoCD Helm chart version to install
-      --auto-approve               Auto approve confirmation prompts with default values (default true)
-      --codesphere-only            Install only Codesphere without dependencies
-  -c, --config string              Path to the Codesphere Private Cloud configuration file (yaml)
-      --direct-connection          Use direct connection for installation, requires having access to the cluster nodes from your machine
-  -f, --force                      Enforce package extraction
-  -h, --help                       help for codesphere
-  -p, --package string             Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
-  -k, --priv-key string            Path to the private key to encrypt/decrypt secrets
-  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd
-      --vault string               Path to the SOPS-encrypted prod.vault.yaml file used for config templating
+      --argo-force-conflicts         Force SSA ownership conflicts during ArgoCD install
+      --argo-registry-url string     OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)
+      --argo-repo string             ArgoCD Helm chart repository URL (default "https://argoproj.github.io/argo-helm")
+      --argo-values stringArray      ArgoCD values YAML file (can be specified multiple times)
+      --argo-version string          ArgoCD Helm chart version to install
+      --auto-approve                 Auto approve confirmation prompts with default values (default true)
+      --codesphere-only              Install only Codesphere without dependencies
+  -c, --config stringArray           Path to a Codesphere Private Cloud configuration file (yaml). Can be specified multiple times and merged in order
+      --direct-connection            Use direct connection for installation, requires having access to the cluster nodes from your machine
+  -f, --force                        Enforce package extraction
+  -h, --help                         help for codesphere
+  -p, --package string               Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
+      --pc-apps-values stringArray   pc-apps values YAML file (can be specified multiple times)
+  -k, --priv-key string              Path to the private key to encrypt/decrypt secrets
+  -s, --skip-steps strings           Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd
+      --vault string                 Path to the SOPS-encrypted prod.vault.yaml file used for config templating
 ```
 
 ### SEE ALSO

--- a/docs/oms_install_codesphere_dependencies.md
+++ b/docs/oms_install_codesphere_dependencies.md
@@ -22,6 +22,9 @@ $ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <
 # Install cluster dependencies without the ArgoCD pre-step
 $ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml -s argocd
 
+# Install cluster dependencies with custom pc-apps values files
+$ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <path-to-private-key> -c config.yaml --pc-apps-values base.yaml --pc-apps-values dc-overlay.yaml
+
 ```
 
 ### Options
@@ -33,19 +36,20 @@ $ oms install codesphere dependencies -p codesphere-v1.2.3-installer.tar.gz -k <
 ### Options inherited from parent commands
 
 ```
-      --argo-force-conflicts       Force SSA ownership conflicts during ArgoCD install
-      --argo-registry-url string   OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)
-      --argo-repo string           ArgoCD Helm chart repository URL (default "https://argoproj.github.io/argo-helm")
-      --argo-values stringArray    ArgoCD values YAML file (can be specified multiple times)
-      --argo-version string        ArgoCD Helm chart version to install
-      --auto-approve               Auto approve confirmation prompts with default values (default true)
-  -c, --config string              Path to the Codesphere Private Cloud configuration file (yaml)
-      --direct-connection          Use direct connection for installation, requires having access to the cluster nodes from your machine
-  -f, --force                      Enforce package extraction
-  -p, --package string             Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
-  -k, --priv-key string            Path to the private key to encrypt/decrypt secrets
-  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd
-      --vault string               Path to the SOPS-encrypted prod.vault.yaml file used for config templating
+      --argo-force-conflicts         Force SSA ownership conflicts during ArgoCD install
+      --argo-registry-url string     OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)
+      --argo-repo string             ArgoCD Helm chart repository URL (default "https://argoproj.github.io/argo-helm")
+      --argo-values stringArray      ArgoCD values YAML file (can be specified multiple times)
+      --argo-version string          ArgoCD Helm chart version to install
+      --auto-approve                 Auto approve confirmation prompts with default values (default true)
+  -c, --config stringArray           Path to a Codesphere Private Cloud configuration file (yaml). Can be specified multiple times and merged in order
+      --direct-connection            Use direct connection for installation, requires having access to the cluster nodes from your machine
+  -f, --force                        Enforce package extraction
+  -p, --package string               Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
+      --pc-apps-values stringArray   pc-apps values YAML file (can be specified multiple times)
+  -k, --priv-key string              Path to the private key to encrypt/decrypt secrets
+  -s, --skip-steps strings           Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd
+      --vault string                 Path to the SOPS-encrypted prod.vault.yaml file used for config templating
 ```
 
 ### SEE ALSO

--- a/docs/oms_install_codesphere_infra.md
+++ b/docs/oms_install_codesphere_infra.md
@@ -31,19 +31,20 @@ $ oms install codesphere infra -p codesphere-v1.2.3-installer-lite.tar.gz -k <pa
 ### Options inherited from parent commands
 
 ```
-      --argo-force-conflicts       Force SSA ownership conflicts during ArgoCD install
-      --argo-registry-url string   OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)
-      --argo-repo string           ArgoCD Helm chart repository URL (default "https://argoproj.github.io/argo-helm")
-      --argo-values stringArray    ArgoCD values YAML file (can be specified multiple times)
-      --argo-version string        ArgoCD Helm chart version to install
-      --auto-approve               Auto approve confirmation prompts with default values (default true)
-  -c, --config string              Path to the Codesphere Private Cloud configuration file (yaml)
-      --direct-connection          Use direct connection for installation, requires having access to the cluster nodes from your machine
-  -f, --force                      Enforce package extraction
-  -p, --package string             Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
-  -k, --priv-key string            Path to the private key to encrypt/decrypt secrets
-  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd
-      --vault string               Path to the SOPS-encrypted prod.vault.yaml file used for config templating
+      --argo-force-conflicts         Force SSA ownership conflicts during ArgoCD install
+      --argo-registry-url string     OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)
+      --argo-repo string             ArgoCD Helm chart repository URL (default "https://argoproj.github.io/argo-helm")
+      --argo-values stringArray      ArgoCD values YAML file (can be specified multiple times)
+      --argo-version string          ArgoCD Helm chart version to install
+      --auto-approve                 Auto approve confirmation prompts with default values (default true)
+  -c, --config stringArray           Path to a Codesphere Private Cloud configuration file (yaml). Can be specified multiple times and merged in order
+      --direct-connection            Use direct connection for installation, requires having access to the cluster nodes from your machine
+  -f, --force                        Enforce package extraction
+  -p, --package string               Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
+      --pc-apps-values stringArray   pc-apps values YAML file (can be specified multiple times)
+  -k, --priv-key string              Path to the private key to encrypt/decrypt secrets
+  -s, --skip-steps strings           Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd
+      --vault string                 Path to the SOPS-encrypted prod.vault.yaml file used for config templating
 ```
 
 ### SEE ALSO

--- a/docs/oms_install_codesphere_platform.md
+++ b/docs/oms_install_codesphere_platform.md
@@ -29,19 +29,20 @@ $ oms install codesphere platform -p codesphere-v1.2.3-installer.tar.gz -k <path
 ### Options inherited from parent commands
 
 ```
-      --argo-force-conflicts       Force SSA ownership conflicts during ArgoCD install
-      --argo-registry-url string   OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)
-      --argo-repo string           ArgoCD Helm chart repository URL (default "https://argoproj.github.io/argo-helm")
-      --argo-values stringArray    ArgoCD values YAML file (can be specified multiple times)
-      --argo-version string        ArgoCD Helm chart version to install
-      --auto-approve               Auto approve confirmation prompts with default values (default true)
-  -c, --config string              Path to the Codesphere Private Cloud configuration file (yaml)
-      --direct-connection          Use direct connection for installation, requires having access to the cluster nodes from your machine
-  -f, --force                      Enforce package extraction
-  -p, --package string             Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
-  -k, --priv-key string            Path to the private key to encrypt/decrypt secrets
-  -s, --skip-steps strings         Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd
-      --vault string               Path to the SOPS-encrypted prod.vault.yaml file used for config templating
+      --argo-force-conflicts         Force SSA ownership conflicts during ArgoCD install
+      --argo-registry-url string     OCI registry URL for the ArgoCD Helm chart (defaults to registry.server from config.yaml)
+      --argo-repo string             ArgoCD Helm chart repository URL (default "https://argoproj.github.io/argo-helm")
+      --argo-values stringArray      ArgoCD values YAML file (can be specified multiple times)
+      --argo-version string          ArgoCD Helm chart version to install
+      --auto-approve                 Auto approve confirmation prompts with default values (default true)
+  -c, --config stringArray           Path to a Codesphere Private Cloud configuration file (yaml). Can be specified multiple times and merged in order
+      --direct-connection            Use direct connection for installation, requires having access to the cluster nodes from your machine
+  -f, --force                        Enforce package extraction
+  -p, --package string               Package file (e.g. codesphere-v1.2.3-installer.tar.gz) to load binaries, installer etc. from
+      --pc-apps-values stringArray   pc-apps values YAML file (can be specified multiple times)
+  -k, --priv-key string              Path to the private key to encrypt/decrypt secrets
+  -s, --skip-steps strings           Steps to be skipped. E.g. copy-dependencies, extract-dependencies, load-container-images, ceph, postgres, kubernetes, docker, argocd
+      --vault string                 Path to the SOPS-encrypted prod.vault.yaml file used for config templating
 ```
 
 ### SEE ALSO

--- a/internal/bootstrap/local/installer.go
+++ b/internal/bootstrap/local/installer.go
@@ -431,7 +431,14 @@ func (b *LocalBootstrapper) RunInstaller() (err error) {
 	}
 
 	if b.Env.UseArgoCD {
-		pcApps, err := installer.NewPcAppsFromBom(b.kubeClient, b.restConfig, filepath.Join(depsDir, "bom.json"), argocd.DefaultNamespace)
+		pcApps, err := installer.NewPcAppsFromBom(
+			b.kubeClient,
+			b.restConfig,
+			filepath.Join(depsDir, "bom.json"),
+			argocd.DefaultNamespace,
+			nil,
+			b.Env.InstallConfig.PcApps,
+		)
 		if err != nil {
 			return fmt.Errorf("failed to initialize pc-apps installer from BOM: %w", err)
 		}

--- a/internal/installer/files/config_yaml.go
+++ b/internal/installer/files/config_yaml.go
@@ -70,6 +70,7 @@ type RootConfig struct {
 	Cluster                ClusterConfig                 `yaml:"cluster"`
 	MetalLB                *MetalLBConfig                `yaml:"metallb,omitempty"`
 	Codesphere             CodesphereConfig              `yaml:"codesphere"`
+	PcApps                 ChartOverride                 `yaml:"pcApps,omitempty"`
 	ManagedServiceBackends *ManagedServiceBackendsConfig `yaml:"managedServiceBackends,omitempty"`
 	Operations             *OperationsConfig             `yaml:"operations,omitempty"`
 }
@@ -637,6 +638,7 @@ func NewRootConfig() RootConfig {
 	return RootConfig{
 		Registry:               &RegistryConfig{},
 		MetalLB:                &MetalLBConfig{},
+		PcApps:                 ChartOverride{},
 		ManagedServiceBackends: &ManagedServiceBackendsConfig{},
 	}
 }

--- a/internal/installer/files/config_yaml.go
+++ b/internal/installer/files/config_yaml.go
@@ -70,7 +70,7 @@ type RootConfig struct {
 	Cluster                ClusterConfig                 `yaml:"cluster"`
 	MetalLB                *MetalLBConfig                `yaml:"metallb,omitempty"`
 	Codesphere             CodesphereConfig              `yaml:"codesphere"`
-	PcApps                 ChartOverride                 `yaml:"pcApps,omitempty"`
+	PcApps                 ChartValues                   `yaml:"pcApps,omitempty"`
 	ManagedServiceBackends *ManagedServiceBackendsConfig `yaml:"managedServiceBackends,omitempty"`
 	Operations             *OperationsConfig             `yaml:"operations,omitempty"`
 }
@@ -402,6 +402,7 @@ type TelemetryExport struct {
 }
 
 type ChartOverride = map[string]interface{}
+type ChartValues = map[string]interface{}
 
 type ImageRef struct {
 	BomRef     string `yaml:"bomRef,omitempty"`
@@ -638,7 +639,7 @@ func NewRootConfig() RootConfig {
 	return RootConfig{
 		Registry:               &RegistryConfig{},
 		MetalLB:                &MetalLBConfig{},
-		PcApps:                 ChartOverride{},
+		PcApps:                 ChartValues{},
 		ManagedServiceBackends: &ManagedServiceBackendsConfig{},
 	}
 }

--- a/internal/installer/files/config_yaml_test.go
+++ b/internal/installer/files/config_yaml_test.go
@@ -83,6 +83,14 @@ codesphere:
               bomRef: ide-service
             pool:
               4: 2
+pcApps:
+  spec:
+    source:
+      targetRevision: main
+      helm:
+        valuesObject:
+          featureFlags:
+            enableSomething: true
 `
 	})
 
@@ -102,6 +110,7 @@ codesphere:
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(rootConfig.Registry.Server).To(Equal("registry.example.com"))
+			Expect(rootConfig.PcApps).To(HaveKey("spec"))
 			Expect(rootConfig.Codesphere.Migration).NotTo(BeNil())
 			Expect(rootConfig.Codesphere.Migration.Postgres).NotTo(BeNil())
 			Expect(rootConfig.Codesphere.Migration.Postgres.Host).To(Equal("10.0.0.25"))

--- a/internal/installer/pc_apps.go
+++ b/internal/installer/pc_apps.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 
 	"github.com/codesphere-cloud/oms/internal/installer/bom"
+	"github.com/codesphere-cloud/oms/internal/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,6 +39,7 @@ type PCApps struct {
 	version        string   // chart version (required)
 	namespace      string   // target namespace for the Helm release
 	valuesFiles    []string // paths to values YAML files, merged in order
+	valuesOverride map[string]interface{}
 	forceConflicts bool
 	helm           HelmClient
 	client         client.Client
@@ -46,7 +48,7 @@ type PCApps struct {
 // NewPCApps creates a new PCApps installer. It validates that required fields
 // are non-empty but does not apply defaults — defaults live on the CLI flag
 // declarations only.
-func NewPCApps(c client.Client, version, namespace string, valuesFiles []string, forceConflicts bool) (*PCApps, error) {
+func NewPCApps(c client.Client, version, namespace string, valuesFiles []string, valuesOverride map[string]interface{}, forceConflicts bool) (*PCApps, error) {
 	if version == "" {
 		return nil, errors.New("version is required")
 	}
@@ -63,13 +65,14 @@ func NewPCApps(c client.Client, version, namespace string, valuesFiles []string,
 		version:        version,
 		namespace:      namespace,
 		valuesFiles:    valuesFiles,
+		valuesOverride: valuesOverride,
 		forceConflicts: forceConflicts,
 		helm:           helm,
 		client:         c,
 	}, nil
 }
 
-func NewPcAppsFromBom(c client.Client, restConfig *rest.Config, bomPath string, namespace string) (*PCApps, error) {
+func NewPcAppsFromBom(c client.Client, restConfig *rest.Config, bomPath string, namespace string, valuesFiles []string, valuesOverride map[string]interface{}) (*PCApps, error) {
 	bomCfg, err := bom.Parse(bomPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse bom.json: %w", err)
@@ -86,11 +89,12 @@ func NewPcAppsFromBom(c client.Client, restConfig *rest.Config, bomPath string, 
 	}
 
 	return &PCApps{
-		version:     pcApps.Tag(),
-		namespace:   namespace,
-		valuesFiles: []string{},
-		helm:        helm,
-		client:      c,
+		version:        pcApps.Tag(),
+		namespace:      namespace,
+		valuesFiles:    valuesFiles,
+		valuesOverride: valuesOverride,
+		helm:           helm,
+		client:         c,
 	}, nil
 }
 
@@ -133,10 +137,12 @@ func (p *PCApps) resolveFromSecret(ctx context.Context) (chartURL, username, pas
 func (p *PCApps) Install(ctx context.Context) error {
 	// Validate values files before any network calls so local errors fail fast.
 	valueOpts := values.Options{ValueFiles: p.valuesFiles}
-	vals, err := valueOpts.MergeValues(getter.All(cli.New()))
+	fileVals, err := valueOpts.MergeValues(getter.All(cli.New()))
 	if err != nil {
 		return fmt.Errorf("loading values files: %w", err)
 	}
+	vals := util.DeepMergeMaps(map[string]any{}, p.valuesOverride)
+	vals = util.DeepMergeMaps(vals, fileVals)
 
 	chartURL, username, password, err := p.resolveFromSecret(ctx)
 	if err != nil {
@@ -179,11 +185,12 @@ func (p *PCApps) Install(ctx context.Context) error {
 
 // NewPCAppsForTesting creates a PCApps instance with injected dependencies for
 // use in tests. This avoids exporting struct fields solely for test access.
-func NewPCAppsForTesting(helm HelmClient, c client.Client, version, namespace string, valuesFiles []string, forceConflicts bool) *PCApps {
+func NewPCAppsForTesting(helm HelmClient, c client.Client, version, namespace string, valuesFiles []string, valuesOverride map[string]interface{}, forceConflicts bool) *PCApps {
 	return &PCApps{
 		version:        version,
 		namespace:      namespace,
 		valuesFiles:    valuesFiles,
+		valuesOverride: valuesOverride,
 		forceConflicts: forceConflicts,
 		helm:           helm,
 		client:         c,

--- a/internal/installer/pc_apps_test.go
+++ b/internal/installer/pc_apps_test.go
@@ -69,7 +69,7 @@ var _ = Describe("PCApps.Install", func() {
 				WithScheme(scheme).
 				WithObjects(newSecret()).
 				Build()
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, false)
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, nil, false)
 		})
 
 		It("reads credentials from K8s secret and calls UpgradeChart with InstallIfNotExist", func() {
@@ -112,7 +112,7 @@ var _ = Describe("PCApps.Install", func() {
 				WithScheme(scheme).
 				WithObjects(newSecret()).
 				Build()
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, false)
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, nil, false)
 		})
 
 		It("returns an error without attempting install", func() {
@@ -131,7 +131,7 @@ var _ = Describe("PCApps.Install", func() {
 			fakeClient = fake.NewClientBuilder().
 				WithScheme(scheme).
 				Build()
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, false)
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, nil, false)
 		})
 
 		It("returns a clear error", func() {
@@ -159,7 +159,7 @@ var _ = Describe("PCApps.Install", func() {
 				WithScheme(scheme).
 				WithObjects(secret).
 				Build()
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, false)
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, nil, false)
 		})
 
 		It("returns an error about missing fields", func() {
@@ -194,7 +194,7 @@ var _ = Describe("PCApps.Install", func() {
 			overlay := filepath.Join(tmpDir, "overlay.yaml")
 			Expect(os.WriteFile(overlay, []byte("foo: overridden\nnested:\n  b: 99\n  c: 3\n"), 0644)).To(Succeed())
 
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{base, overlay}, false)
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{base, overlay}, nil, false)
 
 			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).Return(nil)
 			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
@@ -213,7 +213,7 @@ var _ = Describe("PCApps.Install", func() {
 		})
 
 		It("returns an error for non-existent values file", func() {
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{"/nonexistent/values.yaml"}, false)
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{"/nonexistent/values.yaml"}, nil, false)
 
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())
@@ -224,11 +224,40 @@ var _ = Describe("PCApps.Install", func() {
 			badFile := filepath.Join(tmpDir, "bad.yaml")
 			Expect(os.WriteFile(badFile, []byte("{{invalid yaml"), 0644)).To(Succeed())
 
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{badFile}, false)
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{badFile}, nil, false)
 
 			err := pcApps.Install(context.Background())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("loading values files"))
+		})
+
+		It("merges inline config overrides before values files", func() {
+			override := map[string]interface{}{
+				"foo": "from-config",
+				"nested": map[string]interface{}{
+					"configOnly": true,
+					"shared":     "from-config",
+				},
+			}
+			fileValues := filepath.Join(tmpDir, "values.yaml")
+			Expect(os.WriteFile(fileValues, []byte("foo: from-file\nnested:\n  shared: from-file\n  fileOnly: true\n"), 0644)).To(Succeed())
+
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, []string{fileValues}, override, false)
+
+			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).Return(nil)
+			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.MatchedBy(func(cfg installer.ChartConfig) bool {
+				nested, ok := cfg.Values["nested"].(map[string]any)
+				if !ok {
+					return false
+				}
+				return cfg.Values["foo"] == "from-file" &&
+					nested["configOnly"] == true &&
+					nested["shared"] == "from-file" &&
+					nested["fileOnly"] == true
+			}), installer.UpgradeChartOptions{InstallIfNotExist: true}).Return(nil)
+
+			err := pcApps.Install(context.Background())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -241,7 +270,7 @@ var _ = Describe("PCApps.Install", func() {
 		})
 
 		It("passes ForceConflicts=true to UpgradeChart", func() {
-			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, true)
+			pcApps = installer.NewPCAppsForTesting(helmMock, fakeClient, version, namespace, nil, nil, true)
 
 			helmMock.EXPECT().LoginRegistry(mock.Anything, "ghcr.io", secretUsername, secretPassword).Return(nil)
 			helmMock.EXPECT().UpgradeChart(mock.Anything, mock.Anything, mock.MatchedBy(func(opts installer.UpgradeChartOptions) bool {


### PR DESCRIPTION
Allow repeated --config flags for install codesphere commands and merge the rendered YAML files in order before invoking the installer.

Also expose pc-apps config on the normal config file and values files on the dependencies flow and pass them into the BOM-based pc-apps installer.

config:
```yaml
pcApps:
  chartRegistry: example.com/charts
```