### PR TITLE
feat(cli): add oms copy package command for transferring images between registries

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -358,6 +358,18 @@ License: MIT
 License URL: https://github.com/dlclark/regexp2/blob/v1.12.0/LICENSE
  
 ----------
+Module: github.com/docker/cli/cli/config
+Version: v29.6.2
+License: Apache-2.0
+License URL: https://github.com/docker/cli/blob/v29.6.2/LICENSE
+ 
+----------
+Module: github.com/docker/docker-credential-helpers
+Version: v0.9.8
+License: MIT
+License URL: https://github.com/docker/docker-credential-helpers/blob/v0.9.8/LICENSE
+ 
+----------
 Module: github.com/dylibso/observe-sdk/go
 Version: v0.0.0-20240828172851-9145d8ad07e1
 License: Apache-2.0
@@ -652,6 +664,12 @@ License: BSD-3-Clause
 License URL: https://github.com/google/go-cmp/blob/v0.7.0/LICENSE
  
 ----------
+Module: github.com/google/go-containerregistry
+Version: v0.21.7
+License: Apache-2.0
+License URL: https://github.com/google/go-containerregistry/blob/v0.21.7/LICENSE
+ 
+----------
 Module: github.com/google/go-github/v69/github
 Version: v69.2.0
 License: BSD-3-Clause
@@ -868,28 +886,40 @@ License: MIT
 License URL: https://github.com/kevinburke/ssh_config/blob/v1.6.0/LICENSE
  
 ----------
-Module: github.com/klauspost/compress/internal
+Module: github.com/klauspost/compress
 Version: v1.19.1
 License: MIT
 License URL: https://github.com/klauspost/compress/blob/v1.19.1/LICENSE
  
 ----------
-Module: github.com/klauspost/compress/internal
+Module: github.com/klauspost/compress
 Version: v1.19.1
 License: Apache-2.0
 License URL: https://github.com/klauspost/compress/blob/v1.19.1/LICENSE
  
 ----------
-Module: github.com/klauspost/compress/internal
+Module: github.com/klauspost/compress
 Version: v1.19.1
 License: BSD-3-Clause
 License URL: https://github.com/klauspost/compress/blob/v1.19.1/LICENSE
+ 
+----------
+Module: github.com/klauspost/compress/internal/snapref
+Version: v1.19.1
+License: BSD-3-Clause
+License URL: https://github.com/klauspost/compress/blob/v1.19.1/internal/snapref/LICENSE
  
 ----------
 Module: github.com/klauspost/compress/s2
 Version: v1.19.1
 License: BSD-3-Clause
 License URL: https://github.com/klauspost/compress/blob/v1.19.1/s2/LICENSE
+ 
+----------
+Module: github.com/klauspost/compress/zstd/internal/xxhash
+Version: v1.19.1
+License: MIT
+License URL: https://github.com/klauspost/compress/blob/v1.19.1/zstd/internal/xxhash/LICENSE.txt
  
 ----------
 Module: github.com/klauspost/cpuid/v2

--- a/cli/cmd/copy.go
+++ b/cli/cmd/copy.go
@@ -1,0 +1,27 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	csio "github.com/codesphere-cloud/cs-go/pkg/io"
+	"github.com/codesphere-cloud/oms/cli/cmd/util"
+	"github.com/spf13/cobra"
+)
+
+// CopyCmd represents the copy command.
+type CopyCmd struct {
+	cmd *cobra.Command
+}
+
+// AddCopyCmd adds the copy command group to the root command.
+func AddCopyCmd(rootCmd *cobra.Command, opts *util.GlobalOptions) {
+	copyCmd := CopyCmd{cmd: &cobra.Command{
+		Use:   "copy",
+		Short: "Copy resources between locations",
+		Long: csio.Long(`Copy resources managed by OMS between locations,
+			e.g. package container images and OCI Helm charts between registries.`),
+	}}
+	util.AddCmd(rootCmd, copyCmd.cmd)
+	AddCopyPackageCmd(copyCmd.cmd, opts)
+}

