### PR TITLE
refac(gcp): model the data centers of a bootstrap

### DIFF
--- a/internal/bootstrap/datacenter/datacenter.go
+++ b/internal/bootstrap/datacenter/datacenter.go
@@ -1,0 +1,113 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package datacenter models one Codesphere data center of a bootstrapped installation: the nodes
+// it runs on, the addresses it is reached through, and the paths of the config and vault that
+// describe it. A multi-data-center installation has one of these per data center.
+//
+// The model deliberately carries no reference to the infrastructure a data center runs on, so the
+// bootstrap flows can share it and derive it from their own environment.
+package datacenter
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/installer/files"
+	"github.com/codesphere-cloud/oms/internal/installer/node"
+)
+
+// PrimaryID is the ID of the first data center. It stays 1 in both single- and multi-DC mode, so
+// single-DC installations keep their existing dataCenter.id.
+const PrimaryID = 1
+
+// DataCenter holds the state of one Codesphere data center. Everything that a bootstrap shares
+// between its data centers (the cloud project, the network, the jumpbox, the PostgreSQL server
+// and the container registry) stays with the bootstrap; everything that must differ between them
+// lives here.
+type DataCenter struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+	// Suffix is appended to data-center-scoped resource names. It is empty for the primary
+	// data center, so single-DC bootstraps keep the resource names they have always used.
+	Suffix string `json:"suffix"`
+
+	ControlPlaneNodes []*node.Node `json:"control_plane_nodes"`
+	CephNodes         []*node.Node `json:"ceph_nodes"`
+
+	GatewayIP       string `json:"gateway_ip"`
+	PublicGatewayIP string `json:"public_gateway_ip"`
+	SSHProxyIP      string `json:"ssh_proxy_ip"`
+
+	// Local paths of the generated config and vault.
+	InstallConfigPath string `json:"-"`
+	SecretsFilePath   string `json:"-"`
+	// Paths on the shared jumpbox.
+	RemoteConfigPath string `json:"remote_config_path"`
+	SecretsDir       string `json:"secrets_dir"`
+
+	WorkspaceHostingBaseDomain string `json:"workspace_hosting_base_domain"`
+	SSHBaseDomain              string `json:"ssh_base_domain"`
+
+	// ExternalPostgres marks a data center that uses the primary data center's PostgreSQL
+	// server instead of installing its own.
+	ExternalPostgres bool `json:"external_postgres"`
+
+	InstallConfig      *files.RootConfig `json:"-"`
+	ExistingConfigUsed bool              `json:"-"`
+	// ConfigManager owns this data center's config and vault. It is not serialised, so a data
+	// center restored from an infra file is given a fresh one.
+	ConfigManager installer.InstallConfigManager `json:"-"`
+}
+
+// IsPrimary reports whether this is the first data center of the installation. The primary data
+// center owns the shared PostgreSQL server and the platform gateway that codesphere.domain
+// resolves to.
+func (dc *DataCenter) IsPrimary() bool {
+	return dc.Suffix == ""
+}
+
+// RemoteVaultPath returns the path of this data center's vault on the jumpbox.
+func (dc *DataCenter) RemoteVaultPath() string {
+	return filepath.Join(dc.SecretsDir, "prod.vault.yaml")
+}
+
+// RemoteAgeKeyPath returns the path of this data center's age identity on the jumpbox.
+func (dc *DataCenter) RemoteAgeKeyPath() string {
+	return filepath.Join(dc.SecretsDir, "age_key.txt")
+}
+
+// K0sConfigScriptPath returns the local filename of this data center's k0s configuration script.
+func (dc *DataCenter) K0sConfigScriptPath() string {
+	return fmt.Sprintf("configure-k0s%s.sh", dc.Suffix)
+}
+
+// StepName qualifies a bootstrap step name with the data center it applies to. Single-DC
+// bootstraps keep their unqualified step names.
+func (dc *DataCenter) StepName(name string) string {
+	if dc.Suffix == "" {
+		return name
+	}
+
+	return fmt.Sprintf("%s (dc %d)", name, dc.ID)
+}
+
+// SuffixedPath inserts a data-center suffix before the file extension, turning config.yaml into
+// config-dc2.yaml and prod.vault.yaml into prod-dc2.vault.yaml. The primary data center's empty
+// suffix leaves the path untouched.
+func SuffixedPath(path, suffix string) string {
+	if suffix == "" {
+		return path
+	}
+
+	dir, file := filepath.Split(path)
+
+	base, ext := file, ""
+	if idx := strings.Index(file, "."); idx > 0 {
+		base, ext = file[:idx], file[idx:]
+	}
+
+	return filepath.Join(dir, base+suffix+ext)
+}

