### PR TITLE
fix(gcp-bootstrap): Fix ssh (sudomain .ssh -> .ssh.cs and config generation)

### DIFF
--- a/internal/bootstrap/gcp/gcp.go
+++ b/internal/bootstrap/gcp/gcp.go
@@ -58,7 +58,7 @@ func GetDNSRecordNames(baseDomain string) []struct {
 		{fmt.Sprintf("*.cs.%s.", baseDomain), "A"},
 		{fmt.Sprintf("ws.%s.", baseDomain), "A"},
 		{fmt.Sprintf("*.ws.%s.", baseDomain), "A"},
-		{fmt.Sprintf("*.ssh.%s.", baseDomain), "A"},
+		{fmt.Sprintf("*.ssh.cs.%s.", baseDomain), "A"},
 	}
 }
 
@@ -966,7 +966,7 @@ func (b *GCPBootstrapper) EnsureDNSRecords() error {
 			Rrdatas: []string{b.Env.PublicGatewayIP},
 		},
 		{
-			Name:    fmt.Sprintf("*.ssh.%s.", b.Env.BaseDomain),
+			Name:    fmt.Sprintf("*.ssh.cs.%s.", b.Env.BaseDomain),
 			Type:    "A",
 			Ttl:     300,
 			Rrdatas: []string{b.Env.SshProxyIP},

--- a/internal/bootstrap/gcp/gcp_client_cleanup_test.go
+++ b/internal/bootstrap/gcp/gcp_client_cleanup_test.go
@@ -112,7 +112,7 @@ var _ = Describe("GCP Client Cleanup Methods", func() {
 				Expect(records[2].Rtype).To(Equal("A"))
 				Expect(records[3].Name).To(Equal("*.ws.example.com."))
 				Expect(records[3].Rtype).To(Equal("A"))
-				Expect(records[4].Name).To(Equal("*.ssh.example.com."))
+				Expect(records[4].Name).To(Equal("*.ssh.cs.example.com."))
 				Expect(records[4].Rtype).To(Equal("A"))
 			})
 		})

--- a/internal/bootstrap/gcp/gcp_test.go
+++ b/internal/bootstrap/gcp/gcp_test.go
@@ -1256,7 +1256,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 			It("ensures DNS records", func() {
 				gc.EXPECT().EnsureDNSManagedZone(csEnv.DNSProjectID, csEnv.DNSZoneName, csEnv.BaseDomain+".", mock.Anything).Return(nil)
 				gc.EXPECT().EnsureDNSRecordSets(csEnv.DNSProjectID, csEnv.DNSZoneName, mock.MatchedBy(func(records []*dns.ResourceRecordSet) bool {
-					// Expect 5 records: cs, *.cs, ws, *.ws, *.ssh
+					// Expect 5 records: cs, *.cs, ws, *.ws, *.ssh.cs
 					return len(records) == 5
 				})).Return(nil)
 

--- a/internal/bootstrap/gcp/install_config.go
+++ b/internal/bootstrap/gcp/install_config.go
@@ -423,12 +423,17 @@ func (b *GCPBootstrapper) UpdateInstallConfig() error {
 
 func (b *GCPBootstrapper) applySshProxyConfig() {
 	b.Env.InstallConfig.PcApps = util.DeepMergeMaps(b.Env.InstallConfig.PcApps, files.ChartValues{
-		"ssh-workspace-proxy": map[string]any{
-			"service": map[string]any{
+		"applications": map[string]any{
+			"ssh-workspace-proxy": map[string]any{
 				"enabled": true,
-				"type":    "LoadBalancer",
-				"annotations": map[string]any{
-					"cloud.google.com/load-balancer-ipv4": b.Env.SshProxyIP,
+				"valuesObject": map[string]any{
+					"service": map[string]any{
+						"enabled": true,
+						"type":    "LoadBalancer",
+						"annotations": map[string]any{
+							"cloud.google.com/load-balancer-ipv4": b.Env.SshProxyIP,
+						},
+					},
 				},
 			},
 		},

--- a/internal/bootstrap/gcp/install_config_test.go
+++ b/internal/bootstrap/gcp/install_config_test.go
@@ -330,8 +330,11 @@ var _ = Describe("Installconfig & Secrets", func() {
 				err := bs.UpdateInstallConfig()
 				Expect(err).NotTo(HaveOccurred())
 
-				sshProxy := bs.Env.InstallConfig.PcApps["ssh-workspace-proxy"].(map[string]interface{})
-				sshProxyService := sshProxy["service"].(map[string]interface{})
+				applications := bs.Env.InstallConfig.PcApps["applications"].(map[string]interface{})
+				sshProxy := applications["ssh-workspace-proxy"].(map[string]interface{})
+				Expect(sshProxy["enabled"]).To(Equal(true))
+				sshProxyValues := sshProxy["valuesObject"].(map[string]interface{})
+				sshProxyService := sshProxyValues["service"].(map[string]interface{})
 				Expect(sshProxyService["enabled"]).To(Equal(true))
 				Expect(sshProxyService["type"]).To(Equal("LoadBalancer"))
 				sshProxyAnnotations := sshProxyService["annotations"].(map[string]interface{})


### PR DESCRIPTION
Followup of https://github.com/codesphere-cloud/oms/pull/529

1. The ssh subdomain needs to be  a subdomain of the domain that serves the frontend which in the gcp bootstrap is itself a sudomain (cs).
2. The pc-applications chart generates Application CRs and the value are read from the `applications` subkey which I missed in the last PR: https://github.com/codesphere-cloud/charts/blob/14b6802d488f27b75cda023a24f59dddf14b17df/charts/pc-applications/templates/applications.yaml#L2