### PR TITLE
ci: enable linters on changed code

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -18,12 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
           go-version-file: 'go.mod'
 
-      - name: lint
-        run: make lint
-
       - name: lint-changed
         run: make lint-changed
+
+      - name: lint
+        run: make lint

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -21,5 +21,9 @@ jobs:
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
           go-version-file: 'go.mod'
+
       - name: lint
         run: make lint
+
+      - name: lint-changed
+        run: make lint-changed

--- a/.golangci-tmp.yml
+++ b/.golangci-tmp.yml
@@ -1,22 +1,11 @@
 # Copyright (c) Codesphere Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# This file contains all available configuration options
-# with their default values (in comments).
-#
-# This file is not a configuration example,
-# it contains the exhaustive configuration with explanations of the options.
+# This is the default setting for golangci-lint.
+# In OMS we are providing a new config with more linters enabled. 
+# This default settings is a temporary workaround to not change all findings at once but only on changed code.
 
-# Defines the configuration version.
-# The only possible value is "2".
 version: "2"
 
 linters:
-  # Default set of linters.
-  # The value can be:
-  # - `standard`: the "Default" linters https://golangci-lint.run/docs/linters/#all-linters
-  # - `all`: enables all linters by default.
-  # - `none`: disables all linters by default.
-  # - `fast`: enables only linters considered as "fast" (`golangci-lint help linters --json | jq '[ .[] | select(.fast==true) ] | map(.name)'`).
-  # Default: standard
   default: standard

--- a/.golangci-tmp.yml
+++ b/.golangci-tmp.yml
@@ -20,14 +20,3 @@ linters:
   # - `fast`: enables only linters considered as "fast" (`golangci-lint help linters --json | jq '[ .[] | select(.fast==true) ] | map(.name)'`).
   # Default: standard
   default: standard
-
-  # Enable specific linter.
-  enable:
-    - revive
-    - wsl_v5
-
-issues:
-  # Maximum issues count per one linter.
-  # Set to 0 to disable.
-  # Default: 50
-  max-issues-per-linter: 0

--- a/.golangci-wip.yml
+++ b/.golangci-wip.yml
@@ -1,3 +1,6 @@
+# Copyright (c) Codesphere Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 # This file contains all available configuration options
 # with their default values (in comments).
 #

--- a/.golangci-wip.yml
+++ b/.golangci-wip.yml
@@ -1,0 +1,30 @@
+# This file contains all available configuration options
+# with their default values (in comments).
+#
+# This file is not a configuration example,
+# it contains the exhaustive configuration with explanations of the options.
+
+# Defines the configuration version.
+# The only possible value is "2".
+version: "2"
+
+linters:
+  # Default set of linters.
+  # The value can be:
+  # - `standard`: the "Default" linters https://golangci-lint.run/docs/linters/#all-linters
+  # - `all`: enables all linters by default.
+  # - `none`: disables all linters by default.
+  # - `fast`: enables only linters considered as "fast" (`golangci-lint help linters --json | jq '[ .[] | select(.fast==true) ] | map(.name)'`).
+  # Default: standard
+  default: standard
+
+  # Enable specific linter.
+  enable:
+    - revive
+    - wsl_v5
+
+issues:
+  # Maximum issues count per one linter.
+  # Set to 0 to disable.
+  # Default: 50
+  max-issues-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
   enable:
     - revive
     - wsl_v5
+    - wrapcheck
 
 issues:
   # Maximum issues count per one linter.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ issues:
 
   # Show issues in any part of update files (requires new-from-rev or new-from-patch).
   # Default: false
-  whole-files: true
+  whole-files: false
 
   # Apply the fixes detected by the linters and formatters (if it's supported by the linter).
   # Default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+# This file contains all available configuration options