--- a/internal/bootstrap/datacenter/datacenter_suite_test.go
+++ b/internal/bootstrap/datacenter/datacenter_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package datacenter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDataCenter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DataCenter Suite")
+}

--- a/internal/bootstrap/datacenter/datacenter_test.go
+++ b/internal/bootstrap/datacenter/datacenter_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package datacenter_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/codesphere-cloud/oms/internal/bootstrap/datacenter"
+)
+
+// The methods of DataCenter are asserted against the real layout in the gcp package's
+// BuildDataCenters test, so only the path derivation is covered here.
+var _ = Describe("SuffixedPath", func() {
+	DescribeTable("inserts the suffix before the extension",
+		func(path, suffix, expected string) {
+			Expect(datacenter.SuffixedPath(path, suffix)).To(Equal(expected))
+		},
+		Entry("primary keeps its path", "config.yaml", "", "config.yaml"),
+		Entry("single extension", "config.yaml", "-dc2", "config-dc2.yaml"),
+		// prod.vault.yaml must become prod-dc2.vault.yaml, not prod.vault-dc2.yaml, so the
+		// suffix goes before the first dot rather than the last.
+		Entry("compound extension", "prod.vault.yaml", "-dc2", "prod-dc2.vault.yaml"),
+		Entry("no extension", "config", "-dc2", "config-dc2"),
+		Entry("absolute path", "/etc/codesphere/config.yaml", "-dc2", "/etc/codesphere/config-dc2.yaml"),
+	)
+})

