### PR TITLE
feat(openfga): generate a preshared key in the vault

### DIFF
--- a/internal/installer/files/secret_names.go
+++ b/internal/installer/files/secret_names.go
@@ -44,6 +44,7 @@ const (
 	SecretOpenBaoPassword = "openBaoPassword"
 
 	// OpenFGA
+	SecretOpenFgaPresharedKey            = "openFgaPresharedKey"
 	SecretOpenfgaDbBackupAccessKeyId     = "openfgaDbBackupAccessKeyId"
 	SecretOpenfgaDbBackupSecretAccessKey = "openfgaDbBackupSecretAccessKey"
 

--- a/internal/installer/secrets/secrets.go
+++ b/internal/installer/secrets/secrets.go
@@ -49,6 +49,10 @@ func EnsureSecrets(vault *files.InstallVault, config *files.RootConfig) error {
 	if err := EnsureMounterHmacSecret(vault); err != nil {
 		return fmt.Errorf("ensure hmac secret: %w", err)
 	}
+
+	if err := EnsureOpenFgaPresharedKey(vault); err != nil {
+		return fmt.Errorf("ensure openfga preshared key: %w", err)
+	}
 	if err := EnsureDefaultSecrets(vault); err != nil {
 		return fmt.Errorf("ensure default secrets: %w", err)
 	}
@@ -169,6 +173,30 @@ func EnsureMounterHmacSecret(vault *files.InstallVault) error {
 		Name:   files.SecretMounterHmacSecret,
 		Fields: &files.SecretFields{Password: hex.EncodeToString(b)},
 	})
+	return nil
+}
+
+// EnsureOpenFgaPresharedKey generates the preshared key that OpenFGA and the Codesphere
+// services authenticate with, as 64 hex characters. Idempotent.
+//
+// One OpenFGA instance serves a whole installation, so this key is shared rather than
+// per-data-center: every data center's vault must hold the same value, copied over from
+// the one that deploys OpenFGA.
+func EnsureOpenFgaPresharedKey(vault *files.InstallVault) error {
+	if vault.GetSecret(files.SecretOpenFgaPresharedKey) != nil {
+		return nil
+	}
+
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Errorf("read random bytes: %w", err)
+	}
+
+	vault.SetSecret(files.SecretEntry{
+		Name:   files.SecretOpenFgaPresharedKey,
+		Fields: &files.SecretFields{Password: hex.EncodeToString(b)},
+	})
+
 	return nil
 }
 

--- a/internal/installer/secrets/secrets_test.go
+++ b/internal/installer/secrets/secrets_test.go
@@ -125,6 +125,28 @@ var _ = Describe("EnsureMounterHmacSecret", func() {
 	})
 })
 
+var _ = Describe("EnsureOpenFgaPresharedKey", func() {
+	It("creates a 64-character hex secret", func() {
+		vault := newVault()
+		Expect(secrets.EnsureOpenFgaPresharedKey(vault)).To(Succeed())
+
+		secret := vault.GetSecret("openFgaPresharedKey")
+		Expect(secret).NotTo(BeNil())
+		Expect(secret.Fields).NotTo(BeNil())
+		Expect(secret.Fields.Password).To(HaveLen(64))
+		Expect(secret.Fields.Password).To(MatchRegexp("^[0-9a-f]+$"))
+	})
+
+	It("is idempotent", func() {
+		vault := newVault()
+		Expect(secrets.EnsureOpenFgaPresharedKey(vault)).To(Succeed())
+		original := vault.GetSecret("openFgaPresharedKey").Fields.Password
+
+		Expect(secrets.EnsureOpenFgaPresharedKey(vault)).To(Succeed())
+		Expect(vault.GetSecret("openFgaPresharedKey").Fields.Password).To(Equal(original))
+	})
+})
+
 var _ = Describe("EnsureNixSigningKeys", func() {
 	It("creates priv/pub keys in host:hexKey format", func() {
 		vault := newVault()


### PR DESCRIPTION
OpenFGA and the Codesphere services authenticate with a shared static key. It cannot be a per-pod credential such as a projected ServiceAccount token: one OpenFGA instance serves the whole installation, so in a multi-data-center setup the services reach it across cluster boundaries.

EnsureSecrets therefore generates `openFgaPresharedKey` for a fresh installation. Nothing consumes it yet — the charts read it from the vault once authentication is switched on, and every data center's vault has to carry the same value.