+# with their default values (in comments).
+#
+# This file is not a configuration example,
+# it contains the exhaustive configuration with explanations of the options.
+
+# Defines the configuration version.
+# The only possible value is "2".
+version: "2"
+
+linters:
+  # Default set of linters.
+  # The value can be:
+  # - `standard`: the "Default" linters https://golangci-lint.run/docs/linters/#all-linters
+  # - `all`: enables all linters by default.
+  # - `none`: disables all linters by default.
+  # - `fast`: enables only linters considered as "fast" (`golangci-lint help linters --json | jq '[ .[] | select(.fast==true) ] | map(.name)'`).
+  # Default: standard
+  default: standard

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,3 +28,7 @@ issues:
   # Show issues in any part of update files (requires new-from-rev or new-from-patch).
   # Default: false
   whole-files: true
+
+  # Apply the fixes detected by the linters and formatters (if it's supported by the linter).
+  # Default: false
+  fix: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,6 @@
 # Copyright (c) Codesphere Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# This file contains all available configuration options
-# with their default values (in comments).
-#
-# This file is not a configuration example,
-# it contains the exhaustive configuration with explanations of the options.
-
-# Defines the configuration version.
-# The only possible value is "2".
 version: "2"
 
 linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,3 +20,14 @@ linters:
   # - `fast`: enables only linters considered as "fast" (`golangci-lint help linters --json | jq '[ .[] | select(.fast==true) ] | map(.name)'`).
   # Default: standard
   default: standard
+
+  # Enable specific linter.
+  enable:
+    - revive
+    - wsl_v5
+
+issues:
+  # Maximum issues count per one linter.
+  # Set to 0 to disable.
+  # Default: 50
+  max-issues-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,3 +31,7 @@ issues:
   # Set to 0 to disable.
   # Default: 50
   max-issues-per-linter: 0
+
+  # Show issues in any part of update files (requires new-from-rev or new-from-patch).
+  # Default: false
+  whole-files: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+# Copyright (c) Codesphere Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 # This file contains all available configuration options
 # with their default values (in comments).
 #

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ format:
 	go fmt ./...
 
 lint: install-build-deps
-	go tool golangci-lint run -c .golangci.yml
+	go tool golangci-lint run -c .golangci-tmp.yml
 
 lint-changed: install-build-deps
-	go tool golangci-lint run --new-from-merge-base=main -c .golangci-wip.yml
+	go tool golangci-lint run -c .golangci.yml --new-from-merge-base=main 
 
 install-build-deps:
 ifeq (, $(shell which copywrite))

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint: install-build-deps
 	go tool golangci-lint run -c .golangci-tmp.yml
 
 lint-changed: install-build-deps
-	go tool golangci-lint run -c .golangci.yml --new-from-merge-base=main 
+	go tool golangci-lint run -c .golangci.yml --new-from-merge-base=origin/main 
 
 install-build-deps:
 ifeq (, $(shell which copywrite))

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,10 @@ format:
 	go fmt ./...
 
 lint: install-build-deps
-	go tool golangci-lint run
+	go tool golangci-lint run -c .golangci.yml
+
+lint-changed: install-build-deps
+	go tool golangci-lint run --new-from-merge-base=main -c .golangci-wip.yml
 
 install-build-deps:
 ifeq (, $(shell which copywrite))

--- a/internal/util/ceph.go
+++ b/internal/util/ceph.go
@@ -1,6 +1,8 @@
 // Copyright (c) Codesphere Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package util provides several utilities that are used in other packages and tests.
