### PR TITLE
feat(gcp): add ACME staging option

### DIFF
--- a/cli/cmd/bootstrap_gcp.go
+++ b/cli/cmd/bootstrap_gcp.go
@@ -121,6 +121,7 @@ func AddBootstrapGcpCmd(parent *cobra.Command, opts *GlobalOptions) {
 	flags.Int64Var(&bootstrapGcpCmd.CodesphereEnv.RootDiskSize, "root-disk-size", 50, "Instance root disk size in GB (default: 50)")
 
 	flags.BoolVar(&bootstrapGcpCmd.CodesphereEnv.GoogleACMEIssuer, "google-acme-issuer", false, "Use Google Public CA as the ACME issuer instead of Let's Encrypt. External Account Binding credentials are obtained automatically via the publicca API (default: false)")
+	flags.BoolVar(&bootstrapGcpCmd.CodesphereEnv.ACMEStaging, "acme-staging", false, "Use the Let's Encrypt staging ACME endpoint (certificates are not browser-trusted)")
 
 	flags.StringVar(&bootstrapGcpCmd.CodesphereEnv.OpenBaoURI, "openbao-uri", "", "URI for OpenBao (optional)")
 	flags.StringVar(&bootstrapGcpCmd.CodesphereEnv.OpenBaoEngine, "openbao-engine", "cs-secrets-engine", "OpenBao engine name (default: cs-secrets-engine)")

--- a/docs/oms_beta_bootstrap-gcp.md
+++ b/docs/oms_beta_bootstrap-gcp.md
@@ -17,6 +17,7 @@ oms beta bootstrap-gcp [flags]
 ### Options
 
 ```
+      --acme-staging                              Use the Let's Encrypt staging ACME endpoint (certificates are not browser-trusted)
       --azure-devops-app-client-id string         Azure DevOps App Client ID (optional)
       --azure-devops-app-client-secret string     Azure DevOps App Client Secret (optional)
       --base-domain string                        Base domain for Codesphere (required)

--- a/internal/bootstrap/gcp/gcp.go
+++ b/internal/bootstrap/gcp/gcp.go
@@ -139,6 +139,7 @@ type CodesphereEnvironment struct {
 
 	// ACME Issuer
 	GoogleACMEIssuer bool `json:"google_acme_issuer,omitempty"`
+	ACMEStaging      bool `json:"acme_staging,omitempty"`
 
 	// OpenBao
 	OpenBaoURI      string `json:"-"`
@@ -405,6 +406,10 @@ func (b *GCPBootstrapper) createTestUser() error {
 	return nil
 }
 func (b *GCPBootstrapper) ValidateInput() error {
+	if b.Env.GoogleACMEIssuer && b.Env.ACMEStaging {
+		return fmt.Errorf("acme-staging cannot be combined with google-acme-issuer")
+	}
+
 	err := b.validateInstallVersion()
 	if err != nil {
 		return err

--- a/internal/bootstrap/gcp/gcp_test.go
+++ b/internal/bootstrap/gcp/gcp_test.go
@@ -120,6 +120,15 @@ var _ = Describe("GCP Bootstrapper", func() {
 		})
 	})
 
+	Describe("ValidateInput ACME issuer", func() {
+		It("rejects selecting Let's Encrypt staging and Google Public CA together", func() {
+			csEnv.ACMEStaging = true
+			csEnv.GoogleACMEIssuer = true
+
+			Expect(bs.ValidateInput()).To(MatchError(ContainSubstring("acme-staging cannot be combined with google-acme-issuer")))
+		})
+	})
+
 	Describe("Bootstrap", func() {
 		BeforeEach(func() {
 			csEnv.InstallConfig = &files.RootConfig{Registry: &files.RegistryConfig{}}

--- a/internal/bootstrap/gcp/install_config.go
+++ b/internal/bootstrap/gcp/install_config.go
@@ -231,10 +231,14 @@ func (b *GCPBootstrapper) UpdateInstallConfig() error {
 			},
 		},
 	}
+	acmeServer := "https://acme-v02.api.letsencrypt.org/directory"
+	if b.Env.ACMEStaging {
+		acmeServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
+	}
 	acmeConfig := &files.ACMEConfig{
 		Enabled: true,
 		Email:   "oms-testing@" + b.Env.BaseDomain,
-		Server:  "https://acme-v02.api.letsencrypt.org/directory",
+		Server:  acmeServer,
 	}
 	if b.Env.GoogleACMEIssuer {
 		keyID, b64MacKey, err := b.GCPClient.CreatePublicCAExternalAccountKey(b.Env.ProjectID)

--- a/internal/bootstrap/gcp/install_config_test.go
+++ b/internal/bootstrap/gcp/install_config_test.go
@@ -791,6 +791,23 @@ var _ = Describe("Installconfig & Secrets", func() {
 				})
 			})
 
+			Context("When ACME staging is enabled", func() {
+				BeforeEach(func() {
+					csEnv.ACMEStaging = true
+				})
+
+				It("uses the Let's Encrypt staging directory", func() {
+					icg.EXPECT().GenerateSecrets().Return(nil)
+					icg.EXPECT().WriteInstallConfig("fake-config-file", true).Return(nil)
+					icg.EXPECT().WriteVault("fake-secret", true).Return(nil)
+					nodeClient.EXPECT().CopyFile(mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
+
+					err := bs.UpdateInstallConfig()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(bs.Env.InstallConfig.Codesphere.CertIssuer.Acme.Server).To(Equal("https://acme-staging-v02.api.letsencrypt.org/directory"))
+				})
+			})
+
 			Context("When OpenBao config is set", func() {
 				BeforeEach(func() {
 					csEnv.OpenBaoURI = "https://openbao.example.com"


### PR DESCRIPTION
Allow using the let's encrypt ACME endpoint for bootstrapping to avoid rate limits