### PR TITLE
feat(fga): OMS command to initialize first cluster admin

### DIFF
--- a/cli/cmd/add_cluster_admin.go
+++ b/cli/cmd/add_cluster_admin.go
@@ -41,7 +41,8 @@ func AddAddClusterAdminCmd(parent *cobra.Command, opts *GlobalOptions) {
 				deployment consumes via a secretKeyRef. The secret is created if it does not exist yet and
 				updated otherwise, so running the command again overwrites the previous email.
 
-				The target cluster is determined by the current kubeconfig context.`),
+				The target cluster is determined by the current kubeconfig context. Set the KUBECONFIG
+				environment variable to target a different kubeconfig.`),
 			Example: formatExamples("add-cluster-admin", []packageio.Example{
 				{Cmd: "--email niklas@codesphere.com", Desc: "Set the cluster admin email using the default secret and namespace"},
 				{Cmd: "--email admin@codesphere.com --namespace kube-system --secret-name cluster-admin-email", Desc: "Set the cluster admin email in a custom namespace"},

--- a/cli/cmd/add_cluster_admin.go
+++ b/cli/cmd/add_cluster_admin.go
@@ -1,0 +1,62 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+
+	packageio "github.com/codesphere-cloud/cs-go/pkg/io"
+	"github.com/codesphere-cloud/oms/internal/clusteradmin"
+	"github.com/codesphere-cloud/oms/internal/util"
+	"github.com/spf13/cobra"
+)
+
+type AddClusterAdminCmd struct {
+	cmd  *cobra.Command
+	Opts AddClusterAdminOpts
+}
+
+type AddClusterAdminOpts struct {
+	*GlobalOptions
+	clusteradmin.Opts
+}
+
+func (c *AddClusterAdminCmd) RunE(_ *cobra.Command, _ []string) error {
+	clientset, _, err := util.NewClients()
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	return clusteradmin.AddClusterAdmin(c.cmd.Context(), clientset, c.Opts.Opts)
+}
+
+func AddAddClusterAdminCmd(parent *cobra.Command, opts *GlobalOptions) {
+	c := AddClusterAdminCmd{
+		cmd: &cobra.Command{
+			Use:   "add-cluster-admin",
+			Short: "Set the cluster admin email in a Kubernetes secret",
+			Long: packageio.Long(`Sets the cluster admin email in the target Kubernetes cluster by writing it to a
+				Kubernetes secret. The email is stored under the 'email' key of the secret, which the platform
+				deployment consumes via a secretKeyRef. The secret is created if it does not exist yet and
+				updated otherwise, so running the command again overwrites the previous email.
+
+				The target cluster is determined by the current kubeconfig context.`),
+			Example: formatExamples("add-cluster-admin", []packageio.Example{
+				{Cmd: "--email niklas@codesphere.com", Desc: "Set the cluster admin email using the default secret and namespace"},
+				{Cmd: "--email admin@codesphere.com --namespace kube-system --secret-name cluster-admin-email", Desc: "Set the cluster admin email in a custom namespace"},
+			}),
+		},
+		Opts: AddClusterAdminOpts{GlobalOptions: opts},
+	}
+	c.cmd.RunE = c.RunE
+
+	flags := c.cmd.Flags()
+	flags.StringVar(&c.Opts.Email, "email", "", "Email address of the cluster admin (required)")
+	flags.StringVar(&c.Opts.Namespace, "namespace", clusteradmin.DefaultNamespace, "Kubernetes namespace where the secret is stored")
+	flags.StringVar(&c.Opts.SecretName, "secret-name", clusteradmin.DefaultSecretName, "Name of the Kubernetes secret holding the cluster admin email")
+
+	util.MarkFlagRequired(c.cmd, "email")
+
+	AddCmd(parent, c.cmd)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -88,6 +88,9 @@ func GetRootCmd() *cobra.Command {
 	// Resource creation commands
 	AddCreateCmd(rootCmd, opts)
 
+	// Cluster administration commands
+	AddAddClusterAdminCmd(rootCmd, opts)
+
 	return rootCmd
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ like downloading new versions.
 
 ### SEE ALSO
 
+* [oms add-cluster-admin](oms_add-cluster-admin.md)	 - Set the cluster admin email in a Kubernetes secret
 * [oms beta](oms_beta.md)	 - Commands for early testing
 * [oms build](oms_build.md)	 - Build and push images to a registry
 * [oms create](oms_create.md)	 - Create resources for Codesphere

--- a/docs/oms.md
+++ b/docs/oms.md
@@ -17,6 +17,7 @@ like downloading new versions.
 
 ### SEE ALSO
 
+* [oms add-cluster-admin](oms_add-cluster-admin.md)	 - Set the cluster admin email in a Kubernetes secret
 * [oms beta](oms_beta.md)	 - Commands for early testing
 * [oms build](oms_build.md)	 - Build and push images to a registry
 * [oms create](oms_create.md)	 - Create resources for Codesphere

--- a/docs/oms_add-cluster-admin.md
+++ b/docs/oms_add-cluster-admin.md
@@ -1,0 +1,42 @@
+## oms add-cluster-admin
+
+Set the cluster admin email in a Kubernetes secret
+
+### Synopsis
+
+Sets the cluster admin email in the target Kubernetes cluster by writing it to a
+Kubernetes secret. The email is stored under the 'email' key of the secret, which the platform
+deployment consumes via a secretKeyRef. The secret is created if it does not exist yet and
+updated otherwise, so running the command again overwrites the previous email.
+
+The target cluster is determined by the current kubeconfig context. Set the KUBECONFIG
+environment variable to target a different kubeconfig.
+
+```
+oms add-cluster-admin [flags]
+```
+
+### Examples
+
+```
+# Set the cluster admin email using the default secret and namespace
+$ oms add-cluster-admin --email niklas@codesphere.com
+
+# Set the cluster admin email in a custom namespace
+$ oms add-cluster-admin --email admin@codesphere.com --namespace kube-system --secret-name cluster-admin-email
+
+```
+
+### Options
+
+```
+      --email string         Email address of the cluster admin (required)
+  -h, --help                 help for add-cluster-admin
+      --namespace string     Kubernetes namespace where the secret is stored (default "codesphere")
+      --secret-name string   Name of the Kubernetes secret holding the cluster admin email (default "cluster-admin-email")
+```
+
+### SEE ALSO
+
+* [oms](oms.md)	 - Codesphere Operations Management System (OMS)
+

--- a/internal/clusteradmin/clusteradmin.go
+++ b/internal/clusteradmin/clusteradmin.go
@@ -1,0 +1,99 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package clusteradmin
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/mail"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// DefaultNamespace is the namespace the cluster-admin-email secret lives in.
+	DefaultNamespace = "codesphere"
+	// DefaultSecretName is the name of the secret holding the cluster admin email.
+	// It is referenced by the platform deployment via a secretKeyRef.
+	DefaultSecretName = "cluster-admin-email"
+	// EmailKey is the secret data key under which the admin email is stored.
+	EmailKey = "email"
+)
+
+// Opts contains the options for adding a cluster admin.
+type Opts struct {
+	Email      string
+	Namespace  string
+	SecretName string
+}
+
+// AddClusterAdmin writes the given email to the cluster-admin-email secret in
+// the target cluster, creating the secret if it does not exist yet or updating
+// it otherwise.
+//
+// The email is stored under the EmailKey data key. Running the command again
+// with a different email overwrites the previous value.
+func AddClusterAdmin(ctx context.Context, clientset kubernetes.Interface, opts Opts) error {
+	email, err := normalizeEmail(opts.Email)
+	if err != nil {
+		return err
+	}
+
+	secrets := clientset.CoreV1().Secrets(opts.Namespace)
+
+	existing, err := secrets.Get(ctx, opts.SecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      opts.SecretName,
+				Namespace: opts.Namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				EmailKey: []byte(email),
+			},
+		}
+		if _, err := secrets.Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("creating secret %s/%s: %w", opts.Namespace, opts.SecretName, err)
+		}
+		log.Printf("Created secret '%s' in namespace '%s' with cluster admin email '%s'", opts.SecretName, opts.Namespace, email)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading secret %s/%s: %w", opts.Namespace, opts.SecretName, err)
+	}
+
+	if existing.Data == nil {
+		existing.Data = map[string][]byte{}
+	}
+	if string(existing.Data[EmailKey]) == email {
+		log.Printf("Cluster admin email '%s' already set in secret '%s/%s', nothing to do", email, opts.Namespace, opts.SecretName)
+		return nil
+	}
+	existing.Data[EmailKey] = []byte(email)
+
+	if _, err := secrets.Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("updating secret %s/%s: %w", opts.Namespace, opts.SecretName, err)
+	}
+	log.Printf("Set cluster admin email '%s' in secret '%s/%s'", email, opts.Namespace, opts.SecretName)
+	return nil
+}
+
+// normalizeEmail validates and canonicalizes an email address.
+func normalizeEmail(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("email must not be empty")
+	}
+	addr, err := mail.ParseAddress(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid email %q: %w", raw, err)
+	}
+	return strings.ToLower(addr.Address), nil
+}