+// This file provides ceph related utility functions.
 package util
 
 import (
@@ -21,7 +23,9 @@ import (
 //	["a=10.0.0.1:6789", "b=[v2:10.0.0.2:3300/0,v1:10.0.0.2:6789/0]"]
 func SplitMonitorEndpointEntries(rawEndpoints string) []string {
 	entries := []string{}
+
 	var current strings.Builder
+
 	bracketDepth := 0
 
 	for _, r := range rawEndpoints {
@@ -36,6 +40,7 @@ func SplitMonitorEndpointEntries(rawEndpoints string) []string {
 			if bracketDepth == 0 {
 				entries = append(entries, current.String())
 				current.Reset()
+
 				continue
 			}
 		}
@@ -76,11 +81,13 @@ func ParseMonitorEndpointHost(endpoint string) (string, error) {
 				return host, nil
 			}
 		}
+
 		return "", fmt.Errorf("no valid monitor host found in %q", endpoint)
 	}
 
 	endpoint = strings.TrimPrefix(endpoint, "v1:")
 	endpoint = strings.TrimPrefix(endpoint, "v2:")
+
 	if slash := strings.Index(endpoint, "/"); slash >= 0 {
 		endpoint = endpoint[:slash]
 	}

--- a/internal/util/ceph.go
+++ b/internal/util/ceph.go
@@ -100,6 +100,9 @@ func ParseMonitorEndpointHost(endpoint string) (string, error) {
 		if port == "" {
 			return host, nil
 		}
+		if port == "" {
+			return host, nil
+		}
 		return net.JoinHostPort(host, port), nil
 	}
 

--- a/internal/util/ceph.go
+++ b/internal/util/ceph.go
@@ -97,12 +97,11 @@ func ParseMonitorEndpointHost(endpoint string) (string, error) {
 		if host == "" {
 			return "", fmt.Errorf("endpoint %q does not contain a valid host", endpoint)
 		}
+
 		if port == "" {
 			return host, nil
 		}
-		if port == "" {
-			return host, nil
-		}
+
 		return net.JoinHostPort(host, port), nil
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,19 +1,22 @@
 // Copyright (c) Codesphere Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package version provides functions about the OMS version
 package version
 
 // Variables are injected by goreleaser on release
 var (
-	version string = "0.0.0"
-	commit  string = "none"
-	date    string = "unknown"
-	os      string = "unknown"
-	arch    string = "unknown"
-	binName string = "oms"
+	version = "0.0.0"
+	commit  = "none"
+	date    = "unknown"
+	os      = "unknown"
+	arch    = "unknown"
+	binName = "oms"
 )
 
 //mockery:generate: true
+
+// Version provides access to the build information of the binary.
 type Version interface {
 	Version() string
 	Commit() string
@@ -22,28 +25,35 @@ type Version interface {
 	Arch() string
 }
 
+// Build implements Version using the values injected at release time.
 type Build struct{}
 
+// Version returns the released version of the binary.
 func (b *Build) Version() string {
 	return version
 }
 
+// Commit returns the git commit the binary was built from.
 func (b *Build) Commit() string {
 	return commit
 }
 
+// BuildDate returns the date the binary was built.
 func (b *Build) BuildDate() string {
 	return date
 }
 
+// Os returns the operating system the binary was built for.
 func (b *Build) Os() string {
 	return os
 }
 
+// Arch returns the architecture the binary was built for.
 func (b *Build) Arch() string {
 	return arch
 }
 
+// BinName returns the name of the binary.
 func (b *Build) BinName() string {
 	return binName
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,7 +1,7 @@
 // Copyright (c) Codesphere Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package version provides functions about the OMS version
+// Package version provides build informations about the OMS version.
 package version
 
 // Variables are injected by goreleaser on release


### PR DESCRIPTION
This PR adds a new golangci-lint config that will help us to keep a more consistent style of code, which in the end helps us in code reviews and maintenance.
For now we still use the default settings when linting the whole repository (using `.golangci-tmp.yml`) and our target config (`.golangci.yml`) is only used on changed **files** (not only changed lines).

The target config is also the default config when using golangci during development. So I highly recommend setting golangci-lint v2 as default linter in vscode.

I also fixed two files as an example. I don't  think fixing the findings takes too much time. 
It's usually something like:
- adding a package comment (default godoc style)
- adding comments to exported functions (also godoc)
- using a consistent whitespace style (not the one we all prefer probably, but at least the same for all 😄 )

The new linters in addition to the default settings are:
- https://revive.run/
- https://github.com/bombsimon/wsl
- https://github.com/tomarrell/wrapcheck