### PR TITLE
fix: don't render configs twice

### DIFF
--- a/internal/installer/codesphere.go
+++ b/internal/installer/codesphere.go
@@ -15,9 +15,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/codesphere-cloud/oms/internal/configtemplating"
 	"github.com/codesphere-cloud/oms/internal/installer/files"
-	"github.com/codesphere-cloud/oms/internal/installer/vault"
 	"github.com/codesphere-cloud/oms/internal/system"
 	"github.com/codesphere-cloud/oms/internal/util"
 )
@@ -94,8 +92,7 @@ func (ci *CodesphereInstaller) Install(pm PackageManager, cm ConfigManager, im s
 		return fmt.Errorf("codesphere installation is only supported on Linux amd64. Current platform: %s/%s", goos, goarch)
 	}
 
-	config, cleanup, err := ci.prepareConfig(cm)
-	defer cleanup()
+	config, err := ci.loadConfig(cm)
 	if err != nil {
 		return err
 	}
@@ -115,33 +112,14 @@ func (ci *CodesphereInstaller) Install(pm PackageManager, cm ConfigManager, im s
 	return ci.runInstaller(pm, config)
 }
 
-func (ci *CodesphereInstaller) prepareConfig(cm ConfigManager) (files.RootConfig, func(), error) {
-	originalConfig := ci.ConfigPath
-	cleanup := func() {
-		ci.ConfigPath = originalConfig
-	}
-
-	if ci.VaultPath != "" {
-		store := vault.NewLazyVaultTemplatingSecretStore(ci.VaultPath, ci.PrivKey)
-		renderedConfig, renderCleanup, err := configtemplating.RenderConfigFileToTemp(ci.ConfigPath, store)
-		if err != nil {
-			return files.RootConfig{}, cleanup, fmt.Errorf("failed to render config template: %w", err)
-		}
-
-		cleanup = func() {
-			ci.ConfigPath = originalConfig
-			renderCleanup()
-		}
-		ci.ConfigPath = renderedConfig
-	}
-
+func (ci *CodesphereInstaller) loadConfig(cm ConfigManager) (files.RootConfig, error) {
 	config, err := cm.ParseConfigYaml(ci.ConfigPath)
 	if err != nil {
-		return files.RootConfig{}, cleanup, fmt.Errorf("failed to extract config.yaml: %w", err)
+		return files.RootConfig{}, fmt.Errorf("failed to extract config.yaml: %w", err)
 	}
 
 	ci.warnIfVaultDirDiffersFromSecretsDir(config)
-	return config, cleanup, nil
+	return config, nil
 }
 
 // IsStepSkipped reports whether step is present in persisted or CLI skip steps.


### PR DESCRIPTION
Instead, render them only once.
Rendering twice is bad, because double curly brackets like "{{" need to be escaped _twice_ if you want them to end up in the plain text.

The current flow in main is:

1. prepareInstallConfig(...) renders each input config with RenderConfigFileToTemp(...).
2. That merged temp file is then passed into ci.Install(...).
3. ci.Install(...) calls prepareConfig(...), which renders the config again if VaultPath != "".

This PR removes the second render run in the function prepareConfig.