### PR TITLE
fix(install): resolve vault from config secrets dir

### DIFF
--- a/cli/cmd/install_codesphere_dependencies.go
+++ b/cli/cmd/install_codesphere_dependencies.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -118,10 +119,14 @@ type argoCDAndAppsInstall struct {
 }
 
 func (i *argoCDAndAppsInstall) loadVaultData() error {
-	var err error
-	i.vault, err = installer.LoadVaultData(i.opts.Vault, i.opts.PrivKey)
+	vaultPath, err := i.resolveVaultPath()
 	if err != nil {
-		return fmt.Errorf("failed to load vault: %w", err)
+		return err
+	}
+
+	i.vault, err = installer.LoadVaultData(vaultPath, i.opts.PrivKey)
+	if err != nil {
+		return fmt.Errorf("failed to load vault %s: %w", vaultPath, err)
 	}
 	if s := i.vault.GetSecret(files.SecretRegistryPassword); s != nil && s.Fields != nil {
 		i.ociPassword = s.Fields.Password
@@ -143,6 +148,16 @@ func (i *argoCDAndAppsInstall) loadVaultData() error {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 	return nil
+}
+
+func (i *argoCDAndAppsInstall) resolveVaultPath() (string, error) {
+	if strings.TrimSpace(i.opts.Vault) != "" {
+		return i.opts.Vault, nil
+	}
+	if strings.TrimSpace(i.config.Secrets.BaseDir) == "" {
+		return "", fmt.Errorf("vault path is not set and config.yaml secrets.baseDir is empty")
+	}
+	return filepath.Join(i.config.Secrets.BaseDir, "prod.vault.yaml"), nil
 }
 
 func (i *argoCDAndAppsInstall) installArgoCD() error {

--- a/cli/cmd/install_codesphere_dependencies_test.go
+++ b/cli/cmd/install_codesphere_dependencies_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/codesphere-cloud/oms/internal/installer/files"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("argoCDAndAppsInstall.loadVaultData", func() {
+	It("falls back to config secrets.baseDir when --vault is not set", func() {
+		tmpDir := GinkgoT().TempDir()
+		secretsDir := filepath.Join(tmpDir, "secrets")
+		Expect(os.MkdirAll(secretsDir, 0700)).To(Succeed())
+
+		vault := &files.InstallVault{
+			Secrets: []files.SecretEntry{
+				{
+					Name: files.SecretRegistryPassword,
+					Fields: &files.SecretFields{
+						Password: "registry-password",
+					},
+				},
+				{
+					Name: files.SecretKubeConfig,
+					File: &files.SecretFile{
+						Name: "kubeconfig",
+						Content: `apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: https://127.0.0.1:6443
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user:
+    token: test-token
+`,
+					},
+				},
+			},
+		}
+		vaultYAML, err := vault.Marshal()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.WriteFile(filepath.Join(secretsDir, "prod.vault.yaml"), vaultYAML, 0600)).To(Succeed())
+
+		install := &argoCDAndAppsInstall{
+			opts: &InstallCodesphereOpts{},
+			config: files.RootConfig{
+				Secrets: files.SecretsConfig{
+					BaseDir: secretsDir,
+				},
+			},
+		}
+
+		err = install.loadVaultData()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(install.vault).ToNot(BeNil())
+		Expect(install.ociPassword).To(Equal("registry-password"))
+		Expect(install.kubeConfig).ToNot(BeNil())
+		Expect(install.kubeClient).ToNot(BeNil())
+	})
+})


### PR DESCRIPTION
Allow dependency installation to load prod.vault.yaml from config.secrets.baseDir when --vault is not provided.