### PR TITLE
[test] refactor(bootstrap-local): reuse RGW exec prerequisites

### DIFF
--- a/internal/bootstrap/local/ceph.go
+++ b/internal/bootstrap/local/ceph.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,6 +75,18 @@ type cephClientDef struct {
 	name string
 	// caps is the Ceph auth capabilities.
 	caps map[string]string
+}
+
+type kubernetesClientset = kubernetes.Interface
+
+type rgwExecPrerequisites struct {
+	monHosts    string
+	adminUser   string
+	adminSecret string
+}
+
+var newKubernetesClientset = func(config *rest.Config) (kubernetesClientset, error) {
+	return kubernetes.NewForConfig(config)
 }
 
 // DeployCephFilesystem creates the CephFS filesystem "codesphere" via a CephFilesystem CRD.
@@ -507,6 +520,23 @@ func (b *LocalBootstrapper) EnsureRGWAdminUser() (*RGWUserCredentials, error) {
 }
 
 func (b *LocalBootstrapper) appendCephMonitorArgs(args []string) ([]string, error) {
+	prereqs, err := b.rgwExecPrerequisites()
+	if err != nil {
+		return nil, err
+	}
+	return append([]string{
+		"--mon-host", prereqs.monHosts,
+		"--no-mon-config",
+		"--name", prereqs.adminUser,
+		"--key", prereqs.adminSecret,
+	}, args...), nil
+}
+
+func (b *LocalBootstrapper) rgwExecPrerequisites() (*rgwExecPrerequisites, error) {
+	if b.cachedRGWExecPrereqs != nil {
+		return b.cachedRGWExecPrereqs, nil
+	}
+
 	monHosts, err := b.readCephMonitorHosts()
 	if err != nil {
 		return nil, err
@@ -515,12 +545,13 @@ func (b *LocalBootstrapper) appendCephMonitorArgs(args []string) ([]string, erro
 	if err != nil {
 		return nil, err
 	}
-	return append([]string{
-		"--mon-host", monHosts,
-		"--no-mon-config",
-		"--name", adminUser,
-		"--key", adminSecret,
-	}, args...), nil
+
+	b.cachedRGWExecPrereqs = &rgwExecPrerequisites{
+		monHosts:    monHosts,
+		adminUser:   adminUser,
+		adminSecret: adminSecret,
+	}
+	return b.cachedRGWExecPrereqs, nil
 }
 
 func (b *LocalBootstrapper) readCephMonitorHosts() (string, error) {
@@ -682,9 +713,9 @@ func (b *LocalBootstrapper) execRadosGWAdmin(args []string) (string, string, err
 }
 
 func (b *LocalBootstrapper) execInPod(namespace, podName, containerName string, command []string) (string, string, error) {
-	clientset, err := kubernetes.NewForConfig(b.restConfig)
+	clientset, err := b.podExecClientset()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to create kubernetes clientset: %w", err)
+		return "", "", err
 	}
 
 	req := clientset.CoreV1().RESTClient().Post().
@@ -711,6 +742,20 @@ func (b *LocalBootstrapper) execInPod(namespace, podName, containerName string, 
 		Stderr: &stderr,
 	})
 	return stdout.String(), stderr.String(), err
+}
+
+func (b *LocalBootstrapper) podExecClientset() (kubernetesClientset, error) {
+	if b.cachedPodExecClientset != nil {
+		return b.cachedPodExecClientset, nil
+	}
+
+	clientset, err := newKubernetesClientset(b.restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
+	}
+
+	b.cachedPodExecClientset = clientset
+	return b.cachedPodExecClientset, nil
 }
 
 func rgwUserCredentialsFromAdminJSON(raw string) (*RGWUserCredentials, error) {

--- a/internal/bootstrap/local/ceph_test.go
+++ b/internal/bootstrap/local/ceph_test.go
@@ -4,10 +4,17 @@
 package local
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rookcephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Ceph", func() {
@@ -85,6 +92,87 @@ var _ = Describe("Ceph", func() {
 		It("rejects admin JSON with missing keys", func() {
 			_, err := rgwUserCredentialsFromAdminJSON(`{"keys":[]}`)
 			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("rgwExecPrerequisites", func() {
+		It("caches the Ceph monitor hosts and admin auth for repeated RGW execs", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cephMonEndpointsConfigMap,
+					Namespace: rookNamespace,
+				},
+				Data: map[string]string{
+					"data": "a=10.0.0.1:6789,b=10.0.0.2:6789",
+				},
+			}
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cephMonSecretName,
+					Namespace: rookNamespace,
+				},
+				Data: map[string][]byte{
+					"ceph-username": []byte("client.admin"),
+					"ceph-secret":   []byte("secret-1"),
+				},
+			}
+
+			bootstrapper := &LocalBootstrapper{
+				ctx:        context.Background(),
+				kubeClient: ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap, secret).Build(),
+			}
+
+			prereqs, err := bootstrapper.rgwExecPrerequisites()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(prereqs.monHosts).To(Equal("10.0.0.1:6789,10.0.0.2:6789"))
+			Expect(prereqs.adminUser).To(Equal("client.admin"))
+			Expect(prereqs.adminSecret).To(Equal("secret-1"))
+
+			configMap.Data["data"] = "c=10.0.0.3:6789"
+			Expect(bootstrapper.kubeClient.Update(context.Background(), configMap)).To(Succeed())
+
+			secret.Data["ceph-username"] = []byte("client.changed")
+			secret.Data["ceph-secret"] = []byte("secret-2")
+			Expect(bootstrapper.kubeClient.Update(context.Background(), secret)).To(Succeed())
+
+			cachedPrereqs, err := bootstrapper.rgwExecPrerequisites()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cachedPrereqs).To(BeIdenticalTo(prereqs))
+			Expect(cachedPrereqs.monHosts).To(Equal("10.0.0.1:6789,10.0.0.2:6789"))
+			Expect(cachedPrereqs.adminUser).To(Equal("client.admin"))
+			Expect(cachedPrereqs.adminSecret).To(Equal("secret-1"))
+		})
+	})
+
+	Describe("podExecClientset", func() {
+		It("creates the pod exec clientset only once per bootstrap run", func() {
+			originalFactory := newKubernetesClientset
+			defer func() {
+				newKubernetesClientset = originalFactory
+			}()
+
+			calls := 0
+			clientset := kubefake.NewSimpleClientset()
+			newKubernetesClientset = func(_ *rest.Config) (kubernetesClientset, error) {
+				calls++
+				return clientset, nil
+			}
+
+			bootstrapper := &LocalBootstrapper{
+				restConfig: &rest.Config{Host: "https://example.invalid"},
+			}
+
+			first, err := bootstrapper.podExecClientset()
+			Expect(err).NotTo(HaveOccurred())
+			second, err := bootstrapper.podExecClientset()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(first).To(BeIdenticalTo(clientset))
+			Expect(second).To(BeIdenticalTo(clientset))
+			Expect(calls).To(Equal(1))
 		})
 	})
 })