--- a/cli/cmd/copy_package.go
+++ b/cli/cmd/copy_package.go
@@ -1,0 +1,199 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	csio "github.com/codesphere-cloud/cs-go/pkg/io"
+	"github.com/codesphere-cloud/oms/cli/cmd/util"
+	"github.com/codesphere-cloud/oms/internal/env"
+	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/portal"
+	"github.com/codesphere-cloud/oms/internal/prompt"
+	intutil "github.com/codesphere-cloud/oms/internal/util"
+	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/spf13/cobra"
+)
+
+const defaultInstallerPackageArtifact = "installer-lite.tar.gz"
+
+// CopyPackageCmd represents the copy package command.
+type CopyPackageCmd struct {
+	cmd        *cobra.Command
+	Opts       CopyPackageOpts
+	Env        env.Env
+	FileWriter intutil.FileIO
+	Prompter   prompt.Prompter
+}
+
+// CopyPackageOpts holds the flags accepted by the copy package command.
+type CopyPackageOpts struct {
+	*util.GlobalOptions
+	Package       string
+	Version       string
+	Hash          string
+	Filename      string
+	Dest          string
+	Yes           bool
+	Force         bool
+	Insecure      bool
+	Verbose       bool
+	ShowArtifacts bool
+}
+
+// RunE resolves the installer package and executes its artifact transfers.
+func (c *CopyPackageCmd) RunE(cmd *cobra.Command, _ []string) error {
+	packagePath, err := c.resolvePackage(portal.NewPortalClient())
+	if err != nil {
+		return err
+	}
+
+	packageManager := installer.NewPackage(c.Env.GetOmsWorkdir(), packagePath)
+
+	if c.Opts.Verbose {
+		logs.Debug.SetOutput(os.Stderr)
+	}
+
+	return c.CopyPackage(cmd.Context(), packageManager, &installer.CraneArtifactCopier{
+		Insecure: c.Opts.Insecure,
+	})
+}
+
+// AddCopyPackageCmd adds the package subcommand to the copy command.
+func AddCopyPackageCmd(parent *cobra.Command, opts *util.GlobalOptions) {
+	c := &CopyPackageCmd{
+		cmd: &cobra.Command{
+			Use:   "package",
+			Short: "Copy all images and Helm charts from an installer package",
+			Long: csio.Long(`Read all container images and OCI Helm charts from an installer package BOM
+				and copy them to another registry.
+
+				Use --package for a local installer package or --version to download one
+				from the OMS portal. The source repository paths are preserved below --dest.`),
+			Args: cobra.NoArgs,
+			Example: util.FormatExamples("copy package", []csio.Example{
+				{Cmd: "--package codesphere-v1.70.0-installer-lite.tar.gz --dest registry.example.com/mirror", Desc: "Copy artifacts from a local package"},
+				{Cmd: "--version codesphere-v1.70.0 --dest registry.example.com/mirror --yes", Desc: "Download an upstream package and copy without prompting"},
+			}),
+		},
+		Opts:       CopyPackageOpts{GlobalOptions: opts, Filename: defaultInstallerPackageArtifact},
+		Env:        env.NewEnv(),
+		FileWriter: intutil.NewFilesystemWriter(),
+		Prompter:   prompt.NewPrompter(true),
+	}
+	c.cmd.PreRunE = func(_ *cobra.Command, _ []string) error {
+		if (c.Opts.Package == "") == (c.Opts.Version == "") {
+			return fmt.Errorf("exactly one of --package or --version must be specified")
+		}
+
+		return nil
+	}
+
+	flags := c.cmd.Flags()
+	flags.StringVarP(&c.Opts.Package, "package", "p", "", "Path to a local installer package")
+	flags.StringVarP(&c.Opts.Version, "version", "V", "", "Codesphere package version to download from the OMS portal")
+	flags.StringVarP(&c.Opts.Hash, "hash", "H", "", "Build hash used to disambiguate an upstream package version")
+	flags.StringVarP(&c.Opts.Filename, "file", "f", defaultInstallerPackageArtifact, "Installer artifact to download for an upstream package")
+	flags.StringVar(&c.Opts.Dest, "dest", "", "Destination registry or repository prefix")
+	flags.BoolVar(&c.Opts.Insecure, "insecure", false, "Allow image references to be fetched without TLS")
+	flags.BoolVarP(&c.Opts.Yes, "yes", "y", false, "Copy without prompting for confirmation")
+	flags.BoolVarP(&c.Opts.Verbose, "verbose", "v", false, "Enable debug logs")
+	flags.BoolVar(&c.Opts.Force, "force", false, "Re-extract the installer package")
+	flags.BoolVar(&c.Opts.ShowArtifacts, "show-artifacts", false, "Print the source and destination of every artifact to copy")
+	util.MarkFlagRequired(c.cmd, "dest")
+
+	util.AddCmd(parent, c.cmd)
+	c.cmd.RunE = c.RunE
+}
+
+// CopyPackage extracts the package, prints the complete transfer plan, asks
+// for confirmation, and then copies each artifact.
+func (c *CopyPackageCmd) CopyPackage(ctx context.Context, packageManager installer.PackageManager, copier installer.ArtifactCopier) error {
+	if err := packageManager.Extract(c.Opts.Force); err != nil {
+		return fmt.Errorf("failed to extract package: %w", err)
+	}
+
+	artifacts, err := installer.ReadPackageArtifacts(packageManager.GetDependencyPath("bom.json"), c.Opts.Dest)
+	if err != nil {
+		return fmt.Errorf("failed to read package BOM: %w", err)
+	}
+
+	if len(artifacts) == 0 {
+		return fmt.Errorf("package BOM contains no container images or OCI Helm charts")
+	}
+
+	if c.Opts.ShowArtifacts {
+		log.Printf("Artifacts to copy (%d):", len(artifacts))
+		for _, artifact := range artifacts {
+			log.Printf("  %s -> %s", artifact.Source, artifact.Destination)
+		}
+	} else {
+		log.Printf("Artifacts to copy: %d", len(artifacts))
+	}
+
+	if !c.Opts.Yes && !c.Prompter.Bool("Copy these artifacts?", false) {
+		return fmt.Errorf("transfer cancelled")
+	}
+
+	log.Printf("Copying %d package artifacts...", len(artifacts))
+	if err := installer.CopyPackageArtifacts(ctx, copier, artifacts); err != nil {
+		return fmt.Errorf("failed to copy package artifacts: %w", err)
+	}
+
+	log.Printf("Successfully copied %d package artifacts to %s", len(artifacts), c.Opts.Dest)
+
+	return nil
+}
+
+func (c *CopyPackageCmd) resolvePackage(portalClient portal.Portal) (string, error) {
+	if c.Opts.Package != "" {
+		return c.Opts.Package, nil
+	}
+
+	workdir := c.Env.GetOmsWorkdir()
+	if err := os.MkdirAll(workdir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create OMS workdir: %w", err)
+	}
+
+	build, err := portalClient.GetBuild(portal.CodesphereProduct, c.Opts.Version, c.Opts.Hash)
+	if err != nil {
+		return "", fmt.Errorf("failed to get upstream package: %w", err)
+	}
+
+	download, err := build.GetBuildForDownload(c.Opts.Filename)
+	if err != nil {
+		return "", fmt.Errorf("failed to find artifact in upstream package: %w", err)
+	}
+
+	destination := filepath.Join(workdir, build.BuildPackageFilename(c.Opts.Filename))
+
+	out, err := c.FileWriter.Create(destination)
+	if err != nil {
+		return "", fmt.Errorf("failed to create package file %s: %w", destination, err)
+	}
+
+	if err := portalClient.DownloadBuildArtifact(portal.CodesphereProduct, download, out, 0, false); err != nil {
+		intutil.CloseFileIgnoreError(out)
+		return "", fmt.Errorf("failed to download upstream package: %w", err)
+	}
+
+	intutil.CloseFileIgnoreError(out)
+
+	verifyFile, err := c.FileWriter.Open(destination)
+	if err != nil {
+		return "", fmt.Errorf("failed to open downloaded package for verification: %w", err)
+	}
+	defer intutil.CloseFileIgnoreError(verifyFile)
+
+	if err := portalClient.VerifyBuildArtifactDownload(verifyFile, download); err != nil {
+		return "", fmt.Errorf("failed to verify upstream package: %w", err)
+	}
+
+	return destination, nil
+}

--- a/cli/cmd/copy_package.go
+++ b/cli/cmd/copy_package.go
@@ -166,33 +166,10 @@ func (c *CopyPackageCmd) resolvePackage(portalClient portal.Portal) (string, err
 		return "", fmt.Errorf("failed to get upstream package: %w", err)
 	}
 
-	download, err := build.GetBuildForDownload(c.Opts.Filename)
-	if err != nil {
-		return "", fmt.Errorf("failed to find artifact in upstream package: %w", err)
-	}
-
 	destination := filepath.Join(workdir, build.BuildPackageFilename(c.Opts.Filename))
 