--- a/internal/bootstrap/gcp/datacenter.go
+++ b/internal/bootstrap/gcp/datacenter.go
@@ -1,0 +1,177 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"fmt"
+
+	"github.com/codesphere-cloud/oms/internal/bootstrap/datacenter"
+	"github.com/codesphere-cloud/oms/internal/installer"
+)
+
+// BuildDataCenters derives the data center layout from the bootstrap environment: a single
+// entry in single-DC mode, and two entries in multi-DC mode where the second one shares the
+// first one's PostgreSQL server.
+func BuildDataCenters(env *CodesphereEnvironment, newICG func() installer.InstallConfigManager) []*datacenter.DataCenter {
+	if !env.MultiDC {
+		// A single data center keeps honouring --datacenter-id. In multi-DC mode the IDs are
+		// derived instead, because they drive the per-data-center domains; validateMultiDC
+		// rejects the combination.
+		id := env.DatacenterID
+		if id == 0 {
+			id = datacenter.PrimaryID
+		}
+
+		return []*datacenter.DataCenter{newDataCenter(env, id, "", newICG)}
+	}
+
+	return []*datacenter.DataCenter{
+		newDataCenter(env, datacenter.PrimaryID, "", newICG),
+		newDataCenter(env, datacenter.PrimaryID+1, "-dc2", newICG),
+	}
+}
+
+// ensureDataCenters makes sure the environment has a usable data center layout. It derives the
+// layout on first use and gives every data center an install config manager, so any entry point
+// works whether or not Bootstrap ran first.
+func (b *GCPBootstrapper) ensureDataCenters() {
+	if len(b.Env.DataCenters) > 0 {
+		b.ensureConfigManagers()
+		return
+	}
+
+	b.Env.DataCenters = BuildDataCenters(b.Env, nil)
+	b.adoptLegacyEnvFields()
+	b.ensureConfigManagers()
+}
+
+// ensureConfigManagers gives every data center an install config manager. The primary one reuses
+// the bootstrapper's, so a single-DC bootstrap behaves exactly as it did before multi-DC support.
+// Data centers restored from an infra file arrive without a manager, since it is not serialised.
+func (b *GCPBootstrapper) ensureConfigManagers() {
+	newICG := b.NewConfigManager
+	if newICG == nil {
+		newICG = installer.NewInstallConfigManager
+	}
+
+	for i, dc := range b.Env.DataCenters {
+		if dc.ConfigManager != nil {
+			continue
+		}
+
+		if i == 0 && b.icg != nil {
+			dc.ConfigManager = b.icg
+			continue
+		}
+
+		dc.ConfigManager = newICG()
+	}
+}
+
+// adoptLegacyEnvFields moves state that a caller supplied through the deprecated top-level
+// environment fields into the primary data center. Infra files written before multi-DC support
+// carry the primary data center's nodes and IPs there.
+func (b *GCPBootstrapper) adoptLegacyEnvFields() {
+	primary := b.Env.DataCenters[0]
+	if len(primary.ControlPlaneNodes) == 0 {
+		primary.ControlPlaneNodes = b.Env.ControlPlaneNodes
+	}
+
+	if len(primary.CephNodes) == 0 {
+		primary.CephNodes = b.Env.CephNodes
+	}
+
+	if primary.GatewayIP == "" {
+		primary.GatewayIP = b.Env.GatewayIP
+	}
+
+	if primary.PublicGatewayIP == "" {
+		primary.PublicGatewayIP = b.Env.PublicGatewayIP
+	}
+
+	if primary.SSHProxyIP == "" {
+		primary.SSHProxyIP = b.Env.SshProxyIP
+	}
+
+	if primary.InstallConfig == nil {
+		primary.InstallConfig = b.Env.InstallConfig
+	}
+	// A caller that supplied a config through the environment also tells us whether it is an
+	// existing one, which decides between generating and regenerating secrets.
+	if b.Env.ExistingConfigUsed {
+		primary.ExistingConfigUsed = true
+	}
+}
+
+// mirrorPrimaryDataCenter projects the primary data center's state back onto the top-level
+// environment fields it lived in before multi-DC support. The steps that still read those fields
+// keep working while they are migrated one by one, and the infra file keeps the shape an earlier
+// OMS wrote. The projection is one-way and never read back into a DataCenter.
+func (b *GCPBootstrapper) mirrorPrimaryDataCenter() {
+	if len(b.Env.DataCenters) == 0 {
+		return
+	}
+
+	primary := b.primaryDC()
+	b.Env.ControlPlaneNodes = primary.ControlPlaneNodes
+	b.Env.CephNodes = primary.CephNodes
+	b.Env.GatewayIP = primary.GatewayIP
+	b.Env.PublicGatewayIP = primary.PublicGatewayIP
+	b.Env.SshProxyIP = primary.SSHProxyIP
+	b.Env.InstallConfig = primary.InstallConfig
+	b.Env.ExistingConfigUsed = primary.ExistingConfigUsed
+}
+
+// newDataCenter builds one data center, deriving its resource names, file paths and domains
+// from the environment and the data-center suffix.
+func newDataCenter(env *CodesphereEnvironment, id int, suffix string, newICG func() installer.InstallConfigManager) *datacenter.DataCenter {
+	name := env.DatacenterName
+	if name == "" {
+		name = "dev"
+	}
+
+	if suffix != "" {
+		// The k0s cluster is named codesphere-<datacenter name>, so the names must differ.
+		name += suffix
+	}
+
+	dc := &datacenter.DataCenter{
+		ID:                         id,
+		Name:                       name,
+		Suffix:                     suffix,
+		InstallConfigPath:          datacenter.SuffixedPath(env.InstallConfigPath, suffix),
+		SecretsFilePath:            datacenter.SuffixedPath(env.SecretsFilePath, suffix),
+		RemoteConfigPath:           datacenter.SuffixedPath(remoteInstallConfigPath, suffix),
+		SecretsDir:                 env.SecretsDir + suffix,
+		WorkspaceHostingBaseDomain: workspaceHostingBaseDomain(env, id),
+		SSHBaseDomain:              sshBaseDomain(env, id),
+		ExternalPostgres:           suffix != "",
+	}
+	if newICG != nil {
+		dc.ConfigManager = newICG()
+	}
+
+	return dc
+}
+
+// workspaceHostingBaseDomain returns the domain workspaces of the given data center are served
+// from. Single-DC installations keep ws.<base-domain>; multi-DC installations prefix it with the
+// data center ID so each data center's public gateway gets its own name.
+func workspaceHostingBaseDomain(env *CodesphereEnvironment, id int) string {
+	if !env.MultiDC {
+		return "ws." + env.BaseDomain
+	}
+
+	return fmt.Sprintf("%d.ws.%s", id, env.BaseDomain)
+}
+
+// sshBaseDomain returns the domain the workspace SSH proxy of the given data center is served
+// from, following the same scheme as workspaceHostingBaseDomain.
+func sshBaseDomain(env *CodesphereEnvironment, id int) string {
+	if !env.MultiDC {
+		return "ssh.cs." + env.BaseDomain
+	}
+
+	return fmt.Sprintf("%d.ssh.cs.%s", id, env.BaseDomain)
+}

