### PR TITLE
fix(bootstrap): Query org members only once

### DIFF
--- a/internal/bootstrap/gcp/gce.go
+++ b/internal/bootstrap/gcp/gce.go
@@ -59,12 +59,16 @@ func (b *GCPBootstrapper) EnsureComputeInstances() error {
 	errCh := make(chan error, len(vmDefs))
 	resultCh := make(chan vmResult, len(vmDefs))
 	logCh := make(chan string, len(vmDefs))
+	sshKeys, err := b.getSSHKeys()
+	if err != nil {
+		return fmt.Errorf("failed to determine SSH keys: %w", err)
+	}
 
 	for _, vm := range vmDefs {
 		wg.Add(1)
 		go func(vm VMDef) {
 			defer wg.Done()
-			result, err := b.ensureVM(vm, b.Env.RootDiskSize, logCh)
+			result, err := b.ensureVM(vm, b.Env.RootDiskSize, sshKeys, logCh)
 			if err != nil {
 				errCh <- err
 				return
@@ -122,9 +126,28 @@ func (b *GCPBootstrapper) EnsureComputeInstances() error {
 	return nil
 }
 
+func (b *GCPBootstrapper) getSSHKeys() (string, error) {
+	sshKeys := ""
+	if b.Env.GitHubPAT != "" && b.Env.GitHubTeamOrg != "" && b.Env.GitHubTeamSlug != "" {
+		var err error
+		sshKeys, err = github.GetSSHKeysFromGitHubTeam(b.GitHubClient, b.Env.GitHubTeamOrg, b.Env.GitHubTeamSlug)
+		if err != nil {
+			return "", fmt.Errorf("failed to get SSH keys from GitHub team: %w", err)
+		}
+	}
+
+	pubKey, err := b.ReadSSHKey(b.Env.SSHPublicKeyPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read SSH public key: %w", err)
+	}
+
+	sshKeys += fmt.Sprintf("root:%s\nubuntu:%s", pubKey+"root", pubKey+"ubuntu")
+	return sshKeys, nil
+}
+
 // ensureVM handles the full lifecycle of a single VM: check existence, restart if stopped,
 // or create a new instance with spot fallback. Returns the VM result with assigned IPs.
-func (b *GCPBootstrapper) ensureVM(vm VMDef, rootDiskSize int64, logCh chan<- string) (vmResult, error) {
+func (b *GCPBootstrapper) ensureVM(vm VMDef, rootDiskSize int64, sshKeys string, logCh chan<- string) (vmResult, error) {
 	projectID := b.Env.ProjectID
 	zone := b.Env.Zone
 
@@ -143,7 +166,7 @@ func (b *GCPBootstrapper) ensureVM(vm VMDef, rootDiskSize int64, logCh chan<- st
 			return vmResult{}, fmt.Errorf("instance %s is SUSPENDED; manual resume is required", vm.Name)
 		}
 	} else {
-		instance, err := b.buildInstanceSpec(vm, rootDiskSize)
+		instance, err := b.buildInstanceSpec(vm, rootDiskSize, sshKeys)
 		if err != nil {
 			return vmResult{}, err
 		}
@@ -167,7 +190,7 @@ func (b *GCPBootstrapper) ensureVM(vm VMDef, rootDiskSize int64, logCh chan<- st
 }
 
 // buildInstanceSpec constructs the full compute instance specification for a VM.
-func (b *GCPBootstrapper) buildInstanceSpec(vm VMDef, rootDiskSize int64) (*computepb.Instance, error) {
+func (b *GCPBootstrapper) buildInstanceSpec(vm VMDef, rootDiskSize int64, sshKeys string) (*computepb.Instance, error) {
 	projectID := b.Env.ProjectID
 	region := b.Env.Region
 	zone := b.Env.Zone
@@ -199,22 +222,6 @@ func (b *GCPBootstrapper) buildInstanceSpec(vm VMDef, rootDiskSize int64) (*comp
 			},
 		})
 	}
-
-	sshKeys := ""
-	if b.Env.GitHubPAT != "" && b.Env.GitHubTeamOrg != "" && b.Env.GitHubTeamSlug != "" {
-		var err error
-		sshKeys, err = github.GetSSHKeysFromGitHubTeam(b.GitHubClient, b.Env.GitHubTeamOrg, b.Env.GitHubTeamSlug)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get SSH keys from GitHub team: %w", err)
-		}
-	}
-
-	pubKey, err := b.ReadSSHKey(b.Env.SSHPublicKeyPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read SSH public key: %w", err)
-	}
-
-	sshKeys += fmt.Sprintf("root:%s\nubuntu:%s", pubKey+"root", pubKey+"ubuntu")
 
 	serviceAccount := fmt.Sprintf("cloud-controller@%s.iam.gserviceaccount.com", projectID)
 	instance := &computepb.Instance{

--- a/internal/bootstrap/gcp/gce_test.go
+++ b/internal/bootstrap/gcp/gce_test.go
@@ -567,7 +567,7 @@ var _ = Describe("GCE", func() {
 				})
 
 				It("Sets the root disk size", func() {
-					fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAA..."), nil).Times(8)
+					fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAA..."), nil).Times(1)
 					allRootDiskSizesCorrect := true
 					mu := sync.Mutex{}
 					gc.EXPECT().CreateInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).RunAndReturn(
@@ -590,7 +590,7 @@ var _ = Describe("GCE", func() {
 			})
 
 			It("creates all instances", func() {
-				fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAA..."), nil).Times(8)
+				fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAA..."), nil).Times(1)
 				gc.EXPECT().CreateInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).Return(nil).Times(8)
 				ipResp := makeRunningInstance("10.0.0.x", "1.2.3.x")
 				mockGetInstanceNotFoundThenRunning(gc, csEnv.ProjectID, csEnv.Zone, ipResp, 8)
@@ -612,7 +612,7 @@ var _ = Describe("GCE", func() {
 				It("does not fetch GitHub org keys when GitHub team org is set without slug", func() {
 					ipResp := makeRunningInstance("10.0.0.x", "1.2.3.x")
 					mockGetInstanceNotFoundThenRunning(gc, csEnv.ProjectID, csEnv.Zone, ipResp, 8)
-					fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAA..."), nil).Times(8)
+					fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAA..."), nil).Times(1)
 					gc.EXPECT().CreateInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).Return(nil).Times(8)
 
 					err := bs.EnsureComputeInstances()
@@ -628,7 +628,7 @@ var _ = Describe("GCE", func() {
 						ipResp := makeRunningInstance("10.0.0.x", "1.2.3.x")
 						mockGetInstanceNotFoundThenRunning(gc, csEnv.ProjectID, csEnv.Zone, ipResp, 8)
 
-						fw.EXPECT().ReadFile(csEnv.SSHPublicKeyPath).Return([]byte("ssh-rsa AAA..."), nil).Times(8)
+						fw.EXPECT().ReadFile(csEnv.SSHPublicKeyPath).Return([]byte("ssh-rsa AAA..."), nil).Times(1)
 						gc.EXPECT().CreateInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).RunAndReturn(func(projectID, zone string, instance *computepb.Instance) error {
 							sshMetadata := ""
 							for _, item := range instance.GetMetadata().GetItems() {
@@ -710,7 +710,7 @@ var _ = Describe("GCE", func() {
 				ipResp := makeRunningInstance("10.0.0.x", "1.2.3.x")
 				mockGetInstanceNotFoundThenRunning(gc, csEnv.ProjectID, csEnv.Zone, ipResp, 8)
 
-				fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAA..."), nil).Times(8)
+				fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAA..."), nil).Times(1)
 
 				// Verify CreateInstance is called with SPOT provisioning model
 				gc.EXPECT().CreateInstance(csEnv.ProjectID, csEnv.Zone, mock.MatchedBy(func(instance *computepb.Instance) bool {
@@ -729,7 +729,7 @@ var _ = Describe("GCE", func() {
 				ipResp := makeRunningInstance("10.0.0.x", "1.2.3.x")
 				mockGetInstanceNotFoundThenRunning(gc, csEnv.ProjectID, csEnv.Zone, ipResp, 8)
 
-				fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAA..."), nil).Times(8)
+				fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAA..."), nil).Times(1)
 
 				createCalls := make(map[string]int)
 				var mu sync.Mutex
@@ -764,6 +764,7 @@ var _ = Describe("GCE", func() {
 					// After StartInstance, VM is running
 					return runningResp, nil
 				}).Times(16)
+				fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAAA...  \n"), nil)
 
 				gc.EXPECT().StartInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).Return(nil).Times(8)
 
@@ -775,6 +776,7 @@ var _ = Describe("GCE", func() {
 				runningResp := makeRunningInstance("10.0.0.x", "1.2.3.x")
 				// 8 VMs × 2 GetInstance calls each (initial check + waitForInstanceRunning poll)
 				gc.EXPECT().GetInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).Return(runningResp, nil).Times(16)
+				fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAAA...  \n"), nil)
 
 				err := bs.EnsureComputeInstances()
 				Expect(err).NotTo(HaveOccurred())
@@ -785,6 +787,7 @@ var _ = Describe("GCE", func() {
 				var mu sync.Mutex
 				stagingResp := makeInstance("STAGING", "10.0.0.x", "1.2.3.x")
 				runningResp := makeRunningInstance("10.0.0.x", "1.2.3.x")
+				fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAAA...  \n"), nil)
 				gc.EXPECT().GetInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).RunAndReturn(func(projectID, zone, name string) (*computepb.Instance, error) {
 					mu.Lock()
 					defer mu.Unlock()
@@ -806,6 +809,7 @@ var _ = Describe("GCE", func() {
 				// .Maybe() because VMs are created in parallel; not all may reach StartInstance.
 				gc.EXPECT().GetInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).Return(stoppedResp, nil).Maybe()
 				gc.EXPECT().StartInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).Return(fmt.Errorf("start error")).Maybe()
+				fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAAA...  \n"), nil)
 
 				err := bs.EnsureComputeInstances()
 				Expect(err).To(HaveOccurred())
@@ -813,6 +817,7 @@ var _ = Describe("GCE", func() {
 			})
 
 			It("fails when initial GetInstance returns a non-NotFound error", func() {
+				fw.EXPECT().ReadFile(mock.Anything).Return([]byte("ssh-rsa AAAA...  \n"), nil)
 				gc.EXPECT().GetInstance(csEnv.ProjectID, csEnv.Zone, mock.Anything).Return(nil, fmt.Errorf("permission denied")).Maybe()
 
 				err := bs.EnsureComputeInstances()

--- a/internal/bootstrap/gcp/gcp_test.go
+++ b/internal/bootstrap/gcp/gcp_test.go
@@ -216,7 +216,7 @@ var _ = Describe("GCP Bootstrapper", func() {
 			// EnsureComputeInstances
 			ipResp := makeRunningInstance("10.0.0.1", "1.2.3.4")
 			mockGetInstanceNotFoundThenRunning(gc, projectId, "us-central1-a", ipResp, 8)
-			fw.EXPECT().ReadFile(mock.Anything).Return([]byte("fake-key"), nil).Times(8)
+			fw.EXPECT().ReadFile(mock.Anything).Return([]byte("fake-key"), nil).Times(1)
 			gc.EXPECT().CreateInstance(projectId, "us-central1-a", mock.Anything).Return(nil).Times(8)
 
 			// EnsureGatewayIPAddresses


### PR DESCRIPTION
* Previously we queried them once per VM
* SSH keys are now generated only once and passed to the VM creation