-	out, err := c.FileWriter.Create(destination)
-	if err != nil {
-		return "", fmt.Errorf("failed to create package file %s: %w", destination, err)
-	}
-
-	if err := portalClient.DownloadBuildArtifact(portal.CodesphereProduct, download, out, 0, false); err != nil {
-		intutil.CloseFileIgnoreError(out)
+	if err := portal.DownloadAndVerifyBuild(portalClient, c.FileWriter, portal.CodesphereProduct, build, c.Opts.Filename, destination, portal.DownloadOptions{}); err != nil {
 		return "", fmt.Errorf("failed to download upstream package: %w", err)
-	}
-
-	intutil.CloseFileIgnoreError(out)
-
-	verifyFile, err := c.FileWriter.Open(destination)
-	if err != nil {
-		return "", fmt.Errorf("failed to open downloaded package for verification: %w", err)
-	}
-	defer intutil.CloseFileIgnoreError(verifyFile)
-
-	if err := portalClient.VerifyBuildArtifactDownload(verifyFile, download); err != nil {
-		return "", fmt.Errorf("failed to verify upstream package: %w", err)
 	}
 
 	return destination, nil

--- a/cli/cmd/copy_package_test.go
+++ b/cli/cmd/copy_package_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/prompt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type commandRecordingCopier struct {
+	copies []installer.PackageArtifact
+}
+
+func (c *commandRecordingCopier) Copy(_ context.Context, source, destination string) error {
+	c.copies = append(c.copies, installer.PackageArtifact{Source: source, Destination: destination})
+	return nil
+}
+
+var _ = Describe("CopyPackageCmd", func() {
+	var (
+		packageManager *installer.MockPackageManager
+		bomPath        string
+	)
+
+	BeforeEach(func() {
+		packageManager = installer.NewMockPackageManager(GinkgoT())
+		bomPath = filepath.Join(GinkgoT().TempDir(), "bom.json")
+		Expect(os.WriteFile(bomPath, []byte(`{
+			"components": {"codesphere": {"containerImages": {"api": "ghcr.io/codesphere/api:v1"}}}
+		}`), 0644)).To(Succeed())
+	})
+
+	preparePackageManager := func() {
+		packageManager.EXPECT().Extract(false).Return(nil)
+		packageManager.EXPECT().GetDependencyPath("bom.json").Return(bomPath)
+	}
+
+	It("asks for confirmation before copying", func() {
+		preparePackageManager()
+
+		prompter := prompt.NewMockPrompter(GinkgoT())
+		prompter.EXPECT().Bool("Copy these artifacts?", false).Return(true)
+
+		copier := &commandRecordingCopier{}
+		command := &CopyPackageCmd{
+			Opts:     CopyPackageOpts{Dest: "registry.example.com/mirror"},
+			Prompter: prompter,
+		}
+
+		Expect(command.CopyPackage(context.Background(), packageManager, copier)).To(Succeed())
+		Expect(copier.copies).To(Equal([]installer.PackageArtifact{{
+			Source:      "ghcr.io/codesphere/api:v1",
+			Destination: "registry.example.com/mirror/codesphere/api:v1",
+		}}))
+	})
+
+	It("cancels without copying when confirmation is declined", func() {
+		preparePackageManager()
+
+		prompter := prompt.NewMockPrompter(GinkgoT())
+		prompter.EXPECT().Bool("Copy these artifacts?", false).Return(false)
+
+		copier := &commandRecordingCopier{}
+		command := &CopyPackageCmd{
+			Opts:     CopyPackageOpts{Dest: "registry.example.com/mirror"},
+			Prompter: prompter,
+		}
+
+		err := command.CopyPackage(context.Background(), packageManager, copier)
+		Expect(err).To(MatchError("transfer cancelled"))
+		Expect(copier.copies).To(BeEmpty())
+	})
+
+	It("skips confirmation with --yes", func() {
+		preparePackageManager()
+
+		copier := &commandRecordingCopier{}
+		command := &CopyPackageCmd{
+			Opts:     CopyPackageOpts{Dest: "registry.example.com/mirror", Yes: true},
+			Prompter: prompt.NewMockPrompter(GinkgoT()),
+		}
+
+		Expect(command.CopyPackage(context.Background(), packageManager, copier)).To(Succeed())
+		Expect(copier.copies).To(HaveLen(1))
+	})
+
+	It("registers the command and validates package source flags", func() {
+		root := GetRootCmd()
+		copyPackage, _, err := root.Find([]string{"copy", "package"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(copyPackage).NotTo(BeNil())
+		Expect(copyPackage.Flags().Lookup("dest")).NotTo(BeNil())
+		Expect(copyPackage.Flags().Lookup("yes")).NotTo(BeNil())
+
+		root.SetArgs([]string{"copy", "package", "--dest", "registry.example.com", "--yes"})
+		Expect(root.Execute()).To(MatchError("exactly one of --package or --version must be specified"))
+	})
+})

--- a/cli/cmd/copy_package_test.go
+++ b/cli/cmd/copy_package_test.go
@@ -5,13 +5,18 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/codesphere-cloud/oms/internal/env"
 	"github.com/codesphere-cloud/oms/internal/installer"
+	"github.com/codesphere-cloud/oms/internal/portal"
 	"github.com/codesphere-cloud/oms/internal/prompt"
+	intutil "github.com/codesphere-cloud/oms/internal/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
 )
 
 type commandRecordingCopier struct {
@@ -101,5 +106,59 @@ var _ = Describe("CopyPackageCmd", func() {
 
 		root.SetArgs([]string{"copy", "package", "--dest", "registry.example.com", "--yes"})
 		Expect(root.Execute()).To(MatchError("exactly one of --package or --version must be specified"))
+	})
+
+	Describe("resolvePackage with --version", func() {
+		var (
+			mockEnv        *env.MockEnv
+			mockPortal     *portal.MockPortal
+			mockFileWriter *intutil.MockFileIO
+			workdir        string
+			build          portal.Build
+			command        *CopyPackageCmd
+		)
+
+		BeforeEach(func() {
+			workdir = GinkgoT().TempDir()
+			mockEnv = env.NewMockEnv(GinkgoT())
+			mockEnv.EXPECT().GetOmsWorkdir().Return(workdir)
+
+			mockPortal = portal.NewMockPortal(GinkgoT())
+			mockFileWriter = intutil.NewMockFileIO(GinkgoT())
+
+			build = portal.Build{
+				Version:   "codesphere-v1.70.0",
+				Hash:      "abc1234567",
+				Artifacts: []portal.Artifact{{Filename: defaultInstallerPackageArtifact}},
+			}
+
+			command = &CopyPackageCmd{
+				Opts:       CopyPackageOpts{Version: build.Version, Filename: defaultInstallerPackageArtifact},
+				Env:        mockEnv,
+				FileWriter: mockFileWriter,
+			}
+		})
+
+		It("downloads and verifies the upstream package", func() {
+			mockPortal.EXPECT().GetBuild(portal.CodesphereProduct, build.Version, "").Return(build, nil)
+
+			destination := filepath.Join(workdir, build.BuildPackageFilename(defaultInstallerPackageArtifact))
+			fakeFile := os.NewFile(uintptr(0), destination)
+			mockFileWriter.EXPECT().Create(destination).Return(fakeFile, nil)
+			mockFileWriter.EXPECT().Open(destination).Return(fakeFile, nil)
+			mockPortal.EXPECT().DownloadBuildArtifact(portal.CodesphereProduct, mock.Anything, mock.Anything, 0, false).Return(nil)
+			mockPortal.EXPECT().VerifyBuildArtifactDownload(mock.Anything, mock.Anything).Return(nil)
+
+			path, err := command.resolvePackage(mockPortal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(path).To(Equal(destination))
+		})
+
+		It("returns an error when the upstream package cannot be found", func() {
+			mockPortal.EXPECT().GetBuild(portal.CodesphereProduct, build.Version, "").Return(portal.Build{}, fmt.Errorf("build not found"))
+
+			_, err := command.resolvePackage(mockPortal)
+			Expect(err).To(MatchError(ContainSubstring("failed to get upstream package")))
+		})
 	})
 })

--- a/cli/cmd/download_package.go
+++ b/cli/cmd/download_package.go
@@ -98,8 +98,11 @@ func AddDownloadPackageCmd(download *cobra.Command, opts *util.GlobalOptions) {
 func (c *DownloadPackageCmd) DownloadBuild(p portal.Portal, build portal.Build, filename string) error {
 	fullFilename := build.BuildPackageFilename(filename)
 
-	return portal.DownloadAndVerifyBuild(p, c.FileWriter, portal.CodesphereProduct, build, filename, fullFilename, portal.DownloadOptions{
+	if err := portal.DownloadAndVerifyBuild(p, c.FileWriter, portal.CodesphereProduct, build, filename, fullFilename, portal.DownloadOptions{
 		Resume: true,
 		Quiet:  c.Opts.Quiet,
-	})
+	}); err != nil {
+		return fmt.Errorf("failed to download and verify build: %w", err)
+	}
+	return nil
 }

--- a/cli/cmd/download_package.go
+++ b/cli/cmd/download_package.go
@@ -96,43 +96,10 @@ func AddDownloadPackageCmd(download *cobra.Command, opts *util.GlobalOptions) {
 }
 
 func (c *DownloadPackageCmd) DownloadBuild(p portal.Portal, build portal.Build, filename string) error {
-	download, err := build.GetBuildForDownload(filename)
-	if err != nil {
-		return fmt.Errorf("failed to find artifact in package: %w", err)
-	}
-
 	fullFilename := build.BuildPackageFilename(filename)
-	out, err := c.FileWriter.OpenAppend(fullFilename)
-	if err != nil {
-		out, err = c.FileWriter.Create(fullFilename)
-		if err != nil {
-			return fmt.Errorf("failed to create file %s: %w", fullFilename, err)
-		}
-	}
-	defer intutil.CloseFileIgnoreError(out)
 
-	// get already downloaded file size of fullFilename
-	fileSize := 0
-	fileInfo, err := out.Stat()
-	if err == nil {
-		fileSize = int(fileInfo.Size())
-	}
-
-	err = p.DownloadBuildArtifact("codesphere", download, out, fileSize, c.Opts.Quiet)
-	if err != nil {
-		return fmt.Errorf("failed to download build: %w", err)
-	}
-
-	verifyFile, err := c.FileWriter.Open(fullFilename)
-	if err != nil {
-		return err
-	}
-	defer intutil.CloseFileIgnoreError(verifyFile)
-
-	err = p.VerifyBuildArtifactDownload(verifyFile, download)
-	if err != nil {
-		return fmt.Errorf("failed to verify artifact: %w", err)
-	}
-
-	return nil
+	return portal.DownloadAndVerifyBuild(p, c.FileWriter, portal.CodesphereProduct, build, filename, fullFilename, portal.DownloadOptions{
+		Resume: true,
+		Quiet:  c.Opts.Quiet,
+	})
 }

--- a/cli/cmd/download_package_test.go
+++ b/cli/cmd/download_package_test.go
@@ -242,7 +242,7 @@ var _ = Describe("DownloadPackages", func() {
 	Context("File doesn't exist in build", func() {
 		It("Returns an error", func() {
 			err := c.DownloadBuild(mockPortal, build, "installer-lite.tar.gz")
-			Expect(err).To(MatchError("failed to find artifact in package: artifact not found: installer-lite.tar.gz"))
+			Expect(err).To(MatchError("failed to download and verify build: failed to find artifact in package: artifact not found: installer-lite.tar.gz"))
 		})
 	})
 })

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -61,6 +61,7 @@ func GetRootCmd() *cobra.Command {
 	// Package commands
 	AddListCmd(rootCmd, opts)
 	AddDownloadCmd(rootCmd, opts)
+	AddCopyCmd(rootCmd, opts)
 	AddInstallCmd(rootCmd, opts)
 	AddInitCmd(rootCmd, opts)
 	AddTemplateCmd(rootCmd, opts)

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,3 +33,4 @@ like downloading new versions.
 * [oms template](oms_template.md)	 - Render OMS configuration templates
 * [oms update](oms_update.md)	 - Update OMS related resources
 * [oms version](oms_version.md)	 - Print version
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ like downloading new versions.
 * [oms add-cluster-admin](oms_add-cluster-admin.md)	 - Set the cluster admin email in a Kubernetes secret
 * [oms beta](oms_beta.md)	 - Commands for early testing
 * [oms build](oms_build.md)	 - Build and push images to a registry
+* [oms copy](oms_copy.md)	 - Copy resources between locations
 * [oms create](oms_create.md)	 - Create resources for Codesphere
 * [oms download](oms_download.md)	 - Download resources available through OMS
 * [oms init](oms_init.md)	 - Initialize configuration files
@@ -32,4 +33,3 @@ like downloading new versions.
 * [oms template](oms_template.md)	 - Render OMS configuration templates
 * [oms update](oms_update.md)	 - Update OMS related resources
 * [oms version](oms_version.md)	 - Print version
-

--- a/docs/oms.md
+++ b/docs/oms.md
@@ -20,6 +20,7 @@ like downloading new versions.
 * [oms add-cluster-admin](oms_add-cluster-admin.md)	 - Set the cluster admin email in a Kubernetes secret
 * [oms beta](oms_beta.md)	 - Commands for early testing
 * [oms build](oms_build.md)	 - Build and push images to a registry
+* [oms copy](oms_copy.md)	 - Copy resources between locations
 * [oms create](oms_create.md)	 - Create resources for Codesphere
 * [oms download](oms_download.md)	 - Download resources available through OMS
 * [oms init](oms_init.md)	 - Initialize configuration files

--- a/docs/oms_copy.md
+++ b/docs/oms_copy.md
@@ -1,0 +1,20 @@
+## oms copy
+
+Copy resources between locations
+
+### Synopsis
+
+Copy resources managed by OMS between locations,
+e.g. package container images and OCI Helm charts between registries.
+
+### Options
+
+```
+  -h, --help   help for copy
+```
+
+### SEE ALSO
+
+* [oms](oms.md)	 - Codesphere Operations Management System (OMS)
+* [oms copy package](oms_copy_package.md)	 - Copy all images and Helm charts from an installer package
+

--- a/docs/oms_copy_package.md
+++ b/docs/oms_copy_package.md
@@ -5,7 +5,7 @@ Copy all images and Helm charts from an installer package
 ### Synopsis
 
 Read all container images and OCI Helm charts from an installer package BOM
-and copy them to another registry using crane.
+and copy them to another registry.
 
 Use --package for a local installer package or --version to download one
 from the OMS portal. The source repository paths are preserved below --dest.

--- a/docs/oms_copy_package.md
+++ b/docs/oms_copy_package.md
@@ -1,0 +1,47 @@
+## oms copy package
+
+Copy all images and Helm charts from an installer package
+
+### Synopsis
+
+Read all container images and OCI Helm charts from an installer package BOM
+and copy them to another registry using crane.
+
+Use --package for a local installer package or --version to download one
+from the OMS portal. The source repository paths are preserved below --dest.
+
+```
+oms copy package [flags]
+```
+
+### Examples
+
+```
+# Copy artifacts from a local package
+$ oms copy package --package codesphere-v1.70.0-installer-lite.tar.gz --dest registry.example.com/mirror
+
+# Download an upstream package and copy without prompting
+$ oms copy package --version codesphere-v1.70.0 --dest registry.example.com/mirror --yes
+
+```
+
+### Options
+
+```
+      --dest string      Destination registry or repository prefix
+  -f, --file string      Installer artifact to download for an upstream package (default "installer-lite.tar.gz")
+      --force            Re-extract the installer package
+  -H, --hash string      Build hash used to disambiguate an upstream package version
+  -h, --help             help for package
+      --insecure         Allow image references to be fetched without TLS
+  -p, --package string   Path to a local installer package
+      --show-artifacts   Print the source and destination of every artifact to copy
+  -v, --verbose          Enable debug logs
+  -V, --version string   Codesphere package version to download from the OMS portal
+  -y, --yes              Copy without prompting for confirmation
+```
+
+### SEE ALSO
+
+* [oms copy](oms_copy.md)	 - Copy resources between locations
+

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/getsops/sops/v3 v3.13.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/go-containerregistry v0.21.7
 	github.com/google/go-github/v74 v74.0.0
 	github.com/jedib0t/go-pretty/v6 v6.8.3
 	github.com/lib/pq v1.12.3
@@ -46,6 +47,9 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
 	github.com/pkg/sftp v1.13.11
+	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/common v0.70.1
+	github.com/prometheus/prometheus v0.51.0
 	github.com/rook/rook/pkg/apis v0.0.0-20260820225410-c01991a14138
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.12.1
@@ -57,6 +61,7 @@ require (
 	google.golang.org/api v0.293.0
 	google.golang.org/grpc v1.83.1
 	google.golang.org/protobuf v1.36.12
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v4 v4.2.4
 	k8s.io/api v0.36.4
@@ -342,7 +347,6 @@ require (
 	github.com/google/certificate-transparency-go v1.3.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/go-containerregistry v0.21.7 // indirect
 	github.com/google/go-github/v69 v69.2.0 // indirect
 	github.com/google/go-github/v86 v86.0.0 // indirect
 	github.com/google/go-github/v88 v88.0.0 // indirect
@@ -372,6 +376,7 @@ require (
 	github.com/gostaticanalysis/forcetypeassert v0.2.0 // indirect
 	github.com/gostaticanalysis/nilerr v0.1.2 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
+	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -414,6 +419,7 @@ require (
 	github.com/jjti/go-spancheck v0.6.5 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.13-0.20220915233716-71ac16282d12 // indirect
 	github.com/julz/importas v0.2.0 // indirect
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7 // indirect
@@ -490,6 +496,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-varint v0.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/nakabonne/nestif v0.3.1 // indirect
 	github.com/nishanths/exhaustive v0.12.0 // indirect
 	github.com/nishanths/predeclared v0.2.2 // indirect
@@ -513,9 +520,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/polydawn/refmt v0.90.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.92.0 // indirect
-	github.com/prometheus/client_golang v1.24.1 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/quasilyte/go-ruleguard v0.4.5 // indirect
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23 // indirect
@@ -651,7 +656,6 @@ require (
 	gopkg.in/mail.v2 v2.3.1 // indirect
 	gopkg.in/validator.v2 v2.0.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	honnef.co/go/tools v0.8.0 // indirect
 	k8s.io/apiextensions-apiserver v0.36.2 // indirect
 	k8s.io/apiserver v0.36.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3504,6 +3504,7 @@ github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-latex/latex v0.0.0-20210118124228-b3d85cf34e07/go.mod h1:CO1AlKB2CSIqUrmQPqA0gdRIlnLEY0gK5JGjh37zN5U=
 github.com/go-latex/latex v0.0.0-20210823091927-c0d11ff05a81/go.mod h1:SX0U8uGpxhq9o2S/CELCSUxEWWAuoCUcVCQWv7G2OCk=
@@ -3513,6 +3514,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
+github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
@@ -3974,6 +3977,8 @@ github.com/gostaticanalysis/testutil v0.5.0 h1:Dq4wT1DdTwTGCQQv3rl3IvD5Ld0E6HiY+
 github.com/gostaticanalysis/testutil v0.5.0/go.mod h1:OLQSbuM6zw2EvCcXTz1lVq5unyoNft372msDY0nY5Hs=
 github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
+github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd h1:PpuIBO5P3e9hpqBD0O/HjhShYuM6XE0i/lbE6J94kww=
+github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/graph-gophers/graphql-go v1.9.0 h1:yu0ucKHLc5qGpRwLYKIWtr9bOoxovkWasuBrPQwlHls=
 github.com/graph-gophers/graphql-go v1.9.0/go.mod h1:23olKZ7duEvHlF/2ELEoSZaY1aNPfShjP782SOoNTyM=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -4158,6 +4163,7 @@ github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7X
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -4443,6 +4449,7 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nakabonne/nestif v0.3.1 h1:wm28nZjhQY5HyYPx+weN3Q65k6ilSBxDb8v5S81B81U=
@@ -4672,6 +4679,8 @@ github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlT
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
+github.com/prometheus/prometheus v0.51.0 h1:aRdjTnmHLved29ILtdzZN2GNvOjWATtA/z+3fYuexOc=
+github.com/prometheus/prometheus v0.51.0/go.mod h1:yv4MwOn3yHMQ6MZGHPg/U7Fcyqf+rxqiZfSur6myVtc=
 github.com/quasilyte/go-ruleguard v0.4.5 h1:AGY0tiOT5hJX9BTdx/xBdoCubQUAE2grkqY2lSwvZcA=
 github.com/quasilyte/go-ruleguard v0.4.5/go.mod h1:Vl05zJ538vcEEwu16V/Hdu7IYZWyKSwIy4c88Ro1kRE=
 github.com/quasilyte/go-ruleguard/dsl v0.3.23 h1:lxjt5B6ZCiBeeNO8/oQsegE6fLeCzuMRoVWSkXC4uvY=

--- a/internal/bootstrap/bootstrap_stepper.go
+++ b/internal/bootstrap/bootstrap_stepper.go
@@ -38,7 +38,7 @@ func (b *StepLogger) Step(name string, fn func() error) error {
 	b.subSteps = 0
 	b.currentStep = name
 
-	fmt.Printf("%s%s%s...", LINE_RESET, RESET_TEXT, name)
+	fmt.Printf("%s%s%s...\n", LINE_RESET, RESET_TEXT, name)
 	err := fn()
 	if err != nil {
 		fmt.Printf("%s%s%s failed: %v%s\n", LINE_RESET, RED_TEXT, name, err, RESET_TEXT)
@@ -59,7 +59,7 @@ func (b *StepLogger) Substep(name string, fn func() error) error {
 	b.subSteps += 1
 	b.currentStep = name
 
-	fmt.Printf("%s%s   %s...", LINE_RESET, RESET_TEXT, name)
+	fmt.Printf("%s%s   %s...\n", LINE_RESET, RESET_TEXT, name)
 	err := fn()
 	if err != nil {
 		fmt.Printf("%s%s   %s failed: %v%s\n", LINE_RESET, RED_TEXT, name, err, RESET_TEXT)

--- a/internal/bootstrap/bootstrap_stepper.go
+++ b/internal/bootstrap/bootstrap_stepper.go
@@ -38,7 +38,7 @@ func (b *StepLogger) Step(name string, fn func() error) error {
 	b.subSteps = 0
 	b.currentStep = name
 
-	fmt.Printf("%s%s%s...\n", LINE_RESET, RESET_TEXT, name)
+	fmt.Printf("%s%s%s...", LINE_RESET, RESET_TEXT, name)
 	err := fn()
 	if err != nil {
 		fmt.Printf("%s%s%s failed: %v%s\n", LINE_RESET, RED_TEXT, name, err, RESET_TEXT)
@@ -59,7 +59,7 @@ func (b *StepLogger) Substep(name string, fn func() error) error {
 	b.subSteps += 1
 	b.currentStep = name
 
-	fmt.Printf("%s%s   %s...\n", LINE_RESET, RESET_TEXT, name)
+	fmt.Printf("%s%s   %s...", LINE_RESET, RESET_TEXT, name)
 	err := fn()
 	if err != nil {
 		fmt.Printf("%s%s   %s failed: %v%s\n", LINE_RESET, RED_TEXT, name, err, RESET_TEXT)

--- a/internal/installer/bom/bom.go
+++ b/internal/installer/bom/bom.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/distribution/reference"
 )
@@ -15,6 +16,36 @@ import (
 type Config struct {
 	Components map[string]ComponentConfig `json:"components"`
 	Migrations MigrationsConfig           `json:"migrations"`
+}
+
+// GetOCIArtifacts returns every container image and OCI Helm chart referenced
+// by the BOM. Duplicate references are returned only once and the result is
+// sorted so callers can present a stable transfer plan.
+func (b *Config) GetOCIArtifacts() []string {
+	artifacts := map[string]struct{}{}
+
+	for _, component := range b.Components {
+		for _, image := range component.ContainerImages {
+			if image != "" {
+				artifacts[image] = struct{}{}
+			}
+		}
+
+		for _, file := range component.Files {
+			if file.OciRef != "" {
+				artifacts[file.OciRef] = struct{}{}
+			}
+		}
+	}
+
+	result := make([]string, 0, len(artifacts))
+	for artifact := range artifacts {
+		result = append(result, artifact)
+	}
+
+	sort.Strings(result)
+
+	return result
 }
 
 // ComponentConfig represents a component in the BOM.

--- a/internal/installer/bom/bom_test.go
+++ b/internal/installer/bom/bom_test.go
@@ -213,4 +213,34 @@ var _ = Describe("Bom", func() {
 			Expect(images).To(BeEmpty())
 		})
 	})
+
+	Describe("GetOCIArtifacts", func() {
+		It("returns sorted unique container images and OCI Helm charts from all components", func() {
+			cfg := &bom.Config{Components: map[string]bom.ComponentConfig{
+				"codesphere": {
+					ContainerImages: map[string]string{
+						"api": "ghcr.io/codesphere/api:v1",
+					},
+					Files: map[string]bom.FileRef{
+						"chart": {OciRef: "oci://ghcr.io/codesphere/charts/codesphere:v1"},
+					},
+				},
+				"dependency": {
+					ContainerImages: map[string]string{
+						"duplicate": "ghcr.io/codesphere/api:v1",
+						"redis":     "docker.io/library/redis:7",
+					},
+					Files: map[string]bom.FileRef{
+						"not-oci": {SrcUrl: "https://example.com/file.tgz"},
+					},
+				},
+			}}
+
+			Expect(cfg.GetOCIArtifacts()).To(Equal([]string{
+				"docker.io/library/redis:7",
+				"ghcr.io/codesphere/api:v1",
+				"oci://ghcr.io/codesphere/charts/codesphere:v1",
+			}))
+		})
+	})
 })

--- a/internal/installer/package_copy.go
+++ b/internal/installer/package_copy.go
@@ -1,0 +1,140 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package installer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/codesphere-cloud/oms/internal/installer/bom"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+// PackageArtifact describes one image or OCI Helm chart transfer.
+type PackageArtifact struct {
+	Source      string
+	Destination string
+}
+
+// ArtifactCopier copies an image or OCI artifact between registries.
+type ArtifactCopier interface {
+	Copy(ctx context.Context, source, destination string) error
+}
+
+// CraneArtifactCopier uses go-containerregistry's crane package for transfers.
+type CraneArtifactCopier struct {
+	Insecure bool
+}
+
+// Copy transfers one remote image or OCI artifact with crane.
+func (c *CraneArtifactCopier) Copy(ctx context.Context, source, destination string) error {
+	options := []crane.Option{crane.WithContext(ctx), crane.WithNondistributable()}
+	if c.Insecure {
+		options = append(options, crane.Insecure)
+	}
+	if err := crane.Copy(source, destination, options...); err != nil {
+		return fmt.Errorf("crane copy failed: %w", err)
+	}
+
+	return nil
+}
+
+// ReadPackageArtifacts reads all images and OCI Helm charts from a BOM and
+// builds their destination references. The original repository path is kept
+// below dest so repositories with the same basename cannot collide.
+func ReadPackageArtifacts(bomPath, dest string) ([]PackageArtifact, error) {
+	bomConfig, err := bom.Parse(bomPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse BOM: %w", err)
+	}
+
+	references := bomConfig.GetOCIArtifacts()
+
+	artifacts := make([]PackageArtifact, 0, len(references))
+	for _, source := range references {
+		destination, err := PackageArtifactDestination(source, dest)
+		if err != nil {
+			return nil, err
+		}
+
+		artifacts = append(artifacts, PackageArtifact{
+			Source:      strings.TrimPrefix(source, "oci://"),
+			Destination: destination,
+		})
+	}
+
+	return artifacts, nil
+}
+
+// PackageArtifactDestination maps a source reference below a destination
+// registry or repository prefix while preserving its tag or digest.
+func PackageArtifactDestination(source, dest string) (string, error) {
+	source = strings.TrimPrefix(source, "oci://")
+
+	dest = strings.TrimSuffix(strings.TrimPrefix(dest, "oci://"), "/")
+	if dest == "" {
+		return "", fmt.Errorf("destination registry must not be empty")
+	}
+
+	sourceRef, err := name.ParseReference(source)
+	if err != nil {
+		return "", fmt.Errorf("invalid package artifact reference %q: %w", source, err)
+	}
+
+	separator := ":"
+	if _, ok := sourceRef.(name.Digest); ok {
+		separator = "@"
+	}
+
+	candidate := dest + "/" + sourceRef.Context().RepositoryStr() + separator + sourceRef.Identifier()
+
+	destinationRef, err := name.ParseReference(candidate)
+	if err != nil {
+		return "", fmt.Errorf("invalid destination reference %q: %w", candidate, err)
+	}
+
+	return destinationRef.Name(), nil
+}
+
+// CopyPackageArtifacts transfers the prepared package artifacts in order,
+// printing a single updating progress bar. Crane's own log output is
+// captured rather than written to the terminal, so it doesn't clutter the
+// progress bar; it's only surfaced if a copy fails.
+func CopyPackageArtifacts(ctx context.Context, copier ArtifactCopier, artifacts []PackageArtifact) error {
+	total := len(artifacts)
+	start := time.Now()
+
+	var craneOutput bytes.Buffer
+	logs.Warn.SetOutput(&craneOutput)
+	logs.Progress.SetOutput(&craneOutput)
+	defer func() {
+		logs.Warn.SetOutput(io.Discard)
+		logs.Progress.SetOutput(io.Discard)
+	}()
+
+	for i, artifact := range artifacts {
+		craneOutput.Reset()
+		fmt.Printf("\r\033[2K%3d%% (%d/%d) %s %s -> %s", i*100/max(total, 1), i, total, time.Since(start).Round(time.Second), artifact.Source, artifact.Destination)
+
+		if err := copier.Copy(ctx, artifact.Source, artifact.Destination); err != nil {
+			fmt.Println()
+			if craneOutput.Len() > 0 {
+				fmt.Fprint(os.Stderr, craneOutput.String())
+			}
+
+			return fmt.Errorf("failed to copy %s to %s: %w", artifact.Source, artifact.Destination, err)
+		}
+	}
+
+	fmt.Printf("\r\033[2KCopied %d artifacts in %s\n", total, time.Since(start).Round(time.Second))
+
+	return nil
+}

--- a/internal/installer/package_copy_test.go
+++ b/internal/installer/package_copy_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package installer_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/codesphere-cloud/oms/internal/installer"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type recordingArtifactCopier struct {
+	copies []installer.PackageArtifact
+	err    error
+}
+
+func (c *recordingArtifactCopier) Copy(_ context.Context, source, destination string) error {
+	c.copies = append(c.copies, installer.PackageArtifact{Source: source, Destination: destination})
+	return c.err
+}
+
+var _ = Describe("Package artifact copying", func() {
+	Describe("PackageArtifactDestination", func() {
+		It("preserves the source repository path and tag below the destination", func() {
+			destination, err := installer.PackageArtifactDestination(
+				"oci://ghcr.io/codesphere-cloud/charts/pc-apps:1.2.3",
+				"oci://registry.example.com/private-cloud/",
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(destination).To(Equal("registry.example.com/private-cloud/codesphere-cloud/charts/pc-apps:1.2.3"))
+		})
+
+		It("preserves digests", func() {
+			destination, err := installer.PackageArtifactDestination(
+				"ghcr.io/codesphere-cloud/api@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"registry.example.com/mirror",
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(destination).To(Equal("registry.example.com/mirror/codesphere-cloud/api@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+		})
+
+		It("rejects an empty destination", func() {
+			_, err := installer.PackageArtifactDestination("ghcr.io/codesphere/api:v1", "")
+			Expect(err).To(MatchError("destination registry must not be empty"))
+		})
+	})
+
+	Describe("ReadPackageArtifacts", func() {
+		It("reads images and charts and prepares a stable transfer plan", func() {
+			tempDir := GinkgoT().TempDir()
+			bomPath := filepath.Join(tempDir, "bom.json")
+			Expect(os.WriteFile(bomPath, []byte(`{
+				"components": {
+					"codesphere": {
+						"containerImages": {"api": "ghcr.io/codesphere/api:v1"},
+						"files": {"chart": {"ociRef": "oci://ghcr.io/codesphere/charts/app:v1"}}
+					}
+				}
+			}`), 0644)).To(Succeed())
+
+			artifacts, err := installer.ReadPackageArtifacts(bomPath, "registry.example.com/mirror")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(artifacts).To(Equal([]installer.PackageArtifact{
+				{Source: "ghcr.io/codesphere/api:v1", Destination: "registry.example.com/mirror/codesphere/api:v1"},
+				{Source: "ghcr.io/codesphere/charts/app:v1", Destination: "registry.example.com/mirror/codesphere/charts/app:v1"},
+			}))
+		})
+	})
+
+	Describe("CopyPackageArtifacts", func() {
+		It("copies all artifacts in order", func() {
+			copier := &recordingArtifactCopier{}
+			artifacts := []installer.PackageArtifact{
+				{Source: "source/one:v1", Destination: "dest/one:v1"},
+				{Source: "source/two:v2", Destination: "dest/two:v2"},
+			}
+
+			Expect(installer.CopyPackageArtifacts(context.Background(), copier, artifacts)).To(Succeed())
+			Expect(copier.copies).To(Equal(artifacts))
+		})
+
+		It("adds source and destination context to copy failures", func() {
+			copier := &recordingArtifactCopier{err: errors.New("denied")}
+			err := installer.CopyPackageArtifacts(context.Background(), copier, []installer.PackageArtifact{
+				{Source: "source/one:v1", Destination: "dest/one:v1"},
+			})
+
+			Expect(err).To(MatchError("failed to copy source/one:v1 to dest/one:v1: denied"))
+		})
+	})
+})

--- a/internal/portal/download.go
+++ b/internal/portal/download.go
@@ -1,0 +1,69 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package portal
+
+import (
+	"fmt"
+	"os"
+
+	intutil "github.com/codesphere-cloud/oms/internal/util"
+)
+
+// DownloadOptions configures DownloadAndVerifyBuild.
+type DownloadOptions struct {
+	// Resume appends to an existing partial download at destination instead
+	// of always starting over.
+	Resume bool
+	// Quiet suppresses download progress output.
+	Quiet bool
+}
+
+// DownloadAndVerifyBuild downloads the named artifact from build to destination
+// and verifies its checksum. It is shared by the download and copy package
+// commands so their download and verify behavior stays in sync.
+func DownloadAndVerifyBuild(p Portal, fileWriter intutil.FileIO, product Product, build Build, filename, destination string, opts DownloadOptions) error {
+	download, err := build.GetBuildForDownload(filename)
+	if err != nil {
+		return fmt.Errorf("failed to find artifact in package: %w", err)
+	}
+
+	out, err := openDestination(fileWriter, destination, opts.Resume)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", destination, err)
+	}
+	defer intutil.CloseFileIgnoreError(out)
+
+	fileSize := 0
+	if opts.Resume {
+		if fileInfo, statErr := out.Stat(); statErr == nil {
+			fileSize = int(fileInfo.Size())
+		}
+	}
+
+	if err := p.DownloadBuildArtifact(product, download, out, fileSize, opts.Quiet); err != nil {
+		return fmt.Errorf("failed to download build: %w", err)
+	}
+
+	verifyFile, err := fileWriter.Open(destination)
+	if err != nil {
+		return err
+	}
+	defer intutil.CloseFileIgnoreError(verifyFile)
+
+	if err := p.VerifyBuildArtifactDownload(verifyFile, download); err != nil {
+		return fmt.Errorf("failed to verify artifact: %w", err)
+	}
+
+	return nil
+}
+
+func openDestination(fileWriter intutil.FileIO, destination string, resume bool) (*os.File, error) {
+	if resume {
+		if out, err := fileWriter.OpenAppend(destination); err == nil {
+			return out, nil
+		}
+	}
+
+	return fileWriter.Create(destination)
+}

--- a/internal/portal/download.go
+++ b/internal/portal/download.go
@@ -30,7 +30,7 @@ func DownloadAndVerifyBuild(p Portal, fileWriter intutil.FileIO, product Product
 
 	out, err := openDestination(fileWriter, destination, opts.Resume)
 	if err != nil {
-		return fmt.Errorf("failed to create file %s: %w", destination, err)
+		return fmt.Errorf("failed to open pckage destination file: %w", err)
 	}
 	defer intutil.CloseFileIgnoreError(out)
 
@@ -47,7 +47,7 @@ func DownloadAndVerifyBuild(p Portal, fileWriter intutil.FileIO, product Product
 
 	verifyFile, err := fileWriter.Open(destination)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open %q: %w", destination, err)
 	}
 	defer intutil.CloseFileIgnoreError(verifyFile)
 
@@ -65,5 +65,9 @@ func openDestination(fileWriter intutil.FileIO, destination string, resume bool)
 		}
 	}
 
-	return fileWriter.Create(destination)
+	file, err := fileWriter.Create(destination)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file at %q: %w", destination, err)
+	}
+	return file, nil
 }

--- a/internal/tmpl/NOTICE
+++ b/internal/tmpl/NOTICE
@@ -358,6 +358,18 @@ License: MIT
 License URL: https://github.com/dlclark/regexp2/blob/v1.12.0/LICENSE
  
 ----------
+Module: github.com/docker/cli/cli/config
+Version: v29.6.2
+License: Apache-2.0
+License URL: https://github.com/docker/cli/blob/v29.6.2/LICENSE
+ 
+----------
+Module: github.com/docker/docker-credential-helpers
+Version: v0.9.8
+License: MIT
+License URL: https://github.com/docker/docker-credential-helpers/blob/v0.9.8/LICENSE
+ 
+----------
 Module: github.com/dylibso/observe-sdk/go
 Version: v0.0.0-20240828172851-9145d8ad07e1
 License: Apache-2.0
@@ -652,6 +664,12 @@ License: BSD-3-Clause
 License URL: https://github.com/google/go-cmp/blob/v0.7.0/LICENSE
  
 ----------
+Module: github.com/google/go-containerregistry
+Version: v0.21.7
+License: Apache-2.0
+License URL: https://github.com/google/go-containerregistry/blob/v0.21.7/LICENSE
+ 
+----------
 Module: github.com/google/go-github/v69/github
 Version: v69.2.0
 License: BSD-3-Clause
@@ -868,28 +886,40 @@ License: MIT
 License URL: https://github.com/kevinburke/ssh_config/blob/v1.6.0/LICENSE
  
 ----------
-Module: github.com/klauspost/compress/internal
+Module: github.com/klauspost/compress
 Version: v1.19.1
 License: MIT
 License URL: https://github.com/klauspost/compress/blob/v1.19.1/LICENSE
  
 ----------
-Module: github.com/klauspost/compress/internal
+Module: github.com/klauspost/compress
 Version: v1.19.1
 License: Apache-2.0
 License URL: https://github.com/klauspost/compress/blob/v1.19.1/LICENSE
  
 ----------
-Module: github.com/klauspost/compress/internal
+Module: github.com/klauspost/compress
 Version: v1.19.1
 License: BSD-3-Clause
 License URL: https://github.com/klauspost/compress/blob/v1.19.1/LICENSE
+ 
+----------
+Module: github.com/klauspost/compress/internal/snapref
+Version: v1.19.1
+License: BSD-3-Clause
+License URL: https://github.com/klauspost/compress/blob/v1.19.1/internal/snapref/LICENSE
  
 ----------
 Module: github.com/klauspost/compress/s2
 Version: v1.19.1
 License: BSD-3-Clause
 License URL: https://github.com/klauspost/compress/blob/v1.19.1/s2/LICENSE
+ 
+----------
+Module: github.com/klauspost/compress/zstd/internal/xxhash
+Version: v1.19.1
+License: MIT
+License URL: https://github.com/klauspost/compress/blob/v1.19.1/zstd/internal/xxhash/LICENSE.txt
  
 ----------
 Module: github.com/klauspost/cpuid/v2


### PR DESCRIPTION
Introduces a new `oms copy` command group with a `package` subcommand that copies container images and OCI Helm charts referenced in a BOM between registries. Adds supporting package-copy logic in internal/installer, extends the BOM model, and adds a trailing newline to bootstrap step/substep log lines so copy progress output doesn't run together.