### PR TITLE
feat(installer): config and vault primitives for multiple data centers

### DIFF
--- a/internal/installer/config_manager.go
+++ b/internal/installer/config_manager.go
@@ -35,6 +35,8 @@ type InstallConfigManager interface {
 	ValidateVault() []string
 	GetInstallConfig() *files.RootConfig
 	GetVault() *files.InstallVault
+	SetInstallConfig(config *files.RootConfig)
+	SetVault(vault *files.InstallVault)
 	GetSecretFilePath() string
 	CollectInteractively() error
 
@@ -277,6 +279,18 @@ func (g *InstallConfig) GetInstallConfig() *files.RootConfig {
 
 func (g *InstallConfig) GetVault() *files.InstallVault {
 	return g.Vault
+}
+
+// SetInstallConfig replaces the managed config, so a caller can seed it from another source
+// instead of a profile or a file.
+func (g *InstallConfig) SetInstallConfig(config *files.RootConfig) {
+	g.Config = config
+}
+
+// SetVault replaces the managed vault, so a caller can seed it from another source instead of a
+// file. GenerateSecrets then fills in whatever the seed is missing.
+func (g *InstallConfig) SetVault(vault *files.InstallVault) {
+	g.Vault = vault
 }
 
 func (g *InstallConfig) GetSecretFilePath() string {

--- a/internal/installer/files/config_yaml.go
+++ b/internal/installer/files/config_yaml.go
@@ -4,6 +4,7 @@
 package files
 
 import (
+	"fmt"
 	"strings"
 
 	"go.yaml.in/yaml/v3"
@@ -39,6 +40,40 @@ func (v *InstallVault) SetSecret(entry SecretEntry) {
 	v.Secrets = append(v.Secrets, entry)
 }
 
+// RemoveSecret deletes the entry with the given name, if present.
+func (v *InstallVault) RemoveSecret(name string) {
+	for i := range v.Secrets {
+		if v.Secrets[i].Name == name {
+			v.Secrets = append(v.Secrets[:i], v.Secrets[i+1:]...)
+			return
+		}
+	}
+}
+
+// Clone returns a deep copy of the vault, so callers can derive a new vault without
+// aliasing the original's secret entries.
+func (v *InstallVault) Clone() *InstallVault {
+	if v == nil {
+		return nil
+	}
+
+	clone := &InstallVault{Secrets: make([]SecretEntry, 0, len(v.Secrets))}
+	for _, entry := range v.Secrets {
+		copied := SecretEntry{Name: entry.Name}
+		if entry.File != nil {
+			file := *entry.File
+			copied.File = &file
+		}
+		if entry.Fields != nil {
+			fields := *entry.Fields
+			copied.Fields = &fields
+		}
+		clone.Secrets = append(clone.Secrets, copied)
+	}
+
+	return clone
+}
+
 func (v *InstallVault) Unmarshal(data []byte) error {
 	return yaml.Unmarshal(data, v)
 }
@@ -62,6 +97,8 @@ type SecretFields struct {
 // RootConfig represents the relevant parts of the configuration file
 type RootConfig struct {
 	Datacenter             DatacenterConfig              `yaml:"dataCenter"`
+	DataCenters            []DatacenterConfig            `yaml:"dataCenters,omitempty"`
+	DefaultDataCenterID    int                           `yaml:"defaultDataCenterId,omitempty"`
 	Secrets                SecretsConfig                 `yaml:"secrets"`
 	Registry               *RegistryConfig               `yaml:"registry,omitempty"`
 	Postgres               PostgresConfig                `yaml:"postgres"`
@@ -79,6 +116,11 @@ type OperationsConfig struct {
 	Skip []string `yaml:"skip"`
 }
 
+// DatacenterConfig describes one data center. RootConfig.Datacenter is the data center an installer
+// run installs; RootConfig.DataCenters lists every data center of the installation, which the
+// installer needs to render the platform's data center picker. Both are the same in a
+// single-data-center installation, where DataCenters may be left empty: the installer then defaults
+// it to the local data center. DefaultDataCenterID likewise defaults to Datacenter.ID.
 type DatacenterConfig struct {
 	ID          int    `yaml:"id"`
 	Name        string `yaml:"name"`
@@ -643,6 +685,23 @@ func (c *RootConfig) Marshal() ([]byte, error) {
 	c.buildACMEOverride()
 	c.buildOpenfgaBackupValues()
 	return yaml.Marshal(c)
+}
+
+// Clone returns a deep copy of the config, so a caller can derive a new config without sharing
+// the original's maps, slices and pointers. It round-trips through YAML, so — like any other
+// load of this config — keys the struct does not model are not carried over.
+func (c *RootConfig) Clone() (*RootConfig, error) {
+	data, err := c.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshal config for cloning: %w", err)
+	}
+
+	clone := NewRootConfig()
+	if err := clone.Unmarshal(data); err != nil {
+		return nil, fmt.Errorf("unmarshal cloned config: %w", err)
+	}
+
+	return &clone, nil
 }
 
 // Unmarshal deserializes YAML data into the RootConfig

--- a/internal/installer/files/config_yaml.go
+++ b/internal/installer/files/config_yaml.go
@@ -5,6 +5,7 @@ package files
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"go.yaml.in/yaml/v3"
@@ -40,18 +41,18 @@ func (v *InstallVault) SetSecret(entry SecretEntry) {
 	v.Secrets = append(v.Secrets, entry)
 }
 
-// RemoveSecret deletes the entry with the given name, if present.
-func (v *InstallVault) RemoveSecret(name string) {
-	for i := range v.Secrets {
-		if v.Secrets[i].Name == name {
-			v.Secrets = append(v.Secrets[:i], v.Secrets[i+1:]...)
-			return
-		}
-	}
+// RemoveSecret deletes the entry with the given name and reports whether one was removed.
+func (v *InstallVault) RemoveSecret(name string) bool {
+	before := len(v.Secrets)
+	v.Secrets = slices.DeleteFunc(v.Secrets, func(s SecretEntry) bool {
+		return s.Name == name
+	})
+	return len(v.Secrets) != before
 }
 
 // Clone returns a deep copy of the vault, so callers can derive a new vault without
-// aliasing the original's secret entries.
+// aliasing the original's secret entries. A nil vault clones to nil, so a caller can pass
+// on a vault that was never loaded instead of guarding every call site.
 func (v *InstallVault) Clone() *InstallVault {
 	if v == nil {
 		return nil

--- a/internal/installer/files/config_yaml_test.go
+++ b/internal/installer/files/config_yaml_test.go
@@ -476,3 +476,140 @@ cluster:
 		})
 	})
 })
+
+var _ = Describe("InstallVault", func() {
+	var vault files.InstallVault
+
+	BeforeEach(func() {
+		vault = files.InstallVault{Secrets: []files.SecretEntry{
+			{Name: "postgresPassword", Fields: &files.SecretFields{Password: "pg-secret"}},
+			{Name: "kubeConfig", File: &files.SecretFile{Name: "kubeconfig", Content: "apiVersion: v1"}},
+			{Name: "tokenPrivateKey", Fields: &files.SecretFields{Password: "token-key"}},
+		}}
+	})
+
+	Describe("RemoveSecret", func() {
+		It("removes the named secret and reports that it did", func() {
+			Expect(vault.RemoveSecret("kubeConfig")).To(BeTrue())
+
+			Expect(vault.GetSecret("kubeConfig")).To(BeNil())
+			Expect(vault.Secrets).To(HaveLen(2))
+			Expect(vault.Secrets[0].Name).To(Equal("postgresPassword"))
+			Expect(vault.Secrets[1].Name).To(Equal("tokenPrivateKey"))
+		})
+
+		It("reports that nothing was removed for an unknown secret", func() {
+			Expect(vault.RemoveSecret("doesNotExist")).To(BeFalse())
+			Expect(vault.Secrets).To(HaveLen(3))
+		})
+
+		It("reports that nothing was removed from an empty vault", func() {
+			empty := files.InstallVault{}
+			Expect(empty.RemoveSecret("postgresPassword")).To(BeFalse())
+			Expect(empty.Secrets).To(BeEmpty())
+		})
+
+		It("removes the last remaining secret", func() {
+			single := files.InstallVault{Secrets: []files.SecretEntry{{Name: "only"}}}
+			Expect(single.RemoveSecret("only")).To(BeTrue())
+			Expect(single.Secrets).To(BeEmpty())
+		})
+	})
+
+	Describe("Clone", func() {
+		It("copies every secret entry", func() {
+			clone := vault.Clone()
+
+			Expect(clone.Secrets).To(HaveLen(3))
+			Expect(clone.GetSecret("postgresPassword").Fields.Password).To(Equal("pg-secret"))
+			Expect(clone.GetSecret("kubeConfig").File.Content).To(Equal("apiVersion: v1"))
+			Expect(clone.GetSecret("tokenPrivateKey").Fields.Password).To(Equal("token-key"))
+		})
+
+		It("does not alias the original's entries", func() {
+			clone := vault.Clone()
+
+			clone.GetSecret("postgresPassword").Fields.Password = "changed"
+			clone.GetSecret("kubeConfig").File.Content = "changed"
+			clone.SetSecret(files.SecretEntry{Name: "cephSshPrivateKey"})
+			Expect(clone.RemoveSecret("tokenPrivateKey")).To(BeTrue())
+
+			Expect(vault.GetSecret("postgresPassword").Fields.Password).To(Equal("pg-secret"))
+			Expect(vault.GetSecret("kubeConfig").File.Content).To(Equal("apiVersion: v1"))
+			Expect(vault.GetSecret("cephSshPrivateKey")).To(BeNil())
+			Expect(vault.GetSecret("tokenPrivateKey")).NotTo(BeNil())
+		})
+
+		It("keeps unset optional entry fields nil", func() {
+			sparse := files.InstallVault{Secrets: []files.SecretEntry{{Name: "empty"}}}
+
+			clone := sparse.Clone()
+
+			Expect(clone.Secrets).To(HaveLen(1))
+			Expect(clone.Secrets[0].File).To(BeNil())
+			Expect(clone.Secrets[0].Fields).To(BeNil())
+		})
+
+		It("clones a nil vault to nil", func() {
+			var unloaded *files.InstallVault
+			Expect(unloaded.Clone()).To(BeNil())
+		})
+	})
+})
+
+var _ = Describe("RootConfig Clone", func() {
+	var config files.RootConfig
+
+	BeforeEach(func() {
+		config = files.NewRootConfig()
+		config.Datacenter = files.DatacenterConfig{ID: 1, Name: "dc1"}
+		config.DataCenters = []files.DatacenterConfig{{ID: 1, Name: "dc1"}}
+		config.Secrets.BaseDir = "/etc/codesphere/secrets"
+		config.Registry.Server = "registry.example.com"
+		config.Codesphere.Features = map[string]bool{"multiDc": true}
+		config.Operations = &files.OperationsConfig{Skip: []string{"ceph"}}
+	})
+
+	It("copies the config", func() {
+		clone, err := config.Clone()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(clone.Datacenter).To(Equal(config.Datacenter))
+		Expect(clone.DataCenters).To(Equal(config.DataCenters))
+		Expect(clone.Secrets.BaseDir).To(Equal("/etc/codesphere/secrets"))
+		Expect(clone.Registry.Server).To(Equal("registry.example.com"))
+		Expect(clone.Codesphere.Features).To(Equal(map[string]bool{"multiDc": true}))
+		Expect(clone.Operations.Skip).To(Equal([]string{"ceph"}))
+	})
+
+	It("does not share maps, slices or pointers with the original", func() {
+		clone, err := config.Clone()
+		Expect(err).NotTo(HaveOccurred())
+
+		clone.Datacenter = files.DatacenterConfig{ID: 2, Name: "dc2"}
+		clone.DataCenters[0].Name = "changed"
+		clone.Secrets.BaseDir = "/etc/codesphere/secrets-dc2"
+		clone.Registry.Server = "changed"
+		clone.Codesphere.Features["multiDc"] = false
+		clone.Operations.Skip = append(clone.Operations.Skip, "postgres")
+
+		Expect(config.Datacenter.Name).To(Equal("dc1"))
+		Expect(config.DataCenters[0].Name).To(Equal("dc1"))
+		Expect(config.Secrets.BaseDir).To(Equal("/etc/codesphere/secrets"))
+		Expect(config.Registry.Server).To(Equal("registry.example.com"))
+		Expect(config.Codesphere.Features).To(Equal(map[string]bool{"multiDc": true}))
+		Expect(config.Operations.Skip).To(Equal([]string{"ceph"}))
+	})
+
+	It("drops keys the struct does not model, like any other load of the config", func() {
+		var loaded files.RootConfig
+		Expect(loaded.Unmarshal([]byte("dataCenter:\n  id: 1\nunmodelledKey: value\n"))).NotTo(HaveOccurred())
+
+		clone, err := loaded.Clone()
+		Expect(err).NotTo(HaveOccurred())
+
+		data, err := clone.Marshal()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).NotTo(ContainSubstring("unmodelledKey"))
+	})
+})

--- a/internal/installer/files/secret_names.go
+++ b/internal/installer/files/secret_names.go
@@ -105,3 +105,15 @@ const (
 	SecretStripeSecretKey               = "stripeSecretKey"
 	SecretSendGridApiKey                = "sendGridApiKey"
 )
+
+// PostgresUserSecretName returns the vault secret name holding the postgres username of the
+// service with the given name, e.g. "auth" -> "postgresUserAuth".
+func PostgresUserSecretName(serviceName string) string {
+	return "postgresUser" + Capitalize(serviceName)
+}
+
+// PostgresPasswordSecretName returns the vault secret name holding the postgres password of the
+// service with the given name, e.g. "auth" -> "postgresPasswordAuth".
+func PostgresPasswordSecretName(serviceName string) string {
+	return "postgresPassword" + Capitalize(serviceName)
+}

--- a/internal/installer/mocks.go
+++ b/internal/installer/mocks.go
@@ -604,6 +604,86 @@ func (_c *MockInstallConfigManager_LoadVaultFromUnecryptedFile_Call) RunAndRetur
 	return _c
 }
 
+// SetInstallConfig provides a mock function for the type MockInstallConfigManager
+func (_mock *MockInstallConfigManager) SetInstallConfig(config *files.RootConfig) {
+	_mock.Called(config)
+	return
+}
+
+// MockInstallConfigManager_SetInstallConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetInstallConfig'
+type MockInstallConfigManager_SetInstallConfig_Call struct {
+	*mock.Call
+}
+
+// SetInstallConfig is a helper method to define mock.On call
+//   - config *files.RootConfig
+func (_e *MockInstallConfigManager_Expecter) SetInstallConfig(config any) *MockInstallConfigManager_SetInstallConfig_Call {
+	return &MockInstallConfigManager_SetInstallConfig_Call{Call: _e.mock.On("SetInstallConfig", config)}
+}
+
+func (_c *MockInstallConfigManager_SetInstallConfig_Call) Run(run func(config *files.RootConfig)) *MockInstallConfigManager_SetInstallConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *files.RootConfig
+		if args[0] != nil {
+			arg0 = args[0].(*files.RootConfig)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockInstallConfigManager_SetInstallConfig_Call) Return() *MockInstallConfigManager_SetInstallConfig_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockInstallConfigManager_SetInstallConfig_Call) RunAndReturn(run func(config *files.RootConfig)) *MockInstallConfigManager_SetInstallConfig_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetVault provides a mock function for the type MockInstallConfigManager
+func (_mock *MockInstallConfigManager) SetVault(vault *files.InstallVault) {
+	_mock.Called(vault)
+	return
+}
+
+// MockInstallConfigManager_SetVault_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetVault'
+type MockInstallConfigManager_SetVault_Call struct {
+	*mock.Call
+}
+
+// SetVault is a helper method to define mock.On call
+//   - vault *files.InstallVault
+func (_e *MockInstallConfigManager_Expecter) SetVault(vault any) *MockInstallConfigManager_SetVault_Call {
+	return &MockInstallConfigManager_SetVault_Call{Call: _e.mock.On("SetVault", vault)}
+}
+
+func (_c *MockInstallConfigManager_SetVault_Call) Run(run func(vault *files.InstallVault)) *MockInstallConfigManager_SetVault_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *files.InstallVault
+		if args[0] != nil {
+			arg0 = args[0].(*files.InstallVault)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockInstallConfigManager_SetVault_Call) Return() *MockInstallConfigManager_SetVault_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockInstallConfigManager_SetVault_Call) RunAndReturn(run func(vault *files.InstallVault)) *MockInstallConfigManager_SetVault_Call {
+	_c.Run(run)
+	return _c
+}
+
 // ValidateInstallConfig provides a mock function for the type MockInstallConfigManager
 func (_mock *MockInstallConfigManager) ValidateInstallConfig() []string {
 	ret := _mock.Called()

--- a/internal/installer/secrets/secrets.go
+++ b/internal/installer/secrets/secrets.go
@@ -420,8 +420,8 @@ func EnsurePostgresUsers(vault *files.InstallVault) error {
 		if err != nil {
 			return fmt.Errorf("generate postgres password for %s: %w", svc.Name, err)
 		}
-		setPasswordIfAbsent(vault, fmt.Sprintf("postgresUser%s", files.Capitalize(svc.Name)), svc.DBUsername())
-		setPasswordIfAbsent(vault, fmt.Sprintf("postgresPassword%s", files.Capitalize(svc.Name)), svcPwd)
+		setPasswordIfAbsent(vault, files.PostgresUserSecretName(svc.Name), svc.DBUsername())
+		setPasswordIfAbsent(vault, files.PostgresPasswordSecretName(svc.Name), svcPwd)
 	}
 	return nil
 }


### PR DESCRIPTION
Groundwork for multi-data-center support, with no behaviour change for existing callers.

- `InstallVault.RemoveSecret` and `InstallVault.Clone`, so a vault can be derived from another one instead of generated from scratch.
- `RootConfig.Clone`, a YAML round-trip deep copy.
- The installer's `dataCenters` and `defaultDataCenterId` keys, which declare the topology of the installation. Both are `omitempty`, so a single-data-center config serialises exactly as before.
- `InstallConfigManager.SetInstallConfig` / `SetVault`, so a caller can seed a manager from a source other than a profile or a file.
- `files.PostgresUserSecretName` / `PostgresPasswordSecretName`, so the per-service postgres secret names have a single definition.

## Review notes

Nothing consumes any of this yet — it is all additive.

---

Part of the `oms beta bootstrap-gcp --multi-dc` stack (10 PRs). Merge in order; each PR is based on its predecessor.