### PR TITLE
feat(fga): add optional openfga db backup secrets

### DIFF
--- a/internal/installer/files/secret_names.go
+++ b/internal/installer/files/secret_names.go
@@ -43,6 +43,10 @@ const (
 	// OpenBao
 	SecretOpenBaoPassword = "openBaoPassword"
 
+	// OpenFGA
+	SecretOpenfgaDbBackupAccessKeyId     = "openfgaDbBackupAccessKeyId"
+	SecretOpenfgaDbBackupSecretAccessKey = "openfgaDbBackupSecretAccessKey"
+
 	// Monitoring
 	SecretLokiGatewayBasicAuthPassword = "lokiGatewayBasicAuthPassword"
 	SecretCentralOtelCreds             = "centralOtelCreds"

--- a/internal/installer/secrets/secrets.go
+++ b/internal/installer/secrets/secrets.go
@@ -261,6 +261,8 @@ var optionalPasswordSecrets = []string{
 	files.SecretStripeSecretKey,
 	files.SecretSendGridApiKey,
 	files.SecretOpenBaoPassword,
+	files.SecretOpenfgaDbBackupAccessKeyId,
+	files.SecretOpenfgaDbBackupSecretAccessKey,
 }
 
 func setPassword(vault *files.InstallVault, name, password string) {

--- a/internal/installer/secrets/secrets_test.go
+++ b/internal/installer/secrets/secrets_test.go
@@ -171,6 +171,7 @@ var _ = Describe("EnsureDefaultSecrets", func() {
 			"githubAppsClientId", "githubAppsClientSecret",
 			"gitlabAppClientId", "gitlabAppClientSecret",
 			"stripeSecretKey", "sendGridApiKey", "openBaoPassword",
+			"openfgaDbBackupAccessKeyId", "openfgaDbBackupSecretAccessKey",
 		} {
 			secret := vault.GetSecret(name)
 			Expect(secret).NotTo(BeNil(), "missing %s", name)


### PR DESCRIPTION
Those secrets are required for the openfga db backup that stores it into a s3 bucket.