--- a/internal/bootstrap/gcp/datacenter_test.go
+++ b/internal/bootstrap/gcp/datacenter_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/codesphere-cloud/oms/internal/bootstrap/datacenter"
+	"github.com/codesphere-cloud/oms/internal/bootstrap/gcp"
+	"github.com/codesphere-cloud/oms/internal/installer"
+)
+
+var _ = Describe("BuildDataCenters", func() {
+	newEnv := func(multiDC bool) *gcp.CodesphereEnvironment {
+		return &gcp.CodesphereEnvironment{
+			MultiDC:           multiDC,
+			BaseDomain:        "example.com",
+			DatacenterName:    "dev",
+			SecretsDir:        "/etc/codesphere/secrets",
+			InstallConfigPath: "config.yaml",
+			SecretsFilePath:   "prod.vault.yaml",
+		}
+	}
+
+	Context("single data center", func() {
+		It("keeps the paths, secrets dir and domains a single-DC bootstrap has always used", func() {
+			dcs := gcp.BuildDataCenters(newEnv(false), installer.NewInstallConfigManager)
+
+			Expect(dcs).To(HaveLen(1))
+			dc := dcs[0]
+			Expect(dc.IsPrimary()).To(BeTrue())
+			Expect(dc.ID).To(Equal(1))
+			Expect(dc.Name).To(Equal("dev"))
+			Expect(dc.Suffix).To(BeEmpty())
+			Expect(dc.InstallConfigPath).To(Equal("config.yaml"))
+			Expect(dc.SecretsFilePath).To(Equal("prod.vault.yaml"))
+			Expect(dc.RemoteConfigPath).To(Equal("/etc/codesphere/config.yaml"))
+			Expect(dc.SecretsDir).To(Equal("/etc/codesphere/secrets"))
+			Expect(dc.RemoteVaultPath()).To(Equal("/etc/codesphere/secrets/prod.vault.yaml"))
+			Expect(dc.RemoteAgeKeyPath()).To(Equal("/etc/codesphere/secrets/age_key.txt"))
+			Expect(dc.K0sConfigScriptPath()).To(Equal("configure-k0s.sh"))
+			Expect(dc.WorkspaceHostingBaseDomain).To(Equal("ws.example.com"))
+			Expect(dc.SSHBaseDomain).To(Equal("ssh.cs.example.com"))
+			Expect(dc.ExternalPostgres).To(BeFalse())
+			Expect(dc.StepName("Encrypt vault")).To(Equal("Encrypt vault"))
+		})
+	})
+
+	Context("multi data center", func() {
+		var dcs []*datacenter.DataCenter
+
+		BeforeEach(func() {
+			dcs = gcp.BuildDataCenters(newEnv(true), installer.NewInstallConfigManager)
+		})
+
+		It("builds two data centers with the second sharing the first's postgres", func() {
+			Expect(dcs).To(HaveLen(2))
+			Expect(dcs[0].ExternalPostgres).To(BeFalse())
+			Expect(dcs[1].ExternalPostgres).To(BeTrue())
+		})
+
+		It("leaves the primary data center's resource names unsuffixed", func() {
+			Expect(dcs[0].Suffix).To(BeEmpty())
+			Expect(dcs[0].InstallConfigPath).To(Equal("config.yaml"))
+			Expect(dcs[0].SecretsDir).To(Equal("/etc/codesphere/secrets"))
+		})
+
+		It("gives the secondary data center its own name, paths and secrets dir", func() {
+			dc := dcs[1]
+			Expect(dc.IsPrimary()).To(BeFalse())
+			Expect(dc.ID).To(Equal(2))
+			// The k0s cluster is named codesphere-<datacenter name>, so the names must differ.
+			Expect(dc.Name).To(Equal("dev-dc2"))
+			Expect(dc.InstallConfigPath).To(Equal("config-dc2.yaml"))
+			Expect(dc.SecretsFilePath).To(Equal("prod-dc2.vault.yaml"))
+			Expect(dc.RemoteConfigPath).To(Equal("/etc/codesphere/config-dc2.yaml"))
+			// A separate secrets dir, so the installer cannot overwrite the primary's kubeconfig
+			// and ceph credentials through config.secrets.baseDir.
+			Expect(dc.SecretsDir).To(Equal("/etc/codesphere/secrets-dc2"))
+			Expect(dc.RemoteVaultPath()).To(Equal("/etc/codesphere/secrets-dc2/prod.vault.yaml"))
+			Expect(dc.RemoteAgeKeyPath()).To(Equal("/etc/codesphere/secrets-dc2/age_key.txt"))
+			Expect(dc.K0sConfigScriptPath()).To(Equal("configure-k0s-dc2.sh"))
+			Expect(dc.StepName("Encrypt vault")).To(Equal("Encrypt vault (dc 2)"))
+		})
+
+		It("scopes the workspace and ssh domains per data center", func() {
+			Expect(dcs[0].WorkspaceHostingBaseDomain).To(Equal("1.ws.example.com"))
+			Expect(dcs[0].SSHBaseDomain).To(Equal("1.ssh.cs.example.com"))
+			Expect(dcs[1].WorkspaceHostingBaseDomain).To(Equal("2.ws.example.com"))
+			Expect(dcs[1].SSHBaseDomain).To(Equal("2.ssh.cs.example.com"))
+		})
+
+		It("gives each data center its own config manager", func() {
+			Expect(dcs[0].ConfigManager).NotTo(BeIdenticalTo(dcs[1].ConfigManager))
+		})
+	})
+
+	It("falls back to the dev datacenter name", func() {
+		env := newEnv(false)
+		env.DatacenterName = ""
+
+		Expect(gcp.BuildDataCenters(env, installer.NewInstallConfigManager)[0].Name).To(Equal("dev"))
+	})
+})