--- a/internal/clusteradmin/clusteradmin.go
+++ b/internal/clusteradmin/clusteradmin.go
@@ -45,6 +45,13 @@ func AddClusterAdmin(ctx context.Context, clientset kubernetes.Interface, opts O
 		return err
 	}
 
+	if strings.TrimSpace(opts.Namespace) == "" {
+		return fmt.Errorf("namespace must not be empty")
+	}
+	if strings.TrimSpace(opts.SecretName) == "" {
+		return fmt.Errorf("secret name must not be empty")
+	}
+
 	secrets := clientset.CoreV1().Secrets(opts.Namespace)
 
 	existing, err := secrets.Get(ctx, opts.SecretName, metav1.GetOptions{})

--- a/internal/clusteradmin/clusteradmin_suite_test.go
+++ b/internal/clusteradmin/clusteradmin_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package clusteradmin_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestClusteradmin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Clusteradmin Suite")
+}

--- a/internal/clusteradmin/clusteradmin_test.go
+++ b/internal/clusteradmin/clusteradmin_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package clusteradmin_test
+
+import (
+	"context"
+
+	"github.com/codesphere-cloud/oms/internal/clusteradmin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var _ = Describe("AddClusterAdmin", func() {
+	var (
+		ctx       context.Context
+		clientset *fake.Clientset
+		opts      clusteradmin.Opts
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientset = fake.NewClientset()
+		opts = clusteradmin.Opts{
+			Email:      "niklas@codesphere.com",
+			Namespace:  clusteradmin.DefaultNamespace,
+			SecretName: clusteradmin.DefaultSecretName,
+		}
+	})
+
+	getEmail := func() string {
+		secret, err := clientset.CoreV1().Secrets(opts.Namespace).Get(ctx, opts.SecretName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return string(secret.Data[clusteradmin.EmailKey])
+	}
+
+	It("creates the secret when it does not exist yet", func() {
+		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(Succeed())
+
+		secret, err := clientset.CoreV1().Secrets(opts.Namespace).Get(ctx, opts.SecretName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
+		Expect(getEmail()).To(Equal("niklas@codesphere.com"))
+	})
+
+	It("overwrites the email in an existing secret", func() {
+		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(Succeed())
+
+		opts.Email = "alice@codesphere.com"
+		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(Succeed())
+
+		Expect(getEmail()).To(Equal("alice@codesphere.com"))
+	})
+
+	It("is idempotent when setting the same email twice", func() {
+		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(Succeed())
+		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(Succeed())
+
+		Expect(getEmail()).To(Equal("niklas@codesphere.com"))
+	})
+
+	It("lowercases the email", func() {
+		opts.Email = "NIKLAS@codesphere.com"
+		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(Succeed())
+
+		Expect(getEmail()).To(Equal("niklas@codesphere.com"))
+	})
+
+	It("preserves other keys in a pre-existing secret", func() {
+		_, err := clientset.CoreV1().Secrets(opts.Namespace).Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: opts.SecretName, Namespace: opts.Namespace},
+			Data:       map[string][]byte{"other": []byte("keep")},
+		}, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(Succeed())
+
+		secret, err := clientset.CoreV1().Secrets(opts.Namespace).Get(ctx, opts.SecretName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(secret.Data["other"])).To(Equal("keep"))
+		Expect(string(secret.Data[clusteradmin.EmailKey])).To(Equal("niklas@codesphere.com"))
+	})
+
+	It("rejects an empty email", func() {
+		opts.Email = "   "
+		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(MatchError(ContainSubstring("must not be empty")))
+	})
+
+	It("rejects an invalid email", func() {
+		opts.Email = "not-an-email"
+		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(MatchError(ContainSubstring("invalid email")))
+	})
+})

