### PR TITLE
fix(local): always load the local prod.vault.yaml file unencrypted

### DIFF
--- a/internal/bootstrap/local/local.go
+++ b/internal/bootstrap/local/local.go
@@ -513,7 +513,9 @@ func (b *LocalBootstrapper) loadVaultForConfigTemplating() error {
 		return nil
 	}
 
-	if err := b.icg.LoadVaultFromFile(b.Env.SecretsFilePath); err != nil {
+	// The local prod.vault.yaml file itn eh secrets dir is always unecrpyted.
+	// The encrypted version is in the "secrets" dir.
+	if err := b.icg.LoadVaultFromUnecryptedFile(b.Env.SecretsFilePath); err != nil {
 		return fmt.Errorf("failed to load vault file for config templating: %w", err)
 	}
 


### PR DESCRIPTION
The local installer writes the file unencrypted and then encrypts them to the secrets dir where is then used by the real installer.
The local development flow is intended to be as easy as possible and should not contain production environments this file is kept unecrypted.

Currently we force it to be encrypted which fails most local flows.