### PR TITLE
chore(ci): Allow dot-imports for ginkgo and gomega

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,17 @@ linters:
     - wsl_v5
     - wrapcheck
 
+  settings:
+    revive:
+      enable-default-rules: true
+
+      rules:
+        - name: dot-imports
+          arguments:
+            - allowed-packages:
+                - github.com/onsi/ginkgo/v2
+                - github.com/onsi/gomega
+
 issues:
   # Maximum issues count per one linter.
   # Set to 0 to disable.


### PR DESCRIPTION
ginkgo and gomega are typically used with dot-imports