### PR TITLE
chore: remove invalid managed services experiment

### DIFF
--- a/docs/oms_beta_bootstrap-gcp.md
+++ b/docs/oms_beta_bootstrap-gcp.md
@@ -33,7 +33,7 @@ oms beta bootstrap-gcp [flags]
       --datacenter-name string                    Datacenter name (default: dev) (default "dev")
       --dns-project-id string                     GCP Project ID for Cloud DNS (optional)
       --dns-zone-name string                      Cloud DNS Zone Name (optional) (default "oms-testing")
-      --experiments stringArray                   Experiments to enable in Codesphere installation (optional) (default [managed-services,headless-services,vcluster,custom-service-image,ms-in-ls,secret-management,sub-path-mount])
+      --experiments stringArray                   Experiments to enable in Codesphere installation (optional) (default [headless-services,vcluster,custom-service-image,ms-in-ls,secret-management,sub-path-mount])
       --external-loki-endpoint string             External Loki endpoint for Grafana Alloy log forwarding (optional)
       --external-loki-secret string               External Loki password stored in the generated vault (optional)
       --external-loki-user string                 External Loki username for Grafana Alloy log forwarding (optional)

--- a/docs/oms_beta_bootstrap-local.md
+++ b/docs/oms_beta_bootstrap-local.md
@@ -18,7 +18,7 @@ oms beta bootstrap-local [flags]
 ```
       --argocd                      After infra setup: install ArgoCD, update the OCI pull secret, and install pc-apps from the BOM version
       --base-domain string          Base domain for Codesphere (default "cs.local")
-      --experiments stringArray     Experiments to enable in Codesphere installation (optional) (default [managed-services,headless-services,vcluster,custom-service-image,ms-in-ls,secret-management,sub-path-mount])
+      --experiments stringArray     Experiments to enable in Codesphere installation (optional) (default [headless-services,vcluster,custom-service-image,ms-in-ls,secret-management,sub-path-mount])
       --feature-flags stringArray   Feature flags to enable in Codesphere installation (optional)
   -h, --help                        help for bootstrap-local
       --install-config string       Path to install config file (default: <install-dir>/config.yaml)

--- a/internal/bootstrap/gcp/gcp.go
+++ b/internal/bootstrap/gcp/gcp.go
@@ -62,7 +62,6 @@ func GetDNSRecordNames(baseDomain string) []struct {
 }
 
 var DefaultExperiments []string = []string{
-	"managed-services",
 	"headless-services",
 	"vcluster",
 	"custom-service-image",


### PR DESCRIPTION
`managed-services` flag no longer exists, it was deprecated for a while and now fully removed. 