--- a/internal/clusteradmin/clusteradmin_test.go
+++ b/internal/clusteradmin/clusteradmin_test.go
@@ -93,4 +93,19 @@ var _ = Describe("AddClusterAdmin", func() {
 		opts.Email = "not-an-email"
 		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(MatchError(ContainSubstring("invalid email")))
 	})
+
+	It("rejects a display name followed by a bare email address without angle brackets", func() {
+		opts.Email = "Max Mustermann max@mail.com"
+		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(MatchError(ContainSubstring("invalid email")))
+	})
+
+	It("rejects an empty namespace", func() {
+		opts.Namespace = "   "
+		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(MatchError(ContainSubstring("namespace must not be empty")))
+	})
+
+	It("rejects an empty secret name", func() {
+		opts.SecretName = "   "
+		Expect(clusteradmin.AddClusterAdmin(ctx, clientset, opts)).To(MatchError(ContainSubstring("secret name must not be empty")))
+	})
 })


### PR DESCRIPTION
CU-869dy61ny

Adds a new oms add-cluster-admin CLI command for bootstrapping the first cluster admin on a Codesphere installation.

The command writes the given email address into a Kubernetes secret (cluster-admin-email by default) in the target cluster. On startup, the AuthService reads this secret and grants the stored email cluster-admin permissions via OpenFGA — this is how a fresh installation gets its first admin without a chicken-and-egg problem (no admin exists yet to grant one via the normal permission flow).

Behavior:

Creates the secret if it doesn't exist, or updates it if it does (idempotent — re-running with the same email is a no-op).
--email (required): the cluster admin's email address, validated per RFC 5322 and normalized (lowercased). Malformed input, e.g. not-an-email or a display name without angle brackets like Max Mustermann max@mail.com, is rejected up front with a clear error rather than propagating downstream.
--namespace (default codesphere) and --secret-name (default cluster-admin-email): overridable in case of custom deployments. Empty/whitespace values are rejected early instead of silently overwriting the sensible default.
The target cluster is the current kubeconfig context; can be pointed elsewhere via the standard KUBECONFIG environment variable.