--- a/internal/bootstrap/gcp/gcp.go
+++ b/internal/bootstrap/gcp/gcp.go
@@ -15,6 +15,7 @@ import (
 
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/codesphere-cloud/oms/internal/bootstrap"
+	"github.com/codesphere-cloud/oms/internal/bootstrap/datacenter"
 	"github.com/codesphere-cloud/oms/internal/clusteradmin"
 	"github.com/codesphere-cloud/oms/internal/env"
 	"github.com/codesphere-cloud/oms/internal/github"
@@ -98,18 +99,38 @@ type GCPBootstrapper struct {
 	NodeClient   node.NodeClient
 	PortalClient portal.Portal
 	GitHubClient github.GitHubClient
+	// NewConfigManager creates the install config manager of a data center. Each data center
+	// owns its own config and vault, so multi-DC bootstraps need more than one.
+	NewConfigManager func() installer.InstallConfigManager
+}
+
+// primaryDC returns the first data center, which owns the shared PostgreSQL server and the
+// platform gateway that codesphere.domain resolves to.
+func (b *GCPBootstrapper) primaryDC() *datacenter.DataCenter {
+	return b.Env.DataCenters[0]
 }
 
 type CodesphereEnvironment struct {
-	ProjectID                     string       `json:"project_id"`
-	ProjectTTL                    string       `json:"project_ttl"`
-	ProjectName                   string       `json:"project_name"`
-	DNSProjectID                  string       `json:"dns_project_id"`
-	Jumpbox                       *node.Node   `json:"jumpbox"`
-	PostgreSQLNode                *node.Node   `json:"postgres_node"`
-	ControlPlaneNodes             []*node.Node `json:"control_plane_nodes"`
-	CephNodes                     []*node.Node `json:"ceph_nodes"`
-	ContainerRegistryURL          string       `json:"-"`
+	ProjectID      string     `json:"project_id"`
+	ProjectTTL     string     `json:"project_ttl"`
+	ProjectName    string     `json:"project_name"`
+	DNSProjectID   string     `json:"dns_project_id"`
+	Jumpbox        *node.Node `json:"jumpbox"`
+	PostgreSQLNode *node.Node `json:"postgres_node"`
+	// MultiDC bootstraps two data centers that share the PostgreSQL server but run separate
+	// Kubernetes and Ceph clusters.
+	MultiDC bool `json:"multi_dc"`
+	// DataCenters holds the per-data-center state. It always has at least one entry.
+	DataCenters []*datacenter.DataCenter `json:"datacenters"`
+	// ControlPlaneNodes and CephNodes are where the primary data center's nodes lived before
+	// multi-DC support. The steps that have not been migrated to DataCenters yet still use
+	// them, and infra files written by an earlier OMS carry the nodes here.
+	ControlPlaneNodes []*node.Node `json:"control_plane_nodes"`
+	CephNodes         []*node.Node `json:"ceph_nodes"`
+	// ContainerRegistryURL is the resolved registry server all data centers pull images from.
+	ContainerRegistryURL          string       `json:"container_registry_url,omitempty"`
+	RegistryUsername              string       `json:"-"`
+	RegistryPassword              string       `json:"-"`
 	ExistingConfigUsed            bool         `json:"-"`
 	InstallVersion                string       `json:"install_version"`
 	InstallLocal                  string       `json:"install_local"`
@@ -183,10 +204,13 @@ type CodesphereEnvironment struct {
 	SSHPrivateKeyPath          string `json:"-"`
 	DatacenterID               int    `json:"-"`
 	DatacenterName             string `json:"-"`
-	CustomPgIP                 string `json:"custom_pg_ip"`
-	Region                     string `json:"region"`
-	Zone                       string `json:"zone"`
-	DNSZoneName                string `json:"dns_zone_name"`
+	// DatacenterIDExplicit records whether --datacenter-id was set on the command line. The
+	// value alone cannot distinguish the default 1 from an explicit 1.
+	DatacenterIDExplicit bool   `json:"-"`
+	CustomPgIP           string `json:"custom_pg_ip"`
+	Region               string `json:"region"`
+	Zone                 string `json:"zone"`
+	DNSZoneName          string `json:"dns_zone_name"`
 
 	// Test user creation
 	CreateTestUser bool   `json:"-"`
@@ -210,16 +234,17 @@ func NewGCPBootstrapper(
 	gitHubClient github.GitHubClient,
 ) (*GCPBootstrapper, error) {
 	return &GCPBootstrapper{
-		ctx:          ctx,
-		stlog:        stlog,
-		fw:           fw,
-		icg:          icg,
-		GCPClient:    gcpClient,
-		Env:          CodesphereEnv,
-		NodeClient:   sshRunner,
-		PortalClient: portalClient,
-		Time:         time,
-		GitHubClient: gitHubClient,
+		ctx:              ctx,
+		stlog:            stlog,
+		fw:               fw,
+		icg:              icg,
+		GCPClient:        gcpClient,
+		Env:              CodesphereEnv,
+		NodeClient:       sshRunner,
+		PortalClient:     portalClient,
+		Time:             time,
+		GitHubClient:     gitHubClient,
+		NewConfigManager: installer.NewInstallConfigManager,
 	}, nil
 }
 

--- a/internal/bootstrap/gcp/infrafile.go
+++ b/internal/bootstrap/gcp/infrafile.go
@@ -40,6 +40,12 @@ func LoadInfraFile(fw util.FileIO, infraFilePath string) (CodesphereEnvironment,
 
 // WriteInfraFile writes details about the bootstrapped codesphere environment into a file.
 func (b *GCPBootstrapper) WriteInfraFile() error {
+	b.ensureDataCenters()
+
+	// The steps that still write the top-level node and IP fields are migrated to DataCenters
+	// one by one, so keep both in sync until the last one is.
+	b.mirrorPrimaryDataCenter()
+
 	envBytes, err := json.MarshalIndent(b.Env, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal codesphere env: %w", err)


### PR DESCRIPTION
Until now a bootstrapped project was implicitly a single data center: its nodes, gateway IPs, config paths and domains all lived directly on `CodesphereEnvironment`. Multi-DC needs more than one of each, so this introduces the `DataCenter` type holding everything that must differ per data center, while project-level state (project, VPC, jumpbox, shared postgres node, registry) stays on the environment.

`BuildDataCenters` derives the layout from the flags: one entry today, and with `--multi-dc` a second one that shares the first's PostgreSQL server. The primary data center keeps an empty resource-name suffix, so every name, path and domain a single-DC bootstrap produces is unchanged.

## Review notes

Nothing consumes the layout yet — the callers are migrated in the following PRs. Two mechanisms keep that migration safe:

- `ensureDataCenters` derives the layout on first use and adopts state a caller passed through the legacy top-level environment fields, so every entry point works whether or not `Bootstrap` ran first — including infra files written before multi-DC support.
- `mirrorPrimaryDataCenter` projects the primary data center back onto those fields before the infra file is written, so `cleanup` and `restart-vms` keep reading what they always have. The projection is one-way and never read back.
---

Part of the `oms beta bootstrap-gcp --multi-dc` stack (10 PRs). Merge in order; each PR is based on its predecessor.