### PR TITLE
feat(gcp-bootstrap): Create an IP and configure SSH to use it for LB svc

### DIFF
--- a/internal/bootstrap/gcp/gcp.go
+++ b/internal/bootstrap/gcp/gcp.go
@@ -58,6 +58,7 @@ func GetDNSRecordNames(baseDomain string) []struct {
 		{fmt.Sprintf("*.cs.%s.", baseDomain), "A"},
 		{fmt.Sprintf("ws.%s.", baseDomain), "A"},
 		{fmt.Sprintf("*.ws.%s.", baseDomain), "A"},
+		{fmt.Sprintf("*.ssh.%s.", baseDomain), "A"},
 	}
 }
 
@@ -106,6 +107,7 @@ type CodesphereEnvironment struct {
 	RecoverConfig                 bool            `json:"-"`
 	GatewayIP                     string          `json:"gateway_ip"`
 	PublicGatewayIP               string          `json:"public_gateway_ip"`
+	SshProxyIP                    string          `json:"ssh_proxy_ip"`
 	RegistryType                  RegistryType    `json:"registry_type"`
 	GitHubPAT                     string          `json:"-"`
 	GitHubAppName                 string          `json:"-"`
@@ -696,8 +698,8 @@ func (b *GCPBootstrapper) EnsureFirewallRules() error {
 	return nil
 }
 
-// EnsureGatewayIPAddresses reserves 2 static external IP addresses for the ingress
-// controllers of the cluster.
+// EnsureGatewayIPAddresses reserves the static external IP addresses for the ingress
+// controllers of the cluster (gateway and public gateway) and the SSH workspace proxy.
 func (b *GCPBootstrapper) EnsureGatewayIPAddresses() error {
 	var err error
 	b.Env.GatewayIP, err = b.EnsureExternalIP("gateway")
@@ -707,6 +709,10 @@ func (b *GCPBootstrapper) EnsureGatewayIPAddresses() error {
 	b.Env.PublicGatewayIP, err = b.EnsureExternalIP("public-gateway")
 	if err != nil {
 		return fmt.Errorf("failed to ensure public gateway IP: %w", err)
+	}
+	b.Env.SshProxyIP, err = b.EnsureExternalIP("ssh-proxy")
+	if err != nil {
+		return fmt.Errorf("failed to ensure ssh proxy IP: %w", err)
 	}
 
 	return nil
@@ -958,6 +964,12 @@ func (b *GCPBootstrapper) EnsureDNSRecords() error {
 			Type:    "A",
 			Ttl:     300,
 			Rrdatas: []string{b.Env.PublicGatewayIP},
+		},
+		{
+			Name:    fmt.Sprintf("*.ssh.%s.", b.Env.BaseDomain),
+			Type:    "A",
+			Ttl:     300,
+			Rrdatas: []string{b.Env.SshProxyIP},
 		},
 	}
 

--- a/internal/bootstrap/gcp/gcp_client_cleanup_test.go
+++ b/internal/bootstrap/gcp/gcp_client_cleanup_test.go
@@ -103,7 +103,7 @@ var _ = Describe("GCP Client Cleanup Methods", func() {
 				baseDomain := "example.com"
 				records := gcp.GetDNSRecordNames(baseDomain)
 
-				Expect(records).To(HaveLen(4))
+				Expect(records).To(HaveLen(5))
 				Expect(records[0].Name).To(Equal("cs.example.com."))
 				Expect(records[0].Rtype).To(Equal("A"))
 				Expect(records[1].Name).To(Equal("*.cs.example.com."))
@@ -112,6 +112,8 @@ var _ = Describe("GCP Client Cleanup Methods", func() {
 				Expect(records[2].Rtype).To(Equal("A"))
 				Expect(records[3].Name).To(Equal("*.ws.example.com."))
 				Expect(records[3].Rtype).To(Equal("A"))
+				Expect(records[4].Name).To(Equal("*.ssh.example.com."))
+				Expect(records[4].Rtype).To(Equal("A"))
 			})
 		})
 
@@ -120,7 +122,7 @@ var _ = Describe("GCP Client Cleanup Methods", func() {
 				baseDomain := "internal.codesphere.com"
 				records := gcp.GetDNSRecordNames(baseDomain)
 
-				Expect(records).To(HaveLen(4))
+				Expect(records).To(HaveLen(5))
 				for _, record := range records {
 					Expect(record.Name).To(ContainSubstring("internal.codesphere.com"))
 					Expect(record.Name).To(HaveSuffix("."))

--- a/internal/bootstrap/gcp/gcp_test.go
+++ b/internal/bootstrap/gcp/gcp_test.go
@@ -198,6 +198,9 @@ var _ = Describe("GCP Bootstrapper", func() {
 			gc.EXPECT().GetAddress(projectId, "us-central1", "public-gateway").Return(nil, fmt.Errorf("not found"))
 			gc.EXPECT().CreateAddress(projectId, "us-central1", mock.MatchedBy(func(addr *computepb.Address) bool { return *addr.Name == "public-gateway" })).Return("2.2.2.2", nil)
 			gc.EXPECT().GetAddress(projectId, "us-central1", "public-gateway").Return(&computepb.Address{Address: protoString("2.2.2.2")}, nil)
+			gc.EXPECT().GetAddress(projectId, "us-central1", "ssh-proxy").Return(nil, fmt.Errorf("not found"))
+			gc.EXPECT().CreateAddress(projectId, "us-central1", mock.MatchedBy(func(addr *computepb.Address) bool { return *addr.Name == "ssh-proxy" })).Return("3.3.3.3", nil)
+			gc.EXPECT().GetAddress(projectId, "us-central1", "ssh-proxy").Return(&computepb.Address{Address: protoString("3.3.3.3")}, nil)
 
 			// UpdateInstallConfig
 			icg.EXPECT().GenerateSecrets().Return(nil)
@@ -223,7 +226,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 			// EnsureDNSRecords
 			gc.EXPECT().EnsureDNSManagedZone(csEnv.DNSProjectID, "test-zone", "example.com.", mock.Anything).Return(nil)
 			gc.EXPECT().EnsureDNSRecordSets(csEnv.DNSProjectID, "test-zone", mock.MatchedBy(func(records []*dns.ResourceRecordSet) bool {
-				return len(records) == 4
+				return len(records) == 5
 			})).Return(nil)
 
 			// GenerateK0sConfigScript
@@ -1012,7 +1015,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 
 	Describe("EnsureGatewayIPAddresses", func() {
 		Describe("Valid EnsureGatewayIPAddresses", func() {
-			It("creates two addresses", func() {
+			It("creates three addresses", func() {
 				// Gateway
 				gc.EXPECT().GetAddress(csEnv.ProjectID, csEnv.Region, "gateway").Return(nil, fmt.Errorf("not found"))
 				gc.EXPECT().CreateAddress(csEnv.ProjectID, csEnv.Region, mock.MatchedBy(func(a *computepb.Address) bool {
@@ -1025,10 +1028,17 @@ var _ = Describe("GCP Bootstrapper", func() {
 					return *a.Name == "public-gateway"
 				})).Return("2.2.2.2", nil)
 
+				// SSH workspace proxy
+				gc.EXPECT().GetAddress(csEnv.ProjectID, csEnv.Region, "ssh-proxy").Return(nil, fmt.Errorf("not found"))
+				gc.EXPECT().CreateAddress(csEnv.ProjectID, csEnv.Region, mock.MatchedBy(func(a *computepb.Address) bool {
+					return *a.Name == "ssh-proxy"
+				})).Return("3.3.3.3", nil)
+
 				err := bs.EnsureGatewayIPAddresses()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(bs.Env.GatewayIP).To(Equal("1.1.1.1"))
 				Expect(bs.Env.PublicGatewayIP).To(Equal("2.2.2.2"))
+				Expect(bs.Env.SshProxyIP).To(Equal("3.3.3.3"))
 			})
 		})
 
@@ -1246,8 +1256,8 @@ var _ = Describe("GCP Bootstrapper", func() {
 			It("ensures DNS records", func() {
 				gc.EXPECT().EnsureDNSManagedZone(csEnv.DNSProjectID, csEnv.DNSZoneName, csEnv.BaseDomain+".", mock.Anything).Return(nil)
 				gc.EXPECT().EnsureDNSRecordSets(csEnv.DNSProjectID, csEnv.DNSZoneName, mock.MatchedBy(func(records []*dns.ResourceRecordSet) bool {
-					// Expect 4 records: *.ws, *.cs, cs, ws
-					return len(records) == 4
+					// Expect 5 records: cs, *.cs, ws, *.ws, *.ssh
+					return len(records) == 5
 				})).Return(nil)
 
 				err := bs.EnsureDNSRecords()

--- a/internal/bootstrap/gcp/install_config.go
+++ b/internal/bootstrap/gcp/install_config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/codesphere-cloud/oms/internal/bootstrap"
 	"github.com/codesphere-cloud/oms/internal/installer/files"
 	"github.com/codesphere-cloud/oms/internal/installer/secrets"
+	"github.com/codesphere-cloud/oms/internal/util"
 )
 
 const (
@@ -207,6 +208,8 @@ func (b *GCPBootstrapper) UpdateInstallConfig() error {
 	b.Env.InstallConfig.Cluster.PublicGateway.Annotations = map[string]string{
 		"cloud.google.com/load-balancer-ipv4": b.Env.PublicGatewayIP,
 	}
+
+	b.applySshProxyConfig()
 
 	dnsProject := b.Env.DNSProjectID
 	if b.Env.DNSProjectID == "" {
@@ -416,6 +419,20 @@ func (b *GCPBootstrapper) UpdateInstallConfig() error {
 	}
 
 	return nil
+}
+
+func (b *GCPBootstrapper) applySshProxyConfig() {
+	b.Env.InstallConfig.PcApps = util.DeepMergeMaps(b.Env.InstallConfig.PcApps, files.ChartValues{
+		"ssh-workspace-proxy": map[string]any{
+			"service": map[string]any{
+				"enabled": true,
+				"type":    "LoadBalancer",
+				"annotations": map[string]any{
+					"cloud.google.com/load-balancer-ipv4": b.Env.SshProxyIP,
+				},
+			},
+		},
+	})
 }
 
 func (b *GCPBootstrapper) applyExternalLokiConfig() {

--- a/internal/bootstrap/gcp/install_config_test.go
+++ b/internal/bootstrap/gcp/install_config_test.go
@@ -319,6 +319,8 @@ var _ = Describe("Installconfig & Secrets", func() {
 		})
 		Describe("Valid UpdateInstallConfig", func() {
 			It("updates config and writes files", func() {
+				csEnv.SshProxyIP = "3.3.3.3"
+
 				icg.EXPECT().GenerateSecrets().Return(nil)
 				icg.EXPECT().WriteInstallConfig("fake-config-file", true).Return(nil)
 				icg.EXPECT().WriteVault("fake-secret", true).Return(nil)
@@ -327,6 +329,13 @@ var _ = Describe("Installconfig & Secrets", func() {
 
 				err := bs.UpdateInstallConfig()
 				Expect(err).NotTo(HaveOccurred())
+
+				sshProxy := bs.Env.InstallConfig.PcApps["ssh-workspace-proxy"].(map[string]interface{})
+				sshProxyService := sshProxy["service"].(map[string]interface{})
+				Expect(sshProxyService["enabled"]).To(Equal(true))
+				Expect(sshProxyService["type"]).To(Equal("LoadBalancer"))
+				sshProxyAnnotations := sshProxyService["annotations"].(map[string]interface{})
+				Expect(sshProxyAnnotations["cloud.google.com/load-balancer-ipv4"]).To(Equal("3.3.3.3"))
 
 				Expect(bs.Env.InstallConfig.Datacenter.ID).To(Equal(1))
 				Expect(bs.Env.InstallConfig.Datacenter.Name).To(Equal("dev"))


### PR DESCRIPTION
CU-869dv8e9n

See https://codesphere-cloud.slack.com/archives/C0B4V6UF2QH/p1782288154121389?thread_ts=1782285831.692179&cid=C0B4V6UF2QH for my general approach.

Tried gcp bootstrap locally and the IP is created and the config looks correct to me.
The [corresponding change in the ssh chart](https://github.com/codesphere-cloud/charts/pull/747) is not merged yet, so can't try end to end, but worst case I'll create a followup PR.

<img width="812" height="381" alt="Screenshot 2026-06-24 at 10 35 35" src="https://github.com/user-attachments/assets/1fb0f6f0-bcff-462b-a278-4bd8b6229f7d" />
<img width="519" height="174" alt="Screenshot 2026-06-24 at 10 36 18" src="https://github.com/user-attachments/assets/ef02e80c-3f76-47f8-8d6f-35305501bb9a" />