--- a/internal/bootstrap/local/local.go
+++ b/internal/bootstrap/local/local.go
@@ -62,6 +62,12 @@ type LocalBootstrapper struct {
 	Env *CodesphereEnvironment
 	// cephCredentials holds the Ceph auth credentials read after setup.
 	cephCredentials *CephCredentials
+	// cachedRGWExecPrereqs avoids rereading static Ceph monitor/admin auth data
+	// for repeated radosgw-admin execs in a single bootstrap run.
+	cachedRGWExecPrereqs *rgwExecPrerequisites
+	// cachedPodExecClientset avoids rebuilding the pod exec clientset for each
+	// radosgw-admin invocation in a single bootstrap run.
+	cachedPodExecClientset kubernetesClientset
 	// ageRecipient is the age public key used for SOPS vault encryption.
 	ageRecipient string
 	// ageKeyPath is the filesystem path to the age private key file.


### PR DESCRIPTION

## Test - Please Ignore

- Reuse the pod-exec Kubernetes clientset and cache RGW exec prerequisites within a single `bootstrap-local` run so repeated `radosgw-admin` calls stop rebuilding the same plumbing.
- Prefer this over a `rest.Config` QPS/Burst tweak because it removes concrete repeated work on the hot path instead of only raising the client-side rate limit ceiling.
- For reviewers outside Codesphere: RGW is Ceph's RADOS Gateway, the S3-compatible API/service layer used for object storage access.

## Impact
- Keeps the change local to the local-bootstrap Ceph flow.
- Reduces repeated reads of Ceph monitor/admin-auth inputs for RGW admin commands.
- Reuses the pod-exec clientset for the lifetime of one `LocalBootstrapper`, avoiding repeated client construction on the RGW path.

## Trade-off vs `rest.Config` QPS/Burst tweak
- A QPS/Burst bump is smaller and cheaper to try, but it is a lower-confidence optimization unless we are already seeing client-side throttling.
- This change is slightly larger, but the gain is easier to explain and measure because it removes known repeated work.
- I intentionally did not change shared `rest.Config.Timeout` or add broader controller-runtime caching to keep risk low.

## Test plan
- [x] `go test ./internal/bootstrap/local`
- [x] Added focused tests covering RGW exec prerequisite caching and lazy pod-exec clientset reuse

## Risks and rollback
- The cache is scoped to a single bootstrap run and only covers Ceph monitor/admin-auth inputs plus the pod-exec clientset.
- If this proves unnecessary, rollback is straightforward because the change is isolated to the local bootstrap Ceph path.