### PR TITLE
fix(installer): cap Helm release history at 10 revisions

### DIFF
--- a/internal/installer/helm_client.go
+++ b/internal/installer/helm_client.go
@@ -28,6 +28,12 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+// maxReleaseHistory caps how many revisions Helm keeps per release. The Helm
+// SDK defaults to 0 (unlimited), unlike the CLI which defaults to 10. Every
+// upgrade stores the full chart in a Secret, so an uncapped release grows
+// without bound and eventually makes listing releases too large to transfer.
+const maxReleaseHistory = 10
+
 // ReleaseInfo holds the details of an existing Helm release that the rest of
 // the application cares about — completely decoupled from the Helm SDK types.
 type ReleaseInfo struct {
@@ -333,6 +339,7 @@ func (h *helmClient) UpgradeChart(ctx context.Context, cfg ChartConfig, opts Upg
 	upgradeClient.Version = cfg.Version
 	upgradeClient.RepoURL = cfg.RepoURL
 	upgradeClient.Timeout = 5 * time.Minute
+	upgradeClient.MaxHistory = maxReleaseHistory
 	upgradeClient.ForceConflicts = opts.ForceConflicts
 	upgradeClient.TakeOwnership = opts.TakeOwnership
 


### PR DESCRIPTION
Debug thread: https://codesphere-cloud.slack.com/archives/C09CVP4NTL7/p1787240010614749?thread_ts=1785396099.116169&cid=C09CVP4NTL7

The Helm SDK defaults `MaxHistory` to 0, which means unlimited — unlike the Helm CLI, which defaults to 10. `UpgradeChart` never set it, so every upgrade appends a release Secret that nothing ever collects. `cd-master` runs an unconditional `helm upgrade` on every master commit and each revision embeds the full chart, so the `argocd` release on the OVH dev cluster has reached 202 revisions.

This matters because listing releases has to transfer all of them, and over the WARP tunnel that transfer gets reset a few seconds in, failing master deploys:

```
Install ArgoCD failed: ... query: failed to query with labels: unexpected error
when reading response body. Please retry. Original error: read tcp
172.16.0.2:43848->10.20.3.88:6443: read: connection reset by peer
```

Scope worth being explicit about: this caps the `argocd` release going forward, and fixes the `query with labels` read, which selects on `name=argocd`. It does **not** fix the `list releases failed` variant — `FindRelease` uses `action.NewList`, which fetches every `owner=helm` Secret in the namespace and applies its filter client-side. That namespace currently also holds 616 orphaned `pc-applications` revisions left behind when #633 moved pc-apps to an ArgoCD Application, so the immediate unblock is pruning those; this change keeps `argocd` from growing back into the